### PR TITLE
docs: add component hierarchies

### DIFF
--- a/docs/FiltersHierarchy.md
+++ b/docs/FiltersHierarchy.md
@@ -1,0 +1,26 @@
+# Filters Component Hierarchy
+
+This document outlines the parent-child relationships for React components under `src/features/filters`.
+
+```
+src/features/filters
+├── FiltersPanel.jsx (parent)
+│   ├── FilterPanelCondensed.jsx
+│   └── FilterPanel.jsx (parent)
+│       └── sections
+│           ├── MetadataFilters.jsx
+│           ├── PhysicalFilters.jsx
+│           ├── ContractFilters.jsx
+│           ├── RoleFilters.jsx
+│           ├── StatFilters.jsx
+│           ├── TraitFilters.jsx
+│           ├── OverallGradeFilter.jsx
+│           ├── BadgeFilters.jsx
+│           └── ViewControls.jsx
+├── ActiveFiltersDisplay.jsx (parent)
+│   └── FilterPill.jsx (parent)
+│       └── FilterContent.jsx
+```
+
+- **Parent** components: `FiltersPanel.jsx`, `FilterPanel.jsx`, `ActiveFiltersDisplay.jsx`, `FilterPill.jsx`.
+- **Child** components are the remaining files which do not render other filters components.

--- a/docs/ListsHierarchy.md
+++ b/docs/ListsHierarchy.md
@@ -1,0 +1,33 @@
+# Lists Component Hierarchy
+
+Parent-child relationships for components in `src/features/lists`.
+
+```
+src/features/lists
+├── AddToListButton.jsx (parent)
+│   └── AddToListModal.jsx
+├── ListPreviewModal.jsx (parent)
+│   └── ListExportWrapper.jsx (parent)
+│       ├── ListExportPlayerRowSingle.jsx
+│       ├── ListExportPlayerRowTwoColumn.jsx
+│       ├── ListExportRowCompactSingle.jsx
+│       ├── ListExportRowCompactTwoColumn.jsx
+│       └── ListTierExport.jsx (parent)
+│           └── TierPlayerTile.jsx
+├── ListTierHeader.jsx (parent)
+│   └── ListPlayerRow.jsx
+├── TieredListView.jsx (parent)
+│   └── TierPlayerTile.jsx
+├── CreateListModal.jsx
+├── ExportOptionsModal.jsx
+├── ListColumnToggle.jsx
+├── ListControls.jsx
+├── ListExportToggle.jsx
+├── ListRankToggle.jsx
+├── ListRowStyleToggle.jsx
+├── ListExportTypeToggle.jsx
+└── RankedListTierToggle.jsx
+```
+
+- **Parent** components: `AddToListButton.jsx`, `ListPreviewModal.jsx`, `ListExportWrapper.jsx`, `ListTierExport.jsx`, `ListTierHeader.jsx`, `TieredListView.jsx`.
+- **Child** components are the remaining files that do not nest other list components.

--- a/docs/ProfileHierarchy.md
+++ b/docs/ProfileHierarchy.md
@@ -1,0 +1,26 @@
+# Profile Component Hierarchy
+
+Overview of the components under `src/features/profile` and how they relate.
+
+```
+src/features/profile
+├── PlayerDetails.jsx (parent)
+│   ├── PlayerHeader.jsx (parent)
+│   │   ├── ProfilePlayerName.jsx
+│   │   └── ProfilePlayerPosition.jsx
+│   ├── PlayerStatsTable.jsx
+│   ├── PlayerTraitsGrid.jsx
+│   ├── PlayerRolesSection.jsx (parent)
+│   │   ├── SubRoleSelector.jsx
+│   │   ├── ShootingProfileSelector.jsx
+│   │   └── TwoWayMeter.jsx
+│   ├── BadgeSelector.jsx
+│   └── OverallBlurbBox.jsx
+├── BreakdownModal.jsx
+├── TeamPlayerDropdowns.jsx
+├── TeamPlayerSelector.jsx
+└── PlayerNavigation.jsx
+```
+
+- **Parent** components: `PlayerDetails.jsx`, `PlayerHeader.jsx`, `PlayerRolesSection.jsx`.
+- **Child** components are the remaining files which do not render other profile components.

