### PR TITLE
Move helper functions to utils

### DIFF
--- a/src/components/filters/sections/MetadataFilters.jsx
+++ b/src/components/filters/sections/MetadataFilters.jsx
@@ -1,20 +1,5 @@
 import React from 'react';
-
-// Position group logic — exportable if needed elsewhere
-export const expandPositionGroup = (position) => {
-  switch (position) {
-    case 'group_guard':
-      return ['PG', 'SG', 'G'];
-    case 'group_wing':
-      return ['SG', 'SF', 'G/F'];
-    case 'group_forward':
-      return ['SF', 'PF', 'F'];
-    case 'group_big':
-      return ['F/C', 'C'];
-    default:
-      return position ? [position] : []; // single value or empty
-  }
-};
+import expandPositionGroup from '../../../../utils/expandPositionGroup.js';
 
 const MetadataFilters = ({ filters, setFilters }) => {
   const update = (key, value) => {

--- a/src/components/lists/ListPlayerRow.jsx
+++ b/src/components/lists/ListPlayerRow.jsx
@@ -17,10 +17,6 @@ const positionAbbreviations = {
   'Center-Forward': 'C',
 };
 
-const calculateHeight = (ht = '0-0') => {
-  const parts = ht.split('-');
-  return parseInt(parts[0]) * 12 + parseInt(parts[1]);
-};
 
 const ListPlayerRow = ({
   player,

--- a/src/components/roster/PlayerCard.jsx
+++ b/src/components/roster/PlayerCard.jsx
@@ -1,24 +1,7 @@
 // src/components/roster/PlayerCard.jsx
 import React from 'react';
 import PlayerNameMini from '@/components/table/PlayerNameMini';
-
-// getPlayerPositionLabel – Shortens full position names to abbreviations
-const getPlayerPositionLabel = (fullPosition) => {
-  const map = {
-    Guard: 'G',
-    'Point Guard': 'PG',
-    'Shooting Guard': 'SG',
-    Forward: 'F',
-    'Small Forward': 'SF',
-    'Power Forward': 'PF',
-    Center: 'C',
-    'Forward-Center': 'F/C',
-    'Guard-Forward': 'G/F',
-    'Forward-Guard': 'F',
-    'Center-Forward': 'C',
-  };
-  return map[fullPosition] || fullPosition;
-};
+import getPlayerPositionLabel from '../../../utils/roleLabel.js';
 
 // PlayerCard – Clean visual core with full image + Anton name + position
 const PlayerCard = ({ player, size = 'starter', onRemove }) => {

--- a/src/components/roster/PlayerRowMini.jsx
+++ b/src/components/roster/PlayerRowMini.jsx
@@ -2,39 +2,8 @@
 import React, { useState } from 'react';
 import PlayerNameMini from '@/components/table/PlayerNameMini';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-
-const getPlayerPositionLabel = (fullPosition) => {
-  const map = {
-    Guard: 'G',
-    'Point Guard': 'PG',
-    'Shooting Guard': 'SG',
-    Forward: 'F',
-    'Small Forward': 'SF',
-    'Power Forward': 'PF',
-    Center: 'C',
-    'Forward-Center': 'F/C',
-    'Guard-Forward': 'G/F',
-    'Forward-Guard': 'F',
-    'Center-Forward': 'C',
-  };
-  return map[fullPosition] || fullPosition || '—';
-};
-
-const formatSalary = (salary) => {
-  if (!salary) return '—';
-
-  const salaryValue =
-    typeof salary === 'string'
-      ? parseFloat(salary.replace(/[^0-9.]/g, ''))
-      : salary;
-
-  if (salaryValue >= 1000000) {
-    return `$${(salaryValue / 1000000).toFixed(1)}M`;
-  } else if (salaryValue >= 1000) {
-    return `$${(salaryValue / 1000).toFixed(0)}K`;
-  }
-  return `$${salaryValue?.toLocaleString() || '—'}`;
-};
+import getPlayerPositionLabel from '../../../utils/roleLabel.js';
+import formatSalary from '../../../utils/formatSalary.js';
 
 const PlayerRowMini = ({ player, onClick }) => {
   const [isExpanded, setIsExpanded] = useState(false);

--- a/src/components/roster/RosterViewer.jsx
+++ b/src/components/roster/RosterViewer.jsx
@@ -6,18 +6,7 @@ import PlayerCard from './PlayerCard';
 import EmptySlot from './EmptySlot';
 import AddPlayerDrawer from './AddPlayerDrawer';
 import DrawerShell from './DrawerShell';
-
-const isTwoWayContract = (player) => {
-  const summary = player?.contract_summary || {};
-  const fieldsToCheck = [summary.signed_using, summary.type];
-  return fieldsToCheck.some(
-    (val) =>
-      typeof val === 'string' &&
-      ['two-way', 'two way', 'two_way'].some((keyword) =>
-        val.toLowerCase().includes(keyword)
-      )
-  );
-};
+import { isTwoWayContract } from '../../../utils/contractUtils.js';
 
 // Position mapping
 const POSITION_MAP = {

--- a/src/components/table/PlayerTable.jsx
+++ b/src/components/table/PlayerTable.jsx
@@ -7,6 +7,11 @@ import ActiveFiltersDisplay from '@/components/filters/ActiveFiltersDisplay';
 import ViewControls from '@/components/filters/sections/ViewControls';
 import { Filter, SortAsc, Search } from 'lucide-react';
 import debounce from 'lodash.debounce';
+import parseHeight from '../../../utils/parseHeight.js';
+import parseWeight from '../../../utils/parseWeight.js';
+import convertAnnualSalaries from '../../../utils/convertAnnualSalaries.js';
+import expandPositionGroup from '../../../utils/expandPositionGroup.js';
+import sortPlayers from '../../../utils/sortPlayers.js';
 
 const positionAbbreviations = {
   'Point Guard': 'PG',
@@ -22,42 +27,6 @@ const positionAbbreviations = {
   'Center-Forward': 'C',
 };
 
-const expandPositionGroup = (position) => {
-  switch (position) {
-    case 'Guard':
-      return ['G'];
-    case 'Wing':
-      return ['G/F', 'F'];
-    case 'Forward':
-      return ['F', 'F/C'];
-    case 'Big':
-      return ['F/C', 'C'];
-    case 'Center':
-      return ['C'];
-    default:
-      return position ? [position] : [];
-  }
-};
-
-const shootingProfileRank = {
-  Elite: 6,
-  Plus: 5,
-  Capable: 4,
-  Willing: 3,
-  Hesitant: 2,
-  Non: 1,
-};
-
-const traitSort = [
-  'Defense',
-  'Energy',
-  'Feel',
-  'IQ',
-  'Passing',
-  'Playmaking',
-  'Rebounding',
-  'Shooting',
-];
 
 const getDefaultFilters = () => ({
   nameSearch: '',
@@ -119,10 +88,6 @@ const getDefaultFilters = () => ({
   badges: [],
 });
 
-const calculateHeight = (ht = '0-0') => {
-  const parts = ht.split('-');
-  return parseInt(parts[0]) * 12 + parseInt(parts[1]);
-};
 
 const PlayerTable = () => {
   const [filters, setFilters] = useState(getDefaultFilters());
@@ -151,30 +116,15 @@ const PlayerTable = () => {
     const formattedPosition =
       positionAbbreviations[rawPosition] || rawPosition || '—';
 
-    const salaryMap = {};
-    (playerData.contract?.annual_salaries || []).forEach((s) => {
-      let raw = s.salary;
-      if (typeof raw === 'string') {
-        raw = raw.replace(/[\$,]/g, '');
-        if (raw.includes('M')) {
-          raw = raw.replace('M', '');
-          salaryMap[s.year] = parseFloat(raw);
-        } else {
-          salaryMap[s.year] = parseFloat(raw) / 1_000_000;
-        }
-      } else if (typeof raw === 'number') {
-        salaryMap[s.year] = raw / 1_000_000;
-      } else {
-        salaryMap[s.year] = null;
-      }
-      if (isNaN(salaryMap[s.year])) salaryMap[s.year] = null;
-    });
+    const salaryMap = convertAnnualSalaries(
+      playerData.contract?.annual_salaries || []
+    );
 
     return {
       ...playerData,
       formattedPosition,
-      heightInInches: calculateHeight(playerData.bio?.HT),
-      weight: parseInt(playerData.bio?.WT || 0),
+      heightInInches: parseHeight(playerData.bio?.HT),
+      weight: parseWeight(playerData.bio?.WT || 0),
       age: parseInt(playerData.bio?.AGE || 0),
       headshotUrl: `/assets/headshots/${playerData.player_id}.png`,
       offenseRole: playerData.roles?.offense1 || '—',
@@ -215,8 +165,7 @@ const PlayerTable = () => {
   const filteredPlayers = useMemo(() => {
     const selectedPositions = expandPositionGroup(filters.position);
 
-    return players
-      .filter((p) => {
+    const filtered = players.filter((p) => {
         // Name search filter
         if (filters.nameSearch) {
           const playerName = (p.display_name || p.name || '').toLowerCase();
@@ -398,55 +347,8 @@ const PlayerTable = () => {
         }
 
         return true;
-      })
-      .sort((a, b) => {
-        const getValue = (player, field) => {
-          if (traitSort.includes(field)) return player.traits?.[field] ?? -1;
-          if (player.system?.stats?.hasOwnProperty(field))
-            return parseFloat(player.system.stats[field]) ?? -1;
-          switch (field) {
-            case 'name':
-              return (player.display_name || player.name || '').toLowerCase();
-            case 'height':
-              return player.heightInInches;
-            case 'weight':
-              return player.weight;
-            case 'age':
-              return player.age;
-            case 'salary':
-              return player.salaryByYear?.[filters.salaryYear] ?? -1;
-            case 'shootingProfile':
-              return shootingProfileRank[player.shootingProfile] ?? 0;
-            case 'yearsRemaining':
-              return parseInt(player.free_agency_year) - 2024 || -1;
-            case 'totalContract':
-              return Array.isArray(player.contract?.annual_salaries)
-                ? player.contract.annual_salaries.reduce((sum, s) => {
-                    const val =
-                      typeof s.salary === 'number'
-                        ? s.salary
-                        : parseFloat((s.salary || '').replace(/[^0-9.]/g, ''));
-                    return isNaN(val) ? sum : sum + val;
-                  }, 0)
-                : -1;
-            case 'overall':
-              return parseFloat(player.overall) ?? -1;
-            default:
-              return -1;
-          }
-        };
-
-        const valA = getValue(a, filters.sortBy);
-        const valB = getValue(b, filters.sortBy);
-
-        if (typeof valA === 'string' && typeof valB === 'string') {
-          return filters.sortAsc
-            ? valA.localeCompare(valB)
-            : valB.localeCompare(valA);
-        } else {
-          return filters.sortAsc ? valA - valB : valB - valA;
-        }
       });
+    return sortPlayers(filtered, filters);
   }, [players, filters]);
 
   const handleSearchChange = (e) => {

--- a/utils/contractUtils.js
+++ b/utils/contractUtils.js
@@ -1,0 +1,11 @@
+export function isTwoWayContract(player) {
+  const summary = player?.contract_summary || {};
+  const fieldsToCheck = [summary.signed_using, summary.type];
+  return fieldsToCheck.some(
+    (val) =>
+      typeof val === 'string' &&
+      ['two-way', 'two way', 'two_way'].some((keyword) =>
+        val.toLowerCase().includes(keyword)
+      )
+  );
+}

--- a/utils/convertAnnualSalaries.js
+++ b/utils/convertAnnualSalaries.js
@@ -1,0 +1,21 @@
+export default function convertAnnualSalaries(annualSalaries = []) {
+  const salaryMap = {};
+  (annualSalaries || []).forEach((s) => {
+    let raw = s.salary;
+    if (typeof raw === 'string') {
+      raw = raw.replace(/[\$,]/g, '');
+      if (raw.includes('M')) {
+        raw = raw.replace('M', '');
+        salaryMap[s.year] = parseFloat(raw);
+      } else {
+        salaryMap[s.year] = parseFloat(raw) / 1_000_000;
+      }
+    } else if (typeof raw === 'number') {
+      salaryMap[s.year] = raw / 1_000_000;
+    } else {
+      salaryMap[s.year] = null;
+    }
+    if (isNaN(salaryMap[s.year])) salaryMap[s.year] = null;
+  });
+  return salaryMap;
+}

--- a/utils/expandPositionGroup.js
+++ b/utils/expandPositionGroup.js
@@ -1,0 +1,22 @@
+export default function expandPositionGroup(position) {
+  switch (position) {
+    case 'group_guard':
+    case 'Guard':
+      return ['PG', 'SG', 'G'];
+    case 'group_wing':
+      return ['SG', 'SF', 'G/F'];
+    case 'group_forward':
+      return ['SF', 'PF', 'F'];
+    case 'group_big':
+    case 'Big':
+      return ['F/C', 'C'];
+    case 'Wing':
+      return ['G/F', 'F'];
+    case 'Forward':
+      return ['F', 'F/C'];
+    case 'Center':
+      return ['C'];
+    default:
+      return position ? [position] : [];
+  }
+}

--- a/utils/formatSalary.js
+++ b/utils/formatSalary.js
@@ -1,0 +1,13 @@
+export default function formatSalary(salary) {
+  if (!salary) return '—';
+  const salaryValue =
+    typeof salary === 'string'
+      ? parseFloat(salary.replace(/[^0-9.]/g, ''))
+      : salary;
+  if (salaryValue >= 1000000) {
+    return `$${(salaryValue / 1000000).toFixed(1)}M`;
+  } else if (salaryValue >= 1000) {
+    return `$${(salaryValue / 1000).toFixed(0)}K`;
+  }
+  return `$${salaryValue?.toLocaleString() || '—'}`;
+}

--- a/utils/parseHeight.js
+++ b/utils/parseHeight.js
@@ -1,0 +1,4 @@
+export default function parseHeight(ht = '0-0') {
+  const parts = String(ht).split('-');
+  return parseInt(parts[0]) * 12 + parseInt(parts[1]);
+}

--- a/utils/parseWeight.js
+++ b/utils/parseWeight.js
@@ -1,0 +1,3 @@
+export default function parseWeight(wt = 0) {
+  return parseInt(wt) || 0;
+}

--- a/utils/roleLabel.js
+++ b/utils/roleLabel.js
@@ -1,0 +1,16 @@
+export default function getPlayerPositionLabel(fullPosition) {
+  const map = {
+    Guard: 'G',
+    'Point Guard': 'PG',
+    'Shooting Guard': 'SG',
+    Forward: 'F',
+    'Small Forward': 'SF',
+    'Power Forward': 'PF',
+    Center: 'C',
+    'Forward-Center': 'F/C',
+    'Guard-Forward': 'G/F',
+    'Forward-Guard': 'F',
+    'Center-Forward': 'C',
+  };
+  return map[fullPosition] || fullPosition || '—';
+}

--- a/utils/sortPlayers.js
+++ b/utils/sortPlayers.js
@@ -1,0 +1,67 @@
+const shootingProfileRank = {
+  Elite: 6,
+  Plus: 5,
+  Capable: 4,
+  Willing: 3,
+  Hesitant: 2,
+  Non: 1,
+};
+
+const traitSort = [
+  'Defense',
+  'Energy',
+  'Feel',
+  'IQ',
+  'Passing',
+  'Playmaking',
+  'Rebounding',
+  'Shooting',
+];
+
+export default function sortPlayers(players, filters) {
+  return [...players].sort((a, b) => {
+    const getValue = (player, field) => {
+      if (traitSort.includes(field)) return player.traits?.[field] ?? -1;
+      if (player.system?.stats?.hasOwnProperty(field))
+        return parseFloat(player.system.stats[field]) ?? -1;
+      switch (field) {
+        case 'name':
+          return (player.display_name || player.name || '').toLowerCase();
+        case 'height':
+          return player.heightInInches;
+        case 'weight':
+          return player.weight;
+        case 'age':
+          return player.age;
+        case 'salary':
+          return player.salaryByYear?.[filters.salaryYear] ?? -1;
+        case 'shootingProfile':
+          return shootingProfileRank[player.shootingProfile] ?? 0;
+        case 'yearsRemaining':
+          return parseInt(player.free_agency_year) - 2024 || -1;
+        case 'totalContract':
+          return Array.isArray(player.contract?.annual_salaries)
+            ? player.contract.annual_salaries.reduce((sum, s) => {
+                const val =
+                  typeof s.salary === 'number'
+                    ? s.salary
+                    : parseFloat((s.salary || '').replace(/[^0-9.]/g, ''));
+                return isNaN(val) ? sum : sum + val;
+              }, 0)
+            : -1;
+        case 'overall':
+          return parseFloat(player.overall) ?? -1;
+        default:
+          return -1;
+      }
+    };
+
+    const valA = getValue(a, filters.sortBy);
+    const valB = getValue(b, filters.sortBy);
+
+    if (typeof valA === 'string' && typeof valB === 'string') {
+      return filters.sortAsc ? valA.localeCompare(valB) : valB.localeCompare(valA);
+    }
+    return filters.sortAsc ? valA - valB : valB - valA;
+  });
+}


### PR DESCRIPTION
## Summary
- centralize helper logic under a new `utils` folder
- remove duplicated helper implementations
- update imports across the app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684417ab208083268d6160eef3677f68