### PR TITLE
fix: standardize team names

### DIFF
--- a/src/components/shared/TeamLogo.jsx
+++ b/src/components/shared/TeamLogo.jsx
@@ -1,43 +1,8 @@
 import React from 'react';
-
-const teamLogoMap = {
-  Hawks: 'hawks',
-  Celtics: 'celtics',
-  Nets: 'nets',
-  Hornets: 'hornets',
-  Bulls: 'bulls',
-  Cavaliers: 'cavaliers',
-  Mavericks: 'mavericks',
-  Nuggets: 'nuggets',
-  Pistons: 'pistons',
-  Warriors: 'warriors',
-  Rockets: 'rockets',
-  Pacers: 'pacers',
-  Clippers: 'clippers',
-  Lakers: 'lakers',
-  Grizzlies: 'grizzlies',
-  Heat: 'heat',
-  Bucks: 'bucks',
-  Timberwolves: 'timberwolves',
-  Pelicans: 'pelicans',
-  Knicks: 'knicks',
-  Thunder: 'thunder',
-  Magic: 'magic',
-  Sixers: 'sixers', // ✅ full name version
-  '76ers': 'sixers', // ✅ alternate version with number
-  Suns: 'suns',
-  BTrailBlazers: 'blazers',
-  'Trail Blazers': 'blazers',
-  Blazers: 'blazers',
-  Kings: 'kings',
-  Spurs: 'spurs',
-  Raptors: 'raptors',
-  Jazz: 'jazz',
-  Wizards: 'wizards',
-};
+import { getTeamLogoFilename } from '@/utils/formatting';
 
 const TeamLogo = ({ teamAbbr, className = '' }) => {
-  const fileName = teamLogoMap[teamAbbr] || 'default';
+  const fileName = getTeamLogoFilename(teamAbbr);
   const logoPath = `/assets/logos/${fileName}.png`;
   const sizeClasses = className || 'w-[3.5rem] h-[3.5rem]';
 

--- a/src/features/roster/RosterPreviewModal.jsx
+++ b/src/features/roster/RosterPreviewModal.jsx
@@ -2,6 +2,7 @@
 import React, { useRef } from 'react';
 import { toPng } from 'html-to-image';
 import { getTeamColors } from '@/utils/formatting/teamColors';
+import { getTeamLogoFilename } from '@/utils/formatting/teamLogos';
 import RosterSection from './RosterSection';
 import '@/styles/antonFont.css';
 
@@ -63,7 +64,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
           {/* Logo */}
           {team && (
             <img
-              src={`/assets/logos/${team.toLowerCase()}.png`}
+              src={`/assets/logos/${getTeamLogoFilename(team)}.png`}
               alt=""
               className="absolute inset-0 w-full h-full object-contain opacity-20 blur-sm mt-4 pointer-events-none select-none"
             />

--- a/src/features/roster/RosterViewer.jsx
+++ b/src/features/roster/RosterViewer.jsx
@@ -9,6 +9,7 @@ import RosterSection from './RosterSection';
 import SaveRosterModal from './SaveRosterModal';
 import RosterPreviewModal from './RosterPreviewModal';
 import { getTeamColors } from '@/utils/formatting/teamColors';
+import { getTeamLogoFilename } from '@/utils/formatting/teamLogos';
 import { useRosterManager } from '@/hooks/useRosterManager';
 
 const RosterViewer = ({ isExport = false }) => {
@@ -104,7 +105,7 @@ const RosterViewer = ({ isExport = false }) => {
           {/* Team Branding Background */}
           {selectedTeam && (
             <img
-              src={`/assets/logos/${selectedTeam.toLowerCase()}.png`}
+              src={`/assets/logos/${getTeamLogoFilename(selectedTeam)}.png`}
               alt=""
               className="absolute inset-0 w-full h-full object-contain opacity-20 blur-sm mt-4 pointer-events-none select-none"
               style={{ zIndex: 0 }}

--- a/src/utils/filtering/teamOptions.js
+++ b/src/utils/filtering/teamOptions.js
@@ -23,7 +23,7 @@ export const teamOptions = [
   'Magic',
   '76ers',
   'Suns',
-  'Blazers',
+  'Trail Blazers',
   'Kings',
   'Spurs',
   'Raptors',

--- a/src/utils/formatting/index.js
+++ b/src/utils/formatting/index.js
@@ -1,3 +1,4 @@
 export * from './formatHeight.js';
 export * from './formatSalary.js';
 export * from './teamColors.js';
+export * from './teamLogos.js';

--- a/src/utils/formatting/teamColors.js
+++ b/src/utils/formatting/teamColors.js
@@ -301,6 +301,18 @@ export const TEAM_COLOR_MAP = {
       border: 'border-white',
     },
   },
+  trailblazers: {
+    primary: '#E03A3E',
+    secondary: '#000000',
+    tertiary: '#C4CED4',
+    text: '#FFFFFF',
+    bg: '#E03A3E',
+    classSet: {
+      bg: 'bg-[#E03A3E]',
+      text: 'text-white',
+      border: 'border-white',
+    },
+  },
   kings: {
     primary: '#5A2D81',
     secondary: '#63727A',

--- a/src/utils/formatting/teamLogos.js
+++ b/src/utils/formatting/teamLogos.js
@@ -1,0 +1,40 @@
+export const TEAM_LOGO_MAP = {
+  Hawks: 'hawks',
+  Celtics: 'celtics',
+  Nets: 'nets',
+  Hornets: 'hornets',
+  Bulls: 'bulls',
+  Cavaliers: 'cavaliers',
+  Mavericks: 'mavericks',
+  Nuggets: 'nuggets',
+  Pistons: 'pistons',
+  Warriors: 'warriors',
+  Rockets: 'rockets',
+  Pacers: 'pacers',
+  Clippers: 'clippers',
+  Lakers: 'lakers',
+  Grizzlies: 'grizzlies',
+  Heat: 'heat',
+  Bucks: 'bucks',
+  Timberwolves: 'timberwolves',
+  Pelicans: 'pelicans',
+  Knicks: 'knicks',
+  Thunder: 'thunder',
+  Magic: 'magic',
+  Sixers: 'sixers',
+  '76ers': 'sixers',
+  Suns: 'suns',
+  BTrailBlazers: 'blazers',
+  'Trail Blazers': 'blazers',
+  Blazers: 'blazers',
+  Kings: 'kings',
+  Spurs: 'spurs',
+  Raptors: 'raptors',
+  Jazz: 'jazz',
+  Wizards: 'wizards',
+};
+
+export function getTeamLogoFilename(teamName) {
+  if (!teamName) return 'default';
+  return TEAM_LOGO_MAP[teamName] || teamName.toLowerCase().replace(/\s+/g, '');
+}


### PR DESCRIPTION
## Summary
- ensure team options use Trail Blazers name
- centralize team logo lookups
- update roster views to use the new helper
- support Trail Blazers in team colors

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_685be30fa9d08326abafb971784fbff0