--- a/docs/RosterHierarchy.md
+++ b/docs/RosterHierarchy.md
@@ -1,0 +1,33 @@
+# Roster Component Hierarchy
+
+Relationships among components in `src/features/roster`.
+
+```
+src/features/roster
+├── RosterViewer.jsx (parent)
+│   ├── AddPlayerDrawer.jsx (parent)
+│   │   ├── PlayerRowMini.jsx
+│   │   └── addPlayer
+│   │       ├── DrawerHeader.jsx
+│   │       ├── PlayerSearchBar.jsx
+│   │       └── FilterTabs.jsx (parent)
+│   │           ├── BasicFilters.jsx
+│   │           ├── RolesFilters.jsx
+│   │           └── ContractFilters.jsx
+│   ├── RosterControls.jsx
+│   ├── RosterSection.jsx (parent)
+│   │   ├── StarterCard.jsx
+│   │   ├── RotationCard.jsx
+│   │   ├── BenchCard.jsx
+│   │   └── EmptySlot.jsx
+│   ├── SaveRosterModal.jsx
+│   └── RosterPreviewModal.jsx (parent)
+│       └── RosterSection.jsx
+├── RosterExportWrapper.jsx
+├── RosterExportModal.jsx
+├── CreateRosterModal.jsx
+└── PlayerRowMini.jsx
+```
+
+- **Parent** components: `RosterViewer.jsx`, `AddPlayerDrawer.jsx`, `FilterTabs.jsx`, `RosterSection.jsx`, `RosterPreviewModal.jsx`.
+- **Child** components are the remaining files that do not render other roster components.

--- a/docs/TableHierarchy.md
+++ b/docs/TableHierarchy.md
@@ -1,0 +1,28 @@
+# Table Component Hierarchy
+
+This document maps the React components under `src/features/table`. Parent components are noted when they render other components from the same folder.
+
+```
+src/features/table
+├── PlayerTable.jsx (parent)
+│   ├── PlayerTableHeader.jsx (parent)
+│   │   ├── SearchBar.jsx
+│   │   └── ControlButtons.jsx
+│   └── PlayerRow.jsx (parent)
+│       ├── PlayerNameMini.jsx
+│       ├── ShootingProfileMini.jsx
+│       ├── RolePill.jsx
+│       ├── PlayerDrawer.jsx (parent)
+│       │   ├── BadgeMini.jsx
+│       │   ├── OverallBlurbMini.jsx
+│       │   ├── PlayerSubRolesMini.jsx
+│       │   ├── PlayerContractMini.jsx
+│       │   ├── PlayerStatsMini.jsx
+│       │   └── PlayerTraitsMiniGrid.jsx
+│       └── (uses external components: AddToListButton, TeamLogo, OverallGradeBlock)
+├── TwoWayMini.jsx (child standalone)
+└── SubRolePill.jsx (child standalone)
+```
+
+- **Parent** components: `PlayerTable.jsx`, `PlayerTableHeader.jsx`, `PlayerRow.jsx`, `PlayerDrawer.jsx`.
+- **Child** components are the remaining files which don't render other table components.

--- a/docs/TierMakerHierarchy.md
+++ b/docs/TierMakerHierarchy.md
@@ -1,0 +1,15 @@
+# Tier Maker Component Hierarchy
+
+Structure of components in `src/features/tierMaker`.
+
+```
+src/features/tierMaker
+├── TierMakerBoard.jsx (parent)
+│   ├── TierRow.jsx
+│   └── CreateTierListModal.jsx
+├── TierRow.jsx
+└── CreateTierListModal.jsx
+```
+
+- **Parent** components: `TierMakerBoard.jsx`.
+- **Child** components are the remaining files in this folder.


### PR DESCRIPTION
## Summary
- document parent/child component relationships for filters, lists, profile, roster, and tierMaker features

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_686768aad7e08326b07a40d26fea5778