### PR TITLE
feat: add GM tools routes and initial UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import ListsHome from '@/pages/ListsHome';
 import TierMakerView from '@/pages/TierMakerView';
 import TierListsHome from '@/pages/TierListsHome';
 import RostersHome from '@/pages/RostersHome';
+import GmLeagueView from '@/pages/GmLeagueView';
+import GmDashboardView from '@/pages/GmDashboardView';
 import SiteLayout from '@/components/layout/SiteLayout';
 import NotFound from '@/pages/NotFound';
 import ListPresentationView from '@/pages/ListPresentationView';
@@ -25,6 +27,8 @@ const App = () => {
         <Route path="/list-presentation" element={<ListPresentationView />} />
         <Route path="/tier-lists" element={<TierListsHome />} />
         <Route path="/tier-maker/:tierListId?" element={<TierMakerView />} />
+        <Route path="/gm" element={<GmLeagueView />} />
+        <Route path="/gm/:teamId" element={<GmDashboardView />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/src/components/layout/SiteLayout.jsx
+++ b/src/components/layout/SiteLayout.jsx
@@ -56,6 +56,9 @@ const SiteLayout = () => {
             <Link to="/tier-maker" className="hover:text-white py-1 px-2">
               Tier Maker
             </Link>
+            <Link to="/gm" className="hover:text-white py-1 px-2">
+              GM Tools
+            </Link>
           </NavGroup>
 
           <NavGroup label="Saved" align="right">

--- a/src/features/architect/CapSheet.jsx
+++ b/src/features/architect/CapSheet.jsx
@@ -38,29 +38,28 @@ const CapSheet = ({ teamCapSheet, capSettings, currentYear }) => {
   let totalCapHit = 0;
 
   return (
-    <div className="cap-sheet">
-      <h3>Cap Sheet – {selectedYear}</h3>
-      <div className="year-tabs">
+    <div className="text-white">
+      <h3 className="text-xl font-semibold mb-2">Cap Sheet – {selectedYear}</h3>
+      <div className="flex gap-2 mb-3">
         {allYears.map((year) => (
-          <button 
-            key={year} 
+          <button
+            key={year}
             onClick={() => setSelectedYear(year)}
-            style={{ 
-              fontWeight: year === selectedYear ? 'bold' : 'normal',
-              marginRight: '6px'
-            }}
+            className={`px-2 py-1 rounded text-xs border border-white/20 ${
+              year === selectedYear ? 'bg-blue-600' : 'bg-[#1a1a1a]'
+            }`}
           >
             {year}
           </button>
         ))}
       </div>
-      <table>
-        <thead>
+      <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
+        <thead className="bg-[#111]">
           <tr>
-            <th>Player</th>
-            <th>Salary</th>
-            <th>Cap Hit</th>
-            <th>Notes</th>
+            <th className="p-2 text-left">Player</th>
+            <th className="p-2 text-left">Salary</th>
+            <th className="p-2 text-left">Cap Hit</th>
+            <th className="p-2 text-left">Notes</th>
           </tr>
         </thead>
         <tbody>
@@ -71,21 +70,20 @@ const CapSheet = ({ teamCapSheet, capSettings, currentYear }) => {
               const capHit = getCapHit(contract, selectedYear);
               totalCapHit += capHit;
 
-              const rowClass = !contract.guaranteed ? 'non-guaranteed' : 
-                typeof contract.guaranteed === 'number' ? 'partial-guaranteed' : '';
-
               return (
-                <tr key={`${contract.name}-${idx}`} className={rowClass}>
-                  <td>{contract.name}</td>
-                  <td>${salary.toLocaleString()}</td>
-                  <td>${capHit.toLocaleString()}</td>
-                  <td>{renderNotes(contract, selectedYear)}</td>
+                <tr key={`${contract.name}-${idx}`} className="odd:bg-[#171717]">
+                  <td className="p-2">{contract.name}</td>
+                  <td className="p-2">${salary.toLocaleString()}</td>
+                  <td className="p-2">${capHit.toLocaleString()}</td>
+                  <td className="p-2">{renderNotes(contract, selectedYear)}</td>
                 </tr>
               );
             })}
         </tbody>
       </table>
-      <p><strong>Total Cap Hit:</strong> ${totalCapHit.toLocaleString()}</p>
+      <p className="mt-2 font-semibold">
+        Total Cap Hit: ${totalCapHit.toLocaleString()}
+      </p>
     </div>
   );
 };

--- a/src/features/architect/CapSheetFull.jsx
+++ b/src/features/architect/CapSheetFull.jsx
@@ -46,40 +46,44 @@ const CapSheetFull = ({ teamCapSheet }) => {
   });
 
   return (
-    <div className="cap-sheet-full">
-      <h3>Future Cap Sheet (Multi-Year View)</h3>
-      <table>
-        <thead>
+    <div className="text-white">
+      <h3 className="text-xl font-semibold mb-2">Future Cap Sheet (Multi-Year View)</h3>
+      <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
+        <thead className="bg-[#111]">
           <tr>
-            <th>Player</th>
+            <th className="p-2 text-left">Player</th>
             {allYears.map((year) => (
-              <th key={year}>{year}</th>
+              <th key={year} className="p-2 text-left">
+                {year}
+              </th>
             ))}
-            <th>Notes</th>
+            <th className="p-2 text-left">Notes</th>
           </tr>
         </thead>
         <tbody>
           {teamCapSheet.activeContracts.map((contract, idx) => (
-            <tr key={idx}>
-              <td>{contract.name}</td>
+            <tr key={idx} className="odd:bg-[#171717]">
+              <td className="p-2">{contract.name}</td>
               {allYears.map((year) => {
                 const salary = contract.salaryByYear?.[year];
                 const capHit = getCapHit(contract, year);
                 return (
-                  <td key={year}>
+                  <td key={year} className="p-2">
                     {salary ? `$${capHit.toLocaleString()}` : '—'}
                   </td>
                 );
               })}
-              <td>{renderNotes(contract)}</td>
+              <td className="p-2">{renderNotes(contract)}</td>
             </tr>
           ))}
-          <tr style={{ fontWeight: 'bold', borderTop: '2px solid black' }}>
-            <td>Total Cap</td>
+          <tr className="border-t border-white/20 font-semibold">
+            <td className="p-2">Total Cap</td>
             {allYears.map((year) => (
-              <td key={year}>${yearTotals[year].toLocaleString()}</td>
+              <td key={year} className="p-2">
+                ${yearTotals[year].toLocaleString()}
+              </td>
             ))}
-            <td></td>
+            <td className="p-2"></td>
           </tr>
         </tbody>
       </table>

--- a/src/features/architect/ContractEditor.jsx
+++ b/src/features/architect/ContractEditor.jsx
@@ -74,13 +74,14 @@ const ContractEditor = ({ player, capSettings, teamCapSheet, onSign }) => {
   };
 
   return (
-    <div className="contract-editor">
-      <h2>Create Contract for {player.name}</h2>
+    <div className="text-white">
+      <h2 className="text-xl font-semibold mb-3">Create Contract for {player.name}</h2>
       
-      <label>Contract Type:</label>
-      <select 
-        value={type} 
+      <label className="block mb-1">Contract Type:</label>
+      <select
+        value={type}
         onChange={(e) => handleTypeChange(e.target.value)}
+        className="mb-3 p-2 bg-[#1a1a1a] border border-white/20 rounded"
       >
         <option value="Custom">Custom</option>
         <option value="Max">Max</option>
@@ -89,78 +90,94 @@ const ContractEditor = ({ player, capSettings, teamCapSheet, onSign }) => {
       </select>
 
       {type === 'Custom' && (
-        <div className="custom-contract-fields">
-          <label>Years:</label>
-          <input 
-            type="number" 
-            value={years} 
-            onChange={(e) => setYears(Number(e.target.value))} 
-            min={1} 
-            max={5} 
+        <div className="space-y-2 mb-4">
+          <label className="block">Years:</label>
+          <input
+            type="number"
+            value={years}
+            onChange={(e) => setYears(Number(e.target.value))}
+            min={1}
+            max={5}
+            className="p-1 bg-[#1a1a1a] border border-white/20 rounded w-20"
           />
 
-          <label>Base Salary:</label>
-          <input 
-            type="number" 
-            value={baseSalary} 
-            onChange={(e) => setBaseSalary(Number(e.target.value))} 
+          <label className="block">Base Salary:</label>
+          <input
+            type="number"
+            value={baseSalary}
+            onChange={(e) => setBaseSalary(Number(e.target.value))}
+            className="p-1 bg-[#1a1a1a] border border-white/20 rounded w-32"
           />
 
-          <label>Annual Raise %:</label>
-          <input 
-            type="number" 
-            value={raisePct} 
-            step={0.01} 
-            onChange={(e) => setRaisePct(Number(e.target.value))} 
+          <label className="block">Annual Raise %:</label>
+          <input
+            type="number"
+            value={raisePct}
+            step={0.01}
+            onChange={(e) => setRaisePct(Number(e.target.value))}
+            className="p-1 bg-[#1a1a1a] border border-white/20 rounded w-24"
           />
 
-          <label>
-            <input 
-              type="checkbox" 
-              checked={options.playerOption} 
-              onChange={(e) => setOptions({ 
-                ...options, 
-                playerOption: e.target.checked,
-                playerOptionYear: e.target.checked ? 
-                  new Date().getFullYear() + years - 1 : null
-              })} 
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={options.playerOption}
+              onChange={(e) =>
+                setOptions({
+                  ...options,
+                  playerOption: e.target.checked,
+                  playerOptionYear: e.target.checked
+                    ? new Date().getFullYear() + years - 1
+                    : null,
+                })
+              }
             />
             Player Option
           </label>
 
-          <label>
-            <input 
-              type="checkbox" 
-              checked={options.teamOption} 
-              onChange={(e) => setOptions({ 
-                ...options, 
-                teamOption: e.target.checked,
-                teamOptionYear: e.target.checked ? 
-                  new Date().getFullYear() + years - 1 : null
-              })} 
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={options.teamOption}
+              onChange={(e) =>
+                setOptions({
+                  ...options,
+                  teamOption: e.target.checked,
+                  teamOptionYear: e.target.checked
+                    ? new Date().getFullYear() + years - 1
+                    : null,
+                })
+              }
             />
             Team Option
           </label>
 
-          <label>
-            Guarantee %
-            <input 
-              type="number" 
-              value={guaranteedPercent} 
-              onChange={(e) => setGuaranteedPercent(parseFloat(e.target.value))} 
-              min={0} 
-              max={100} 
-              step={5} 
+          <label className="block">Guarantee %
+            <input
+              type="number"
+              value={guaranteedPercent}
+              onChange={(e) =>
+                setGuaranteedPercent(parseFloat(e.target.value))
+              }
+              min={0}
+              max={100}
+              step={5}
+              className="p-1 bg-[#1a1a1a] border border-white/20 rounded w-20 ml-2"
             />
           </label>
 
-          <button onClick={handleCustomPreview}>Preview Contract</button>
+            <button
+              onClick={handleCustomPreview}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm"
+            >
+              Preview Contract
+            </button>
         </div>
       )}
 
       {preview && (
-        <div className="contract-preview">
-          <h3>Contract Preview:</h3>
+        <div className="bg-[#1a1a1a] p-4 rounded border border-white/10 mt-4">
+          <h3 className="font-semibold mb-2">Contract Preview:</h3>
           <ul>
             {Object.entries(preview.salaryByYear).map(([year, salary]) => (
               <li key={year}>
@@ -183,7 +200,12 @@ const ContractEditor = ({ player, capSettings, teamCapSheet, onSign }) => {
                       `${guaranteedPercent}% guaranteed`}
           </p>
 
-          <button onClick={handleSign}>Sign Player</button>
+          <button
+            onClick={handleSign}
+            className="mt-2 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-sm"
+          >
+            Sign Player
+          </button>
         </div>
       )}
     </div>

--- a/src/features/architect/DraftPickTracker.jsx
+++ b/src/features/architect/DraftPickTracker.jsx
@@ -8,53 +8,53 @@ const DraftPickTracker = ({ pickLog = [], currentPicks = {} }) => {
   ).sort((a, b) => a - b);
 
   return (
-    <div className="draft-pick-tracker">
-      <h3>Draft Pick Trade Log</h3>
+    <div className="text-white">
+      <h3 className="text-lg font-semibold mb-2">Draft Pick Trade Log</h3>
       {pickLog.length === 0 ? (
         <p>No draft pick trades logged.</p>
       ) : (
-        <table>
+        <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
           <thead>
             <tr>
-              <th>Date</th>
-              <th>Action</th>
-              <th>Pick</th>
-              <th>Partner Team</th>
-              <th>Notes</th>
+              <th className="p-2 text-left">Date</th>
+              <th className="p-2 text-left">Action</th>
+              <th className="p-2 text-left">Pick</th>
+              <th className="p-2 text-left">Partner Team</th>
+              <th className="p-2 text-left">Notes</th>
             </tr>
           </thead>
           <tbody>
             {pickLog.map((entry, idx) => (
-              <tr key={`${entry.date}-${idx}`}>
-                <td>{entry.date || 'Unknown'}</td>
-                <td>{entry.action || '—'}</td>
-                <td>{entry.pick || '—'}</td>
-                <td>{entry.partner || '—'}</td>
-                <td>{entry.notes || '—'}</td>
+              <tr key={`${entry.date}-${idx}`} className="odd:bg-[#171717]">
+                <td className="p-2">{entry.date || 'Unknown'}</td>
+                <td className="p-2">{entry.action || '—'}</td>
+                <td className="p-2">{entry.pick || '—'}</td>
+                <td className="p-2">{entry.partner || '—'}</td>
+                <td className="p-2">{entry.notes || '—'}</td>
               </tr>
             ))}
           </tbody>
         </table>
       )}
 
-      <h3 style={{ marginTop: '30px' }}>Current Pick Inventory</h3>
+      <h3 className="mt-6 text-lg font-semibold">Current Pick Inventory</h3>
       {years.length === 0 ? (
         <p>No picks currently owned.</p>
       ) : (
-        <table>
+        <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
           <thead>
             <tr>
-              <th>Year</th>
-              <th>1st Round</th>
-              <th>2nd Round</th>
+              <th className="p-2 text-left">Year</th>
+              <th className="p-2 text-left">1st Round</th>
+              <th className="p-2 text-left">2nd Round</th>
             </tr>
           </thead>
           <tbody>
             {years.map((year) => (
-              <tr key={year}>
-                <td>{year}</td>
-                <td>{currentPicks[year]?.first || '—'}</td>
-                <td>{currentPicks[year]?.second || '—'}</td>
+              <tr key={year} className="odd:bg-[#171717]">
+                <td className="p-2">{year}</td>
+                <td className="p-2">{currentPicks[year]?.first || '—'}</td>
+                <td className="p-2">{currentPicks[year]?.second || '—'}</td>
               </tr>
             ))}
           </tbody>

--- a/src/features/architect/ExceptionHistoryTracker.jsx
+++ b/src/features/architect/ExceptionHistoryTracker.jsx
@@ -4,24 +4,24 @@ const ExceptionHistoryTracker = ({ exceptionHistory = [], mleHistory = [] }) => 
   const renderTPEHistory = () => {
     if (exceptionHistory.length === 0) return <p>No TPE activity logged.</p>;
     return (
-      <table>
+      <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
         <thead>
           <tr>
-            <th>Date</th>
-            <th>Action</th>
-            <th>Amount</th>
-            <th>Source Player</th>
-            <th>Expires</th>
+            <th className="p-2 text-left">Date</th>
+            <th className="p-2 text-left">Action</th>
+            <th className="p-2 text-left">Amount</th>
+            <th className="p-2 text-left">Source Player</th>
+            <th className="p-2 text-left">Expires</th>
           </tr>
         </thead>
         <tbody>
           {exceptionHistory.map((entry, idx) => (
-            <tr key={idx}>
-              <td>{entry.date}</td>
-              <td>{entry.action}</td>
-              <td>${entry.amount.toLocaleString()}</td>
-              <td>{entry.source || '—'}</td>
-              <td>{entry.expires || '—'}</td>
+            <tr key={idx} className="odd:bg-[#171717]">
+              <td className="p-2">{entry.date}</td>
+              <td className="p-2">{entry.action}</td>
+              <td className="p-2">${entry.amount.toLocaleString()}</td>
+              <td className="p-2">{entry.source || '—'}</td>
+              <td className="p-2">{entry.expires || '—'}</td>
             </tr>
           ))}
         </tbody>
@@ -32,24 +32,24 @@ const ExceptionHistoryTracker = ({ exceptionHistory = [], mleHistory = [] }) => 
   const renderMLEHistory = () => {
     if (mleHistory.length === 0) return <p>No MLE activity logged.</p>;
     return (
-      <table>
+      <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
         <thead>
           <tr>
-            <th>Year</th>
-            <th>Total</th>
-            <th>Used</th>
-            <th>Remaining</th>
-            <th>Notes</th>
+            <th className="p-2 text-left">Year</th>
+            <th className="p-2 text-left">Total</th>
+            <th className="p-2 text-left">Used</th>
+            <th className="p-2 text-left">Remaining</th>
+            <th className="p-2 text-left">Notes</th>
           </tr>
         </thead>
         <tbody>
           {mleHistory.map((mle, idx) => (
-            <tr key={idx}>
-              <td>{mle.year}</td>
-              <td>${mle.total.toLocaleString()}</td>
-              <td>${mle.used.toLocaleString()}</td>
-              <td>${(mle.total - mle.used).toLocaleString()}</td>
-              <td>{mle.notes || '—'}</td>
+            <tr key={idx} className="odd:bg-[#171717]">
+              <td className="p-2">{mle.year}</td>
+              <td className="p-2">${mle.total.toLocaleString()}</td>
+              <td className="p-2">${mle.used.toLocaleString()}</td>
+              <td className="p-2">${(mle.total - mle.used).toLocaleString()}</td>
+              <td className="p-2">{mle.notes || '—'}</td>
             </tr>
           ))}
         </tbody>
@@ -58,11 +58,11 @@ const ExceptionHistoryTracker = ({ exceptionHistory = [], mleHistory = [] }) => 
   };
 
   return (
-    <div className="exception-history-tracker">
-      <h3>Trade Exception Activity</h3>
+    <div className="text-white">
+      <h3 className="text-lg font-semibold mb-2">Trade Exception Activity</h3>
       {renderTPEHistory()}
 
-      <h3 style={{ marginTop: '30px' }}>MLE Usage History</h3>
+      <h3 className="mt-6 text-lg font-semibold">MLE Usage History</h3>
       {renderMLEHistory()}
     </div>
   );

--- a/src/features/architect/ExceptionTracker.jsx
+++ b/src/features/architect/ExceptionTracker.jsx
@@ -17,10 +17,11 @@ const ExceptionTracker = ({ teamCapSheet, currentYear }) => {
     if (!mle) return <p>No MLE available.</p>;
     const remaining = mle.amount - (mle.used || 0);
     return (
-      <div className="mle-block">
+      <div className="text-sm">
         <strong title="MLE: Mid-Level Exception (can be used to sign free agents above the minimum)">
           MLE:
-        </strong><br />
+        </strong>
+        <br />
         Total: ${mle.amount.toLocaleString()}<br />
         Used: ${mle.used?.toLocaleString() || 0}<br />
         Remaining: ${remaining.toLocaleString()}
@@ -31,7 +32,7 @@ const ExceptionTracker = ({ teamCapSheet, currentYear }) => {
   const renderTPEs = () => {
     if (tradeExceptions.length === 0) return <p>No Trade Exceptions</p>;
     return (
-      <ul className="tpe-list">
+      <ul className="mt-1 space-y-1 text-sm">
         {tradeExceptions.map((tpe, idx) => {
           const statusClass = getTPEStatusClass(tpe.expires);
           const days = daysUntil(tpe.expires);
@@ -49,10 +50,10 @@ const ExceptionTracker = ({ teamCapSheet, currentYear }) => {
   };
 
   return (
-    <div className="exception-tracker">
-      <h3>Exception Tracker</h3>
+    <div className="text-white">
+      <h3 className="text-lg font-semibold mb-2">Exception Tracker</h3>
       {renderMLE()}
-      <div style={{ marginTop: '12px' }}>
+      <div className="mt-3">
         <strong title="TPEs: Created when trading a player without taking back matching salary. Last 1 year.">
           Trade Exceptions:
         </strong>

--- a/src/features/architect/FreeAgentPool.jsx
+++ b/src/features/architect/FreeAgentPool.jsx
@@ -30,12 +30,15 @@ const FreeAgentPool = ({ freeAgents, teamCapSheet, capSettings, currentYear, onS
   };
 
   return (
-    <div className="free-agent-pool">
-      <h2>Free Agent Pool</h2>
-      <ul>
+    <div className="text-white">
+      <h2 className="text-xl font-semibold mb-2">Free Agent Pool</h2>
+      <ul className="space-y-1 mb-4">
         {freeAgents.map((p) => (
           <li key={p.name}>
-            <button onClick={() => handleSelect(p)}>
+            <button
+              onClick={() => handleSelect(p)}
+              className="text-blue-400 hover:underline text-sm"
+            >
               {p.name} – Asking: ${p.askingSalary.toLocaleString()} – Rights: {p.birdRights}
             </button>
           </li>
@@ -43,20 +46,25 @@ const FreeAgentPool = ({ freeAgents, teamCapSheet, capSettings, currentYear, onS
       </ul>
 
       {selectedPlayer && (
-        <div className="fa-details">
-          <h3>{selectedPlayer.name}</h3>
-          <p>Asking: ${selectedPlayer.askingSalary.toLocaleString()}</p>
-          <p>Bird Rights: {selectedPlayer.birdRights}</p>
-          <button onClick={handleSign}>Sign Player</button>
+        <div className="bg-[#1a1a1a] p-4 rounded border border-white/10 mb-3">
+          <h3 className="font-semibold mb-1">{selectedPlayer.name}</h3>
+          <p className="text-sm mb-1">Asking: ${selectedPlayer.askingSalary.toLocaleString()}</p>
+          <p className="text-sm mb-3">Bird Rights: {selectedPlayer.birdRights}</p>
+          <button
+            onClick={handleSign}
+            className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-sm"
+          >
+            Sign Player
+          </button>
         </div>
       )}
 
       {signResult && (
-        <div style={{ marginTop: '10px' }}>
+        <div className="mt-2 text-sm">
           {signResult.allowed ? (
-            <span style={{ color: 'green' }}>{signResult.message}</span>
+            <span className="text-green-500">{signResult.message}</span>
           ) : (
-            <span style={{ color: 'red' }}>{signResult.reason}</span>
+            <span className="text-red-500">{signResult.reason}</span>
           )}
         </div>
       )}

--- a/src/features/architect/GMDashboard.jsx
+++ b/src/features/architect/GMDashboard.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   saveTeamCapSheet,
   loadTeamCapSheet,
   saveFreeAgents,
   loadFreeAgents,
-} from '../utils/firebaseHelpers';
+} from '@/utils/architect/firebaseHelpers';
 
 import RosterManager from './RosterManager';
 import CapSheet from './CapSheet';
@@ -16,16 +16,14 @@ import FreeAgentPool from './FreeAgentPool';
 import OffseasonTab from './OffseasonTab';
 import TeamHistoryTab from './TeamHistoryTab';
 import ExceptionTracker from './ExceptionTracker';
+import usePlayerData from '@/hooks/usePlayerData.js';
 
 import capSettings from '../utils/capSettings';
-import initialFreeAgents from '../data/freeAgents';
-import initialTeamA from '../data/teamLakers';
-import initialTeamB from '../data/teamKnicks';
 
 const GMDashboard = () => {
   const { teamId } = useParams();
   const [teamCapSheet, setTeamCapSheet] = useState(null);
-  const [otherTeamCapSheet] = useState(initialTeamB);
+  const [otherTeamCapSheet] = useState(null);
   const [currentYear, setCurrentYear] = useState(2025);
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const [freeAgents, setFreeAgents] = useState([]);
@@ -34,6 +32,15 @@ const GMDashboard = () => {
   const [offseasonRun, setOffseasonRun] = useState(false);
   const [offseasonSummary, setOffseasonSummary] = useState(null);
   const [showModal, setShowModal] = useState(false);
+  const { players } = usePlayerData();
+
+  const playersMap = useMemo(() => {
+    const map = {};
+    players.forEach((p) => {
+      map[p.display_name || p.name] = p;
+    });
+    return map;
+  }, [players]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -132,6 +139,7 @@ const GMDashboard = () => {
             currentYear={currentYear}
             onUpdateRoster={handleUpdateRoster}
             onEditContract={handleEditContract}
+            playersMap={playersMap}
           />
         )}
 
@@ -165,7 +173,7 @@ const GMDashboard = () => {
         {activeTab === 'trade' && (
           <TradeEditor
             teamA={teamCapSheet}
-            teamB={otherTeamCapSheet}
+            teamB={otherTeamCapSheet || teamCapSheet}
             capSettings={capSettings}
             currentYear={currentYear}
           />

--- a/src/features/architect/LeagueView.jsx
+++ b/src/features/architect/LeagueView.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { loadTeamCapSheet } from '../utils/firebaseHelpers';
+import { loadTeamCapSheet } from '@/utils/architect/firebaseHelpers';
 import { useNavigate } from 'react-router-dom';
 
 const teamsList = [
@@ -39,23 +39,26 @@ const LeagueView = () => {
   };
 
   return (
-    <div className="league-view">
-      <h1>HoopZero Architect – League View</h1>
-      <table>
-        <thead>
+    <div className="text-white">
+      <h1 className="text-2xl font-bold mb-4">HoopZero Architect – League View</h1>
+      <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
+        <thead className="bg-[#111]">
           <tr>
-            <th>Team</th>
-            <th>Total Salary</th>
-            <th>Action</th>
+            <th className="p-2 text-left">Team</th>
+            <th className="p-2 text-left">Total Salary</th>
+            <th className="p-2" />
           </tr>
         </thead>
         <tbody>
-          {teamSummaries.map(team => (
-            <tr key={team.teamName}>
-              <td>{team.teamName}</td>
-              <td>${team.totalSalary.toLocaleString()}</td>
-              <td>
-                <button onClick={() => goToTeam(team.teamName)}>
+          {teamSummaries.map((team) => (
+            <tr key={team.teamName} className="odd:bg-[#171717]">
+              <td className="p-2">{team.teamName}</td>
+              <td className="p-2">${team.totalSalary.toLocaleString()}</td>
+              <td className="p-2 text-right">
+                <button
+                  onClick={() => goToTeam(team.teamName)}
+                  className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded text-xs"
+                >
                   Manage Team
                 </button>
               </td>

--- a/src/features/architect/OffseasonTab.jsx
+++ b/src/features/architect/OffseasonTab.jsx
@@ -37,8 +37,8 @@ const OffseasonTab = ({
   };
 
   return (
-    <div className="offseason-tab">
-      <h2>Offseason Manager</h2>
+    <div className="text-white">
+      <h2 className="text-xl font-semibold mb-2">Offseason Manager</h2>
       
       {!optionsConfirmed && !offseasonRun && (
         <OptionManager 
@@ -49,16 +49,19 @@ const OffseasonTab = ({
       )}
 
       {optionsConfirmed && !offseasonRun && (
-        <div style={{ marginTop: '20px' }}>
-          <h4>All option decisions confirmed.</h4>
-          <button onClick={handleAdvanceYear}>
+        <div className="mt-5">
+          <h4 className="font-semibold mb-2">All option decisions confirmed.</h4>
+          <button
+            onClick={handleAdvanceYear}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm"
+          >
             Advance to {currentYear + 1}
           </button>
         </div>
       )}
 
       {offseasonRun && (
-        <div style={{ marginTop: '20px' }}>
+        <div className="mt-5">
           <strong>✅ Offseason Complete!</strong>
           <p>You are now in the {currentYear + 1} season.</p>
         </div>

--- a/src/features/architect/OptionManager.jsx
+++ b/src/features/architect/OptionManager.jsx
@@ -45,29 +45,32 @@ const OptionManager = ({ teamCapSheet, currentYear, onDecisionsReady }) => {
   };
 
   return (
-    <div className="option-manager">
-      <h3>Pending Contract Options – {currentYear + 1}</h3>
+    <div className="text-white">
+      <h3 className="text-lg font-semibold mb-2">Pending Contract Options – {currentYear + 1}</h3>
       
       {optionsList.length === 0 ? (
         <p>No player or team options pending.</p>
       ) : (
-        <table>
-          <thead>
+        <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
+          <thead className="bg-[#111]">
             <tr>
-              <th>Player</th>
-              <th>Type</th>
-              <th>Salary</th>
-              <th>Decision</th>
+              <th className="p-2 text-left">Player</th>
+              <th className="p-2 text-left">Type</th>
+              <th className="p-2 text-left">Salary</th>
+              <th className="p-2 text-left">Decision</th>
             </tr>
           </thead>
           <tbody>
             {optionsList.map((opt) => (
-              <tr key={opt.name}>
-                <td>{opt.name}</td>
-                <td>{opt.type}</td>
-                <td>${opt.salary.toLocaleString()}</td>
-                <td>
-                  <button onClick={() => toggleDecision(opt.name)}>
+              <tr key={opt.name} className="odd:bg-[#171717]">
+                <td className="p-2">{opt.name}</td>
+                <td className="p-2">{opt.type}</td>
+                <td className="p-2">${opt.salary.toLocaleString()}</td>
+                <td className="p-2">
+                  <button
+                    onClick={() => toggleDecision(opt.name)}
+                    className="text-xs text-blue-400 hover:underline"
+                  >
                     {decisions[opt.name] ? 'Accept' : 'Decline'}
                   </button>
                 </td>
@@ -78,9 +81,9 @@ const OptionManager = ({ teamCapSheet, currentYear, onDecisionsReady }) => {
       )}
 
       {optionsList.length > 0 && (
-        <button 
-          onClick={handleSubmit} 
-          style={{ marginTop: '10px' }}
+        <button
+          onClick={handleSubmit}
+          className="mt-3 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-sm"
         >
           Confirm Decisions
         </button>

--- a/src/features/architect/RosterManager.jsx
+++ b/src/features/architect/RosterManager.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { stretchContract } from '../utils/contractUtils';
 
-const RosterManager = ({ teamCapSheet, currentYear, onUpdateRoster, onEditContract }) => {
+const RosterManager = ({
+  teamCapSheet,
+  currentYear,
+  onUpdateRoster,
+  onEditContract,
+  playersMap = {},
+}) => {
   const handleWaivePlayer = (player) => {
     const updatedRoster = teamCapSheet.activeContracts.filter(p => p.name !== player.name);
     const dead = { 
@@ -36,40 +42,59 @@ const RosterManager = ({ teamCapSheet, currentYear, onUpdateRoster, onEditContra
   };
 
   return (
-    <div className="roster-manager">
-      <h2>{teamCapSheet.teamName} Roster</h2>
-      <table>
-        <thead>
+    <div className="text-white">
+      <h2 className="text-xl font-semibold mb-2">{teamCapSheet.teamName} Roster</h2>
+      <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
+        <thead className="bg-[#111]">
           <tr>
-            <th>Player</th>
-            <th>Years</th>
-            <th>Salary</th>
-            <th>Contract Type</th>
-            <th>Options</th>
-            <th>Actions</th>
+            <th className="p-2 text-left">Player</th>
+            <th className="p-2 text-left">Years</th>
+            <th className="p-2 text-left">Salary</th>
+            <th className="p-2 text-left">Type</th>
+            <th className="p-2 text-left">Options</th>
+            <th className="p-2" />
           </tr>
         </thead>
         <tbody>
-          {teamCapSheet.activeContracts.map((player) => (
-            <tr key={player.name}>
-              <td>{player.name}</td>
-              <td>{player.years}</td>
-              <td>
-                {player.salaryByYear[currentYear] ? 
-                  `$${player.salaryByYear[currentYear].toLocaleString()}` : '—'}
-              </td>
-              <td>{player.type}</td>
-              <td>
-                {player.options?.playerOption && 'PO '}
-                {player.options?.teamOption && 'TO '}
-              </td>
-              <td>
-                <button onClick={() => onEditContract(player)}>Edit</button>
-                <button onClick={() => handleWaivePlayer(player)}>Waive</button>
-                <button onClick={() => handleStretchPlayer(player)}>Stretch</button>
-              </td>
-            </tr>
-          ))}
+          {teamCapSheet.activeContracts.map((player) => {
+            const details = playersMap[player.name] || {};
+            return (
+              <tr key={player.name} className="odd:bg-[#171717]">
+                <td className="p-2">{details.display_name || player.name}</td>
+                <td className="p-2">{player.years}</td>
+                <td className="p-2">
+                  {player.salaryByYear[currentYear]
+                    ? `$${player.salaryByYear[currentYear].toLocaleString()}`
+                    : '—'}
+                </td>
+                <td className="p-2">{player.type}</td>
+                <td className="p-2">
+                  {player.options?.playerOption && 'PO '}
+                  {player.options?.teamOption && 'TO '}
+                </td>
+                <td className="p-2 text-right">
+                  <button
+                    onClick={() => onEditContract(player)}
+                    className="text-xs text-blue-400 hover:underline mr-2"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleWaivePlayer(player)}
+                    className="text-xs text-red-500 hover:underline mr-2"
+                  >
+                    Waive
+                  </button>
+                  <button
+                    onClick={() => handleStretchPlayer(player)}
+                    className="text-xs text-yellow-500 hover:underline"
+                  >
+                    Stretch
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/features/architect/TeamHistoryTab.jsx
+++ b/src/features/architect/TeamHistoryTab.jsx
@@ -5,19 +5,19 @@ import DraftPickTracker from './DraftPickTracker';
 
 const TeamHistoryTab = ({ teamCapSheet }) => {
   return (
-    <div className="team-history-tab">
-      <h2>Team Transaction History</h2>
+    <div className="text-white">
+      <h2 className="text-xl font-semibold mb-4">Team Transaction History</h2>
       
-      <section style={{ marginBottom: '40px' }}>
-        <WaiveStretchTracker 
-          waivedContracts={teamCapSheet.waivedContracts || []} 
+      <section className="mb-10">
+        <WaiveStretchTracker
+          waivedContracts={teamCapSheet.waivedContracts || []}
         />
       </section>
-      
-      <section style={{ marginBottom: '40px' }}>
-        <ExceptionHistoryTracker 
-          exceptionHistory={teamCapSheet.exceptionHistory || []} 
-          mleHistory={teamCapSheet.mleHistory || []} 
+
+      <section className="mb-10">
+        <ExceptionHistoryTracker
+          exceptionHistory={teamCapSheet.exceptionHistory || []}
+          mleHistory={teamCapSheet.mleHistory || []}
         />
       </section>
       

--- a/src/features/architect/TradeEditor.jsx
+++ b/src/features/architect/TradeEditor.jsx
@@ -36,18 +36,18 @@ const TradeEditor = ({ teamA, teamB, capSettings, currentYear }) => {
   };
 
   return (
-    <div className="trade-editor">
-      <h2>Trade Machine</h2>
+    <div className="text-white">
+      <h2 className="text-xl font-semibold mb-4">Trade Machine</h2>
       
-      <div className="trade-boxes">
+      <div className="flex flex-col md:flex-row gap-6">
         {/* Team A */}
-        <div>
-          <h3>{teamA.teamName}</h3>
+        <div className="flex-1">
+          <h3 className="font-semibold mb-1">{teamA.teamName}</h3>
           <strong>Players:</strong>
-          <ul>
+          <ul className="mb-2">
             {teamA.activeContracts.map((p) => (
-              <li key={p.name}>
-                <label>
+              <li key={p.name} className="text-sm">
+                <label className="flex items-center gap-2">
                   <input
                     type="checkbox"
                     checked={teamASends.includes(p)}
@@ -61,10 +61,10 @@ const TradeEditor = ({ teamA, teamB, capSettings, currentYear }) => {
           </ul>
           
           <strong>Picks:</strong>
-          <ul>
+          <ul className="mb-2">
             {teamA.picks?.map((pick) => (
-              <li key={`${pick.year}-${pick.round}`}>
-                <label>
+              <li key={`${pick.year}-${pick.round}`} className="text-sm">
+                <label className="flex items-center gap-2">
                   <input
                     type="checkbox"
                     checked={teamAPicksOut.includes(pick)}
@@ -76,17 +76,17 @@ const TradeEditor = ({ teamA, teamB, capSettings, currentYear }) => {
             ))}
           </ul>
           
-          <p><strong>Total Salary:</strong> ${getSalary(teamASends).toLocaleString()}</p>
+          <p className="text-sm"><strong>Total Salary:</strong> ${getSalary(teamASends).toLocaleString()}</p>
         </div>
         
         {/* Team B */}
-        <div>
-          <h3>{teamB.teamName}</h3>
+        <div className="flex-1">
+          <h3 className="font-semibold mb-1">{teamB.teamName}</h3>
           <strong>Players:</strong>
-          <ul>
+          <ul className="mb-2">
             {teamB.activeContracts.map((p) => (
-              <li key={p.name}>
-                <label>
+              <li key={p.name} className="text-sm">
+                <label className="flex items-center gap-2">
                   <input
                     type="checkbox"
                     checked={teamBSends.includes(p)}
@@ -99,10 +99,10 @@ const TradeEditor = ({ teamA, teamB, capSettings, currentYear }) => {
           </ul>
           
           <strong>Picks:</strong>
-          <ul>
+          <ul className="mb-2">
             {teamB.picks?.map((pick) => (
-              <li key={`${pick.year}-${pick.round}`}>
-                <label>
+              <li key={`${pick.year}-${pick.round}`} className="text-sm">
+                <label className="flex items-center gap-2">
                   <input
                     type="checkbox"
                     checked={teamBPicksOut.includes(pick)}
@@ -114,14 +114,19 @@ const TradeEditor = ({ teamA, teamB, capSettings, currentYear }) => {
             ))}
           </ul>
           
-          <p><strong>Total Salary:</strong> ${getSalary(teamBSends).toLocaleString()}</p>
+          <p className="text-sm"><strong>Total Salary:</strong> ${getSalary(teamBSends).toLocaleString()}</p>
         </div>
       </div>
-      
-      <button onClick={handleValidate}>Validate Trade</button>
-      
+
+      <button
+        onClick={handleValidate}
+        className="mt-4 bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm"
+      >
+        Validate Trade
+      </button>
+
       {result && (
-        <div className="trade-result" style={{ marginTop: '15px' }}>
+        <div className="mt-4 text-sm">
           <strong>{result.legal ? '✅ Trade Approved' : '❌ Trade Rejected'}</strong>
           <p>{result.reason || 'Trade complies with all rules.'}</p>
         </div>

--- a/src/features/architect/WaiveStretchTracker.jsx
+++ b/src/features/architect/WaiveStretchTracker.jsx
@@ -16,28 +16,28 @@ const WaiveStretchTracker = ({ waivedContracts = [] }) => {
     .sort();
 
   return (
-    <div className="waive-stretch-tracker">
-      <h3>Waived & Stretched Contracts</h3>
+    <div className="text-white">
+      <h3 className="text-lg font-semibold mb-2">Waived & Stretched Contracts</h3>
       
       {waivedContracts.length === 0 ? (
         <p>No waived contracts.</p>
       ) : (
-        <table>
+        <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
           <thead>
             <tr>
-              <th>Player</th>
-              <th>Waived On</th>
-              <th>Stretched?</th>
-              <th>Dead Cap Breakdown</th>
+              <th className="p-2 text-left">Player</th>
+              <th className="p-2 text-left">Waived On</th>
+              <th className="p-2 text-left">Stretched?</th>
+              <th className="p-2 text-left">Dead Cap Breakdown</th>
             </tr>
           </thead>
           <tbody>
             {waivedContracts.map((wc, idx) => (
-              <tr key={idx}>
-                <td>{wc.name}</td>
-                <td>{wc.waivedOn}</td>
-                <td>{wc.stretched ? 'Yes' : 'No'}</td>
-                <td>
+              <tr key={idx} className="odd:bg-[#171717]">
+                <td className="p-2">{wc.name}</td>
+                <td className="p-2">{wc.waivedOn}</td>
+                <td className="p-2">{wc.stretched ? 'Yes' : 'No'}</td>
+                <td className="p-2 space-y-1">
                   {Object.entries(wc.deadCap || {}).map(([year, amt]) => (
                     <div key={year}>
                       {year}: ${amt.toLocaleString()}
@@ -50,23 +50,23 @@ const WaiveStretchTracker = ({ waivedContracts = [] }) => {
         </table>
       )}
       
-      <h4 style={{ marginTop: '20px' }}>Dead Cap by Year</h4>
+      <h4 className="mt-5 font-semibold">Dead Cap by Year</h4>
       
       {sortedYears.length === 0 ? (
         <p>No dead money on the books.</p>
       ) : (
-        <table>
+        <table className="min-w-full text-sm bg-[#1a1a1a] border border-white/10 rounded">
           <thead>
             <tr>
-              <th>Year</th>
-              <th>Total Dead Cap</th>
+              <th className="p-2 text-left">Year</th>
+              <th className="p-2 text-left">Total Dead Cap</th>
             </tr>
           </thead>
           <tbody>
             {sortedYears.map((year) => (
-              <tr key={year}>
-                <td>{year}</td>
-                <td>${deadCapByYear[year].toLocaleString()}</td>
+              <tr key={year} className="odd:bg-[#171717]">
+                <td className="p-2">{year}</td>
+                <td className="p-2">${deadCapByYear[year].toLocaleString()}</td>
               </tr>
             ))}
           </tbody>

--- a/src/pages/GmDashboardView.jsx
+++ b/src/pages/GmDashboardView.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import GMDashboard from '@/features/architect/GMDashboard';
+
+const GmDashboardView = () => (
+  <div className="px-4 pt-4 pb-10">
+    <div className="max-w-[1100px] mx-auto">
+      <GMDashboard />
+    </div>
+  </div>
+);
+
+export default GmDashboardView;

--- a/src/pages/GmLeagueView.jsx
+++ b/src/pages/GmLeagueView.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import LeagueView from '@/features/architect/LeagueView';
+
+const GmLeagueView = () => (
+  <div className="px-4 pt-4">
+    <div className="max-w-[1100px] mx-auto">
+      <LeagueView />
+    </div>
+  </div>
+);
+
+export default GmLeagueView;

--- a/src/utils/architect/firebaseHelpers.js
+++ b/src/utils/architect/firebaseHelpers.js
@@ -1,16 +1,11 @@
-import { initializeApp } from "firebase/app";
-import { 
-  getFirestore, 
-  doc, 
-  setDoc, 
-  getDoc, 
-  collection, 
-  getDocs 
-} from "firebase/firestore";
-import firebaseConfig from "../firebaseConfig";
-
-const app = initializeApp(firebaseConfig);
-const db = getFirestore(app);
+import {
+  doc,
+  setDoc,
+  getDoc,
+  collection,
+  getDocs,
+} from 'firebase/firestore';
+import { db } from '../../firebaseConfig';
 
 // Save a team's cap sheet
 export const saveTeamCapSheet = async (teamId, capSheet) => {


### PR DESCRIPTION
## Summary
- implement HoopZero Architect league view and GM dashboard pages
- convert architect components to Tailwind styling
- add GM Tools link in main navigation
- update Firebase helpers to reuse existing config
- wire GM pages into router

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9510964883268c8690855ac8132c