### PR TITLE
refactor: split export row components

### DIFF
--- a/docs/FILE_MAP.md
+++ b/docs/FILE_MAP.md
@@ -114,8 +114,10 @@
 │ │ ├── ListColumnToggle.jsx Toggle visible columns
 │ │ ├── ListExportToggle.jsx Toggle export mode
 │ │ ├── ListTierExport.jsx Export tiered list
-│ │ ├── ListExportPlayerRow.jsx Row used during export
-│ │ ├── ListExportRowCompact.jsx Compact export row
+│ │ ├── ListExportPlayerRowSingle.jsx Single column export row
+│ │ ├── ListExportPlayerRowTwoColumn.jsx Two column export row
+│ │ ├── ListExportRowCompactSingle.jsx Single column compact row
+│ │ ├── ListExportRowCompactTwoColumn.jsx Two column compact row
 │ │ ├── RankedListTierToggle.jsx Switch ranked vs tier view
 │ │ └── ListExportTypeToggle.jsx Choose export type
 │ ├── filters/ Filtering UI modules

--- a/src/features/lists/ListExportPlayerRowSingle.jsx
+++ b/src/features/lists/ListExportPlayerRowSingle.jsx
@@ -1,0 +1,65 @@
+// src/features/lists/ListExportPlayerRowSingle.jsx
+import React from 'react';
+import PlayerNameMini from '@/features/table/PlayerNameMini';
+import TeamLogo from '@/components/shared/TeamLogo';
+import { getPlayerPositionLabel } from '@/utils/roles';
+
+const ListExportPlayerRowSingle = ({ player, rank }) => {
+  const nameParts = (
+    player.display_name ||
+    player.name ||
+    'Unknown Player'
+  ).split(' ');
+  const firstName = nameParts[0]?.toUpperCase() || '';
+  const lastName = nameParts.slice(1).join(' ').toUpperCase() || '';
+
+  const rawPosition = player.bio?.Position || player.formattedPosition || '';
+  const position = getPlayerPositionLabel(rawPosition) || '—';
+
+  return (
+    <div className="w-full h-[90px] bg-neutral-800 rounded-sm flex items-center overflow-hidden border border-black mb-0 pr-4">
+      {/* Rank Bar */}
+      {rank !== null && (
+        <div className="h-full w-12 flex flex-col items-center justify-center bg-neutral-700 text-white font-bold text-xl font-mono relative">
+          <div>{rank}</div>
+          <div className="absolute right-0 top-0 h-full w-[2px] bg-neutral-950"></div>
+        </div>
+      )}
+
+      {/* Headshot */}
+      <div className="h-full w-[70px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden">
+        <img
+          src={
+            player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+          }
+          onError={(e) => {
+            e.target.src = '/assets/headshots/default.png';
+          }}
+          alt={player.name}
+          className="h-full w-full object-cover"
+        />
+      </div>
+
+      {/* Main Info */}
+      <div className="flex flex-col justify-center ml-3">
+        <div className="h-[40px] flex items-center">
+          <PlayerNameMini name={player.display_name || player.name} />
+        </div>
+        <div className="flex items-center mt-[11px] -mb-1 gap-2 text-white/50 text-[13px]">
+          <TeamLogo teamAbbr={player.bio?.Team} className="w-5 h-5" />
+          <div>
+            {player.bio?.HT || '—'} <span className="text-white/30">|</span>{' '}
+            {player.bio?.WT || '—'} lbs
+          </div>
+        </div>
+      </div>
+
+      {/* Position – Far Right */}
+      <div className="ml-auto text-white/60 text-xl font-semibold pr-1">
+        {position}
+      </div>
+    </div>
+  );
+};
+
+export default ListExportPlayerRowSingle;

--- a/src/features/lists/ListExportPlayerRowTwoColumn.jsx
+++ b/src/features/lists/ListExportPlayerRowTwoColumn.jsx
@@ -1,10 +1,10 @@
-// src/features/lists/ListExportPlayerRow.jsx
+// src/features/lists/ListExportPlayerRowTwoColumn.jsx
 import React from 'react';
 import PlayerNameMini from '@/features/table/PlayerNameMini';
 import TeamLogo from '@/components/shared/TeamLogo';
 import { getPlayerPositionLabel } from '@/utils/roles';
 
