### PR TITLE
fix: lighten fonts in roster preview

### DIFF
--- a/src/features/roster/RosterSection/BenchCard.jsx
+++ b/src/features/roster/RosterSection/BenchCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PlayerNameMini from '@/features/table/PlayerTable/PlayerRow/PlayerNameMini';
 import { getPlayerPositionLabel } from '@/utils/roles';
 
-const BenchCard = ({ player, onRemove, showRemove = true }) => {
+const BenchCard = ({ player, onRemove, showRemove = true, isExport = false }) => {
   if (!player) return null;
 
   const headshot = player.headshot || '/default_headshot.png';
@@ -24,7 +24,9 @@ const BenchCard = ({ player, onRemove, showRemove = true }) => {
               ✕
             </button>
           )}
-          <div className="absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[12px] font-semibold uppercase rounded-sm tracking-wider shadow-md">
+          <div
+            className={`absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[12px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`}
+          >
             {getPlayerPositionLabel(player.bio?.Position)}
           </div>
         </div>
@@ -32,6 +34,8 @@ const BenchCard = ({ player, onRemove, showRemove = true }) => {
           <PlayerNameMini
             name={player.display_name || player.name}
             scale={0.77}
+            firstWeightClass={isExport ? 'font-normal' : 'font-light'}
+            lastWeightClass={isExport ? 'font-normal' : 'font-bold'}
           />
         </div>
       </div>

--- a/src/features/roster/RosterSection/RotationCard.jsx
+++ b/src/features/roster/RosterSection/RotationCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PlayerNameMini from '@/features/table/PlayerTable/PlayerRow/PlayerNameMini';
 import { getPlayerPositionLabel } from '@/utils/roles';
 
-const RotationCard = ({ player, onRemove, showRemove = true }) => {
+const RotationCard = ({ player, onRemove, showRemove = true, isExport = false }) => {
   if (!player) return null;
 
   const headshot = player.headshot || '/default_headshot.png';
@@ -24,7 +24,9 @@ const RotationCard = ({ player, onRemove, showRemove = true }) => {
               ✕
             </button>
           )}
-          <div className="absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[14px] font-semibold uppercase rounded-sm tracking-wider shadow-md">
+          <div
+            className={`absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[14px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`}
+          >
             {getPlayerPositionLabel(player.bio?.Position)}
           </div>
         </div>
@@ -32,6 +34,8 @@ const RotationCard = ({ player, onRemove, showRemove = true }) => {
           <PlayerNameMini
             name={player.display_name || player.name}
             scale={0.87}
+            firstWeightClass={isExport ? 'font-normal' : 'font-light'}
+            lastWeightClass={isExport ? 'font-normal' : 'font-bold'}
           />
         </div>
       </div>

--- a/src/features/roster/RosterSection/StarterCard.jsx
+++ b/src/features/roster/RosterSection/StarterCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PlayerNameMini from '@/features/table/PlayerTable/PlayerRow/PlayerNameMini';
 import { getPlayerPositionLabel } from '@/utils/roles';
 
-const StarterCard = ({ player, onRemove, showRemove = true }) => {
+const StarterCard = ({ player, onRemove, showRemove = true, isExport = false }) => {
   if (!player) return null;
 
   const headshot = player.headshot || '/default_headshot.png';
@@ -24,12 +24,18 @@ const StarterCard = ({ player, onRemove, showRemove = true }) => {
               ✕
             </button>
           )}
-          <div className="absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[16px] font-semibold uppercase rounded-sm tracking-wider shadow-md">
+          <div
+            className={`absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[16px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`}
+          >
             {getPlayerPositionLabel(player.bio?.Position)}
           </div>
         </div>
         <div className="bg-[#0f0f0f] px-2 pt-1 pb-2 h-[60px] flex flex-col items-center justify-center text-center border-t border-white/10">
-          <PlayerNameMini name={player.display_name || player.name} />
+          <PlayerNameMini
+            name={player.display_name || player.name}
+            firstWeightClass={isExport ? 'font-normal' : 'font-light'}
+            lastWeightClass={isExport ? 'font-normal' : 'font-bold'}
+          />
         </div>
       </div>
     </div>

--- a/src/features/roster/RosterSection/index.jsx
+++ b/src/features/roster/RosterSection/index.jsx
@@ -56,6 +56,7 @@ const RosterSection = ({
               player={player}
               onRemove={(e) => onRemove(section, idx, e)}
               showRemove={!isExport}
+              isExport={isExport}
             />
           );
         }

--- a/src/features/table/PlayerTable/PlayerRow/PlayerNameMini.jsx
+++ b/src/features/table/PlayerTable/PlayerRow/PlayerNameMini.jsx
@@ -47,7 +47,13 @@ const fontSizeOverrides = {
   'Trayce Jackson-Davis': { first: 20, last: 17 },
 };
 
-const PlayerNameMini = ({ name = 'LeBron James', scale = 1, width = 140 }) => {
+const PlayerNameMini = ({
+  name = 'LeBron James',
+  scale = 1,
+  width = 140,
+  firstWeightClass = 'font-light',
+  lastWeightClass = 'font-bold',
+}) => {
   const [firstName, lastName] = formatFullName(name);
   const override = fontSizeOverrides[name] || {};
   const firstSize = (override.first || 22) * scale;
@@ -59,13 +65,13 @@ const PlayerNameMini = ({ name = 'LeBron James', scale = 1, width = 140 }) => {
       style={{ width: `${width * scale}px` }}
     >
       <span
-        className="text-white/70 font-anton font-light uppercase mb-[2px] tracking-normal leading-none"
+        className={`text-white/70 font-anton ${firstWeightClass} uppercase mb-[2px] tracking-normal leading-none`}
         style={{ fontSize: `${firstSize}px` }}
       >
         {firstName}
       </span>
       <span
-        className="text-white font-anton font-bold uppercase tracking-normal leading-none"
+        className={`text-white font-anton ${lastWeightClass} uppercase tracking-normal leading-none`}
         style={{ fontSize: `${lastSize}px` }}
       >
         {lastName}


### PR DESCRIPTION
## Summary
- make font weight customizable in `PlayerNameMini`
- pass export mode into roster cards and use lighter weights

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68688b0c3aa083268963b48f2e08e449