### PR TITLE
refactor: rename list management components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import PlayerTableView from '@/pages/PlayerTableView';
 import PlayerProfileView from '@/pages/PlayerProfileView';
 import TeamRosterViewer from '@/pages/TeamRosterView';
-import RankedListView from '@/pages/RankedListView';
+import RankedListView from '@/pages/ListManager';
 import ListsHome from '@/pages/ListsHome';
 import TierMakerView from '@/pages/TierMakerView';
 import SiteLayout from '@/components/layout/SiteLayout';

--- a/src/features/lists/ListControls.jsx
+++ b/src/features/lists/ListControls.jsx
@@ -1,3 +1,5 @@
+// ListControls.jsx
+// Control bar for list editing – includes save button, divider insert, and toggle UI.
 import React from 'react';
 import { Plus } from 'lucide-react';
 

--- a/src/features/lists/ListExportPlayerRow.jsx
+++ b/src/features/lists/ListExportPlayerRow.jsx
@@ -1,4 +1,5 @@
-// src/features/lists/PlayerListPresentation.jsx
+// ListExportPlayerRow.jsx
+// Condensed visual version of a player row used in export view (list-style layout).
 
 import React from 'react';
 import PlayerNameMini from '@/features/table/PlayerNameMini';

--- a/src/features/lists/ListExportWrapper.jsx
+++ b/src/features/lists/ListExportWrapper.jsx
@@ -1,8 +1,9 @@
-// src/features/lists/ListDisplayWrapper.jsx
+// ListExportWrapper.jsx
+// Wrapper component that chooses which export layout to display (flat or tiered).
 
 import React from 'react';
-import PlayerListPresentation from '@/features/lists/PlayerListPresentation';
-import PlayerTierPresentation from '@/features/lists/PlayerTierPresentation';
+import PlayerListPresentation from '@/features/lists/ListExportPlayerRow';
+import PlayerTierPresentation from '@/features/lists/TierPlayerTile';
 
 const ListDisplayWrapper = ({ players = [], view = 'list' }) => {
   if (!players || players.length === 0) {

--- a/src/features/lists/ListPlayerRow.jsx
+++ b/src/features/lists/ListPlayerRow.jsx
@@ -1,4 +1,5 @@
-// RankedListPlayerRow.jsx
+// ListPlayerRow.jsx
+// Full player row component for use in ranked or tiered lists. Includes arrow controls.
 import React from 'react';
 import PlayerRow from '@/features/table/PlayerRow';
 import { ChevronUp, ChevronDown, X } from 'lucide-react';

--- a/src/features/lists/ListTierExport.jsx
+++ b/src/features/lists/ListTierExport.jsx
@@ -1,7 +1,8 @@
-// src/features/lists/PlayerTierView.jsx
+// ListTierExport.jsx
+// Tiered export layout for lists. Groups players visually into labeled tiers.
 
 import React from 'react';
-import PlayerTierPresentation from '@/features/lists/PlayerTierPresentation';
+import PlayerTierPresentation from '@/features/lists/TierPlayerTile';
 
 const PlayerTierView = ({ tieredPlayers = {} }) => {
   const tierNames = Object.keys(tieredPlayers).sort((a, b) => {

--- a/src/features/lists/ListTierHeader.jsx
+++ b/src/features/lists/ListTierHeader.jsx
@@ -1,6 +1,8 @@
+// ListTierHeader.jsx
+// Displays a tier label (e.g. "Tier 1") and wraps a group of ListPlayerRow entries.
 import React from 'react';
 import { ChevronUp, ChevronDown, Trash2 } from 'lucide-react';
-import RankedListPlayerRow from '@/features/lists/RankedListPlayerRow';
+import RankedListPlayerRow from '@/features/lists/ListPlayerRow';
 
 const RankedListTier = ({
   label,

--- a/src/features/lists/RankedListTierToggle.jsx
+++ b/src/features/lists/RankedListTierToggle.jsx
@@ -1,4 +1,5 @@
-// src/features/lists/ToggleViewButton.jsx
+// RankedListTierToggle.jsx
+// Toggle component to enable tiered grouping within a ranked list.
 
 import React from 'react';
 

--- a/src/features/lists/TierPlayerTile.jsx
+++ b/src/features/lists/TierPlayerTile.jsx
@@ -1,4 +1,5 @@
-// src/features/lists/PlayerTierPresentation.jsx
+// TierPlayerTile.jsx
+// Small visual player card used in tier layouts (ListTierExport and TierMaker).
 import React from 'react';
 import { getPlayerPositionLabel } from '@/utils/roles';
 import { formatHeight } from '@/utils/formatting';

--- a/src/features/lists/TieredListView.jsx
+++ b/src/features/lists/TieredListView.jsx
@@ -1,7 +1,7 @@
 // src/features/lists/TieredListView.jsx
 
 import React from 'react';
-import PlayerTierPresentation from '@/features/lists/PlayerTierPresentation';
+import PlayerTierPresentation from '@/features/lists/TierPlayerTile';
 
 const TieredListView = ({ tieredPlayers = {} }) => {
   const tierNames = Object.keys(tieredPlayers).sort((a, b) => {

--- a/src/features/tierMaker/TierMakerBoard.jsx
+++ b/src/features/tierMaker/TierMakerBoard.jsx
@@ -1,7 +1,7 @@
 // src/features/tierMaker/TierMakerBoard.jsx
 
 import React, { useState, useMemo } from 'react';
-import PlayerTierPresentation from '@/features/lists/PlayerTierPresentation';
+import PlayerTierPresentation from '@/features/lists/TierPlayerTile';
 import usePlayerData from '@/hooks/usePlayerData.js';
 import { POSITION_MAP } from '@/utils/roles';
 import DrawerShell from '@/components/shared/ui/drawers/DrawerShell';

--- a/src/pages/ListManager.jsx
+++ b/src/pages/ListManager.jsx
@@ -1,4 +1,6 @@
-// RankedListView.jsx
+// ListManager.jsx
+// Central component for building and editing player lists (flat, ranked, or tiered).
+// Handles all list structure logic and renders full player rows with controls.
 
 import React, { useEffect, useState, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
@@ -7,8 +9,8 @@ import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import usePlayerData from '@/hooks/usePlayerData.js';
 import { toast } from 'react-hot-toast';
 
-import RankedListTier from '@/features/lists/RankedListTier';
-import RankedListControls from '@/features/lists/RankedListControls';
+import RankedListTier from '@/features/lists/ListTierHeader';
+import RankedListControls from '@/features/lists/ListControls';
 
 const RankedListView = () => {
   const { listId } = useParams();

--- a/src/pages/ListPresentationView.jsx
+++ b/src/pages/ListPresentationView.jsx
@@ -1,8 +1,8 @@
 // src/pages/ListPresentationView.jsx
 
 import React, { useState } from 'react';
-import ToggleViewButton from '@/features/lists/ToggleViewButton';
-import ListDisplayWrapper from '@/features/lists/ListDisplayWrapper';
+import ToggleViewButton from '@/features/lists/RankedListTierToggle';
+import ListDisplayWrapper from '@/features/lists/ListExportWrapper';
 import TieredListView from '@/features/lists/TieredListView';
 
 const samplePlayer = {


### PR DESCRIPTION
## Summary
- rename list editing view to `ListManager`
- rename ranked list utilities in `lists` feature
- update imports for renamed files

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_6853d027c2448326884f13a5e0b4a320