-const ListExportPlayerRow = ({ player, rank }) => {
+const ListExportPlayerRowTwoColumn = ({ player, rank }) => {
   const nameParts = (
     player.display_name ||
     player.name ||
@@ -62,4 +62,4 @@ const ListExportPlayerRow = ({ player, rank }) => {
   );
 };
 
-export default ListExportPlayerRow;
+export default ListExportPlayerRowTwoColumn;

--- a/src/features/lists/ListExportRowCompactSingle.jsx
+++ b/src/features/lists/ListExportRowCompactSingle.jsx
@@ -1,9 +1,9 @@
-// src/features/lists/ListExportRowCompact.jsx
+// src/features/lists/ListExportRowCompactSingle.jsx
 import React from 'react';
 import TeamLogo from '@/components/shared/TeamLogo';
 import { getPlayerPositionLabel } from '@/utils/roles';
 
-const ListExportRowCompact = ({ player, rank }) => {
+const ListExportRowCompactSingle = ({ player, rank }) => {
   const name = player.display_name || player.name || 'Unknown Player';
   const nameParts = name.split(' ');
   const firstName = nameParts[0]?.toUpperCase() || '';
@@ -69,4 +69,4 @@ const ListExportRowCompact = ({ player, rank }) => {
   );
 };
 
-export default ListExportRowCompact;
+export default ListExportRowCompactSingle;

--- a/src/features/lists/ListExportRowCompactTwoColumn.jsx
+++ b/src/features/lists/ListExportRowCompactTwoColumn.jsx
@@ -1,0 +1,72 @@
+// src/features/lists/ListExportRowCompactTwoColumn.jsx
+import React from 'react';
+import TeamLogo from '@/components/shared/TeamLogo';
+import { getPlayerPositionLabel } from '@/utils/roles';
+
+const ListExportRowCompactTwoColumn = ({ player, rank }) => {
+  const name = player.display_name || player.name || 'Unknown Player';
+  const nameParts = name.split(' ');
+  const firstName = nameParts[0]?.toUpperCase() || '';
+  const lastName = nameParts.slice(1).join(' ').toUpperCase() || '';
+
+  const rawPosition = player.bio?.Position || player.formattedPosition || '';
+  const position = getPlayerPositionLabel(rawPosition) || '—';
+
+  const height = player.bio?.HT || '—';
+  const weight = player.bio?.WT ? `${player.bio.WT} lbs` : '— lbs';
+
+  return (
+    <div className="w-full h-[45px] bg-neutral-800 rounded-sm flex items-center border border-black mb-0 pr-0 overflow-hidden">
+      {/* Rank Bar */}
+      {rank !== null && (
+        <div className="h-full w-10 flex flex-col items-center justify-center bg-neutral-700 text-white font-bold text-base font-mono relative">
+          <div>{rank}</div>
+          <div className="absolute right-0 top-0 h-full w-[2px] bg-neutral-950"></div>
+        </div>
+      )}
+
+      {/* Headshot */}
+      <div className="h-[45px] w-[50px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden rounded-sm">
+        <img
+          src={
+            player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+          }
+          onError={(e) => {
+            e.target.src = '/assets/headshots/default.png';
+          }}
+          alt={player.name}
+          className="h-full w-full object-cover"
+        />
+      </div>
+
+      {/* Main Info Block */}
+      <div className="flex items-center ml-3 mr-4 flex-1 justify-between">
+        {/* Name */}
+        <div
+          className="text-white font-anton font-bold uppercase tracking-normal leading-none whitespace-nowrap overflow-visible"
+          style={{ fontSize: `17px`, maxWidth: '300px' }}
+        >
+          {firstName}{' '}
+          <span className="text-white/70 font-light">{lastName}</span>
+        </div>
+
+        {/* HT / WT / Team Logo */}
+        <div className="flex items-center justify-end text-white/50 text-[13px] w-[130px] gap-2">
+          <TeamLogo teamAbbr={player.bio?.Team} className="w-4 h-4" />
+          <div className="whitespace-nowrap tabular-nums flex gap-1 items-center">
+            <span className="w-[32px] text-right">{height}</span>
+            <span className="text-white/30">|</span>
+            <span className="w-[48px] text-left">{weight}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Position */}
+      <div className="w-[70px] flex items-center justify-center text-white/60 text-sm font-semibold -mr-3">
+        {position}
+      </div>
+    </div>
+  );
+};
+
+export default ListExportRowCompactTwoColumn;

--- a/src/features/lists/ListExportWrapper.jsx
+++ b/src/features/lists/ListExportWrapper.jsx
@@ -1,7 +1,9 @@
 // src/features/lists/ListExportWrapper.jsx
 import React from 'react';
-import ListExportPlayerRow from './ListExportPlayerRow';
-import ListExportRowCompact from './ListExportRowCompact';
+import ListExportPlayerRowSingle from './ListExportPlayerRowSingle';
+import ListExportPlayerRowTwoColumn from './ListExportPlayerRowTwoColumn';
+import ListExportRowCompactSingle from './ListExportRowCompactSingle';
+import ListExportRowCompactTwoColumn from './ListExportRowCompactTwoColumn';
 import ListTierExport from './ListTierExport';
 
 const ListExportWrapper = ({
@@ -24,7 +26,12 @@ const ListExportWrapper = ({
     );
   };
 
-  const Row = compact ? ListExportRowCompact : ListExportPlayerRow;
+  let Row;
+  if (compact) {
+    Row = twoColumn ? ListExportRowCompactTwoColumn : ListExportRowCompactSingle;
+  } else {
+    Row = twoColumn ? ListExportPlayerRowTwoColumn : ListExportPlayerRowSingle;
+  }
 
   const renderColumn = (plist, startIdx) => (
     <div className="flex flex-col gap-[3px] w-1/2 items-center">

--- a/src/pages/ExportRowPreview.jsx
+++ b/src/pages/ExportRowPreview.jsx
@@ -1,6 +1,6 @@
 // src/pages/ExportRowPreview.jsx
 import React from 'react';
-import ListExportRowCompact from '@/features/lists/ListExportRowCompact';
+import ListExportRowCompactSingle from '@/features/lists/ListExportRowCompactSingle';
 
 const dummyPlayer = {
   player_id: 'lebron_james',
@@ -20,7 +20,7 @@ const ExportRowPreview = () => {
   return (
     <div className="bg-neutral-900 p-6 grid grid-cols-1 gap-y-2">
       {[1, 2, 3, 4, 5].map((rank) => (
-        <ListExportRowCompact key={rank} player={dummyPlayer} rank={rank} />
+        <ListExportRowCompactSingle key={rank} player={dummyPlayer} rank={rank} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- split export row components for single vs two column layouts
- update wrapper to choose row by layout
- adjust ExportRowPreview and documentation

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_685d46a8ac54832684d06cffbf3743db