### PR TITLE
fix: normalize architect player names

### DIFF
--- a/src/features/architect/CapSheet.jsx
+++ b/src/features/architect/CapSheet.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
+import { formatName } from '@/utils/formatting';
 import { getMinimumCapHit } from '@/utils/architect/contractUtils';
 import CapSummaryTiles from '@/features/architect/CapSummaryTiles';
 import { POSITION_MAP } from '@/utils/roles/positionMap';
 import getCapPercentage from '@/utils/architect/getCapPercentage';
 import capProjections from '@/utils/architect/capProjections';
 
-const CapSheet = ({ teamCapSheet, currentYear, onSelectPlayer }) => {
+const CapSheet = ({ teamCapSheet, currentYear, onSelectPlayer, playersMap = {} }) => {
   const [selectedYear, setSelectedYear] = useState(currentYear);
   const [showCapHolds, setShowCapHolds] = useState(false);
 
@@ -146,7 +147,8 @@ const CapSheet = ({ teamCapSheet, currentYear, onSelectPlayer }) => {
                     onClick={() => onSelectPlayer && onSelectPlayer(player)}
                     className="text-blue-400 hover:underline"
                   >
-                    {player.name}
+                    {playersMap[player.name]?.display_name ||
+                      formatName(player.name)}
                   </button>
                 </td>
                 <td className="p-2">
@@ -194,7 +196,9 @@ const CapSheet = ({ teamCapSheet, currentYear, onSelectPlayer }) => {
                   totalCapHit += amt;
                   return (
                     <tr key={idx} className="odd:bg-[#171717]">
-                      <td className="p-2">{p.name}</td>
+                      <td className="p-2">
+                        {playersMap[p.name]?.display_name || formatName(p.name)}
+                      </td>
                       <td className="p-2">${amt.toLocaleString()}</td>
                       <td className="p-2">{reason}</td>
                     </tr>

--- a/src/features/architect/CapSheetFull.jsx
+++ b/src/features/architect/CapSheetFull.jsx
@@ -1,17 +1,11 @@
 // CapSheetFull.jsx
 import React, { useState } from 'react';
+import { formatName } from '@/utils/formatting';
 
-const CapSheetFull = ({ teamCapSheet, onSelectPlayer }) => {
+const CapSheetFull = ({ teamCapSheet, onSelectPlayer, playersMap = {} }) => {
   if (!teamCapSheet || !teamCapSheet.players) return null;
 
   const [showCapHolds, setShowCapHolds] = useState(false);
-
-  // Project-wide name formatting
-  const formatName = (name) =>
-    name
-      .split(' ')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-      .join(' ');
 
   // Always include 2025–2031
   const allYears = Array.from({ length: 7 }, (_, i) => 2025 + i);
@@ -91,7 +85,8 @@ const CapSheetFull = ({ teamCapSheet, onSelectPlayer }) => {
                     onClick={() => onSelectPlayer && onSelectPlayer(player)}
                     className="text-blue-400 hover:underline"
                   >
-                    {player.display_name}
+                    {playersMap[player.name]?.display_name ||
+                      formatName(player.display_name || player.name)}
                   </button>
                 </td>
                 {allYears.map((year) => {
@@ -156,7 +151,10 @@ const CapSheetFull = ({ teamCapSheet, onSelectPlayer }) => {
                       typeof p.cap_hold === 'object' ? p.cap_hold?.reason : '';
                     return (
                       <tr key={idx} className="odd:bg-[#171717]">
-                        <td className="p-2">{formatName(p.display_name)}</td>
+                        <td className="p-2">
+                          {playersMap[p.name]?.display_name ||
+                            formatName(p.display_name || p.name)}
+                        </td>
                         <td className="p-2">${amt.toLocaleString()}</td>
                         <td className="p-2">{reason}</td>
                       </tr>

--- a/src/features/architect/ContractEditor.jsx
+++ b/src/features/architect/ContractEditor.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { formatName } from '@/utils/formatting';
 import {
   generateContract,
   createMaxContract,
@@ -6,7 +7,13 @@ import {
   getMinimumSalary,
 } from '@/utils/architect/contractUtils';
 
-const ContractEditor = ({ player, capProjections, teamCapSheet, onSign }) => {
+const ContractEditor = ({
+  player,
+  capProjections,
+  teamCapSheet,
+  onSign,
+  playersMap = {},
+}) => {
   console.log('ContractEditor loaded for player:', player);
 
   const [type, setType] = useState('Custom');
@@ -95,7 +102,8 @@ const ContractEditor = ({ player, capProjections, teamCapSheet, onSign }) => {
   return (
     <div className="text-white">
       <h2 className="text-xl font-semibold mb-3">
-        Create Contract for {player.name}
+        Create Contract for{' '}
+        {playersMap[player.name]?.display_name || formatName(player.name)}
       </h2>
 
       <label className="block mb-1">Contract Type:</label>

--- a/src/features/architect/ContractEditorModal.jsx
+++ b/src/features/architect/ContractEditorModal.jsx
@@ -9,6 +9,7 @@ const ContractEditorModal = ({
   capProjections,
   teamCapSheet,
   onSign,
+  playersMap = {},
 }) => (
   <Dialog open={isOpen} onOpenChange={onClose}>
     <DialogContent className="p-4 max-w-xl">
@@ -17,6 +18,7 @@ const ContractEditorModal = ({
         capProjections={capProjections}
         teamCapSheet={teamCapSheet}
         onSign={onSign}
+        playersMap={playersMap}
       />
     </DialogContent>
   </Dialog>

--- a/src/features/architect/FreeAgentPool.jsx
+++ b/src/features/architect/FreeAgentPool.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { formatName } from '@/utils/formatting';
 import { canSignFreeAgent } from '@/utils/architect/freeAgentLogic';
 import { generateContract } from '@/utils/architect/contractUtils';
 
@@ -8,6 +9,7 @@ const FreeAgentPool = ({
   capProjections,
   currentYear,
   onSign,
+  playersMap = {},
 }) => {
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const [signResult, setSignResult] = useState(null);
@@ -51,8 +53,8 @@ const FreeAgentPool = ({
               onClick={() => handleSelect(p)}
               className="text-blue-400 hover:underline text-sm"
             >
-              {p.name} – Asking: ${p.askingSalary.toLocaleString()} – Rights:{' '}
-              {p.birdRights}
+              {playersMap[p.name]?.display_name || formatName(p.name)} – Asking:
+              ${p.askingSalary.toLocaleString()} – Rights: {p.birdRights}
             </button>
           </li>
         ))}
@@ -60,7 +62,10 @@ const FreeAgentPool = ({
 
       {selectedPlayer && (
         <div className="bg-[#1a1a1a] p-4 rounded border border-white/10 mb-3">
-          <h3 className="font-semibold mb-1">{selectedPlayer.name}</h3>
+          <h3 className="font-semibold mb-1">
+            {playersMap[selectedPlayer.name]?.display_name ||
+              formatName(selectedPlayer.name)}
+          </h3>
           <p className="text-sm mb-1">
             Asking: ${selectedPlayer.askingSalary.toLocaleString()}
           </p>

--- a/src/features/architect/GMDashboard.jsx
+++ b/src/features/architect/GMDashboard.jsx
@@ -294,6 +294,7 @@ const GMDashboard = () => {
               teamCapSheet={teamCapSheet.capSheet}
               currentYear={currentYear}
               onSelectPlayer={handleEditContract}
+              playersMap={playersMap}
             />
 
             <ExceptionTracker
@@ -307,6 +308,7 @@ const GMDashboard = () => {
           <CapSheetFull
             teamCapSheet={teamCapSheet.capSheet}
             onSelectPlayer={handleEditContract}
+            playersMap={playersMap}
           />
         )}
 
@@ -316,6 +318,7 @@ const GMDashboard = () => {
             teamB={otherTeamCapSheet || teamCapSheet}
             capProjections={capProjections}
             currentYear={currentYear}
+            playersMap={playersMap}
           />
         )}
 
@@ -326,6 +329,7 @@ const GMDashboard = () => {
             capProjections={capProjections}
             currentYear={currentYear}
             onSign={handleSign}
+            playersMap={playersMap}
           />
         )}
 
@@ -340,6 +344,7 @@ const GMDashboard = () => {
             setOffseasonRun={setOffseasonRun}
             setOffseasonSummary={setOffseasonSummary}
             setShowModal={setShowModal}
+            playersMap={playersMap}
           />
         )}
 
@@ -437,6 +442,7 @@ const GMDashboard = () => {
           capProjections={capProjections}
           teamCapSheet={teamCapSheet}
           onSign={handleSign}
+          playersMap={playersMap}
         />
       )}
 

--- a/src/features/architect/OffseasonTab.jsx
+++ b/src/features/architect/OffseasonTab.jsx
@@ -12,6 +12,7 @@ const OffseasonTab = ({
   setOffseasonRun,
   setOffseasonSummary,
   setShowModal,
+  playersMap = {},
 }) => {
   const [optionsConfirmed, setOptionsConfirmed] = useState(false);
   const [optionDecisions, setOptionDecisions] = useState(null);
@@ -45,6 +46,7 @@ const OffseasonTab = ({
           teamCapSheet={teamCapSheet}
           currentYear={currentYear}
           onDecisionsReady={handleDecisionsReady}
+          playersMap={playersMap}
         />
       )}
 

--- a/src/features/architect/OptionManager.jsx
+++ b/src/features/architect/OptionManager.jsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { formatName } from '@/utils/formatting';
 
-const OptionManager = ({ teamCapSheet, currentYear, onDecisionsReady }) => {
+const OptionManager = ({
+  teamCapSheet,
+  currentYear,
+  onDecisionsReady,
+  playersMap = {},
+}) => {
   const [optionsList, setOptionsList] = useState([]);
   const [decisions, setDecisions] = useState({});
 
@@ -62,7 +68,9 @@ const OptionManager = ({ teamCapSheet, currentYear, onDecisionsReady }) => {
           <tbody>
             {optionsList.map((opt) => (
               <tr key={opt.name} className="odd:bg-[#171717]">
-                <td className="p-2">{opt.name}</td>
+                <td className="p-2">
+                  {playersMap[opt.name]?.display_name || formatName(opt.name)}
+                </td>
                 <td className="p-2">{opt.type}</td>
                 <td className="p-2">${opt.salary.toLocaleString()}</td>
                 <td className="p-2">

--- a/src/features/architect/TradeEditor.jsx
+++ b/src/features/architect/TradeEditor.jsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import { validateTrade } from '@/utils/architect/tradeValidator';
+import { formatName } from '@/utils/formatting';
 
-const TradeEditor = ({ teamA, teamB, capProjections, currentYear }) => {
+const TradeEditor = ({
+  teamA,
+  teamB,
+  capProjections,
+  currentYear,
+  playersMap = {},
+}) => {
   const [teamASends, setTeamASends] = useState([]);
   const [teamBSends, setTeamBSends] = useState([]);
   const [teamAPicksOut, setTeamAPicksOut] = useState([]);
@@ -56,7 +63,7 @@ const TradeEditor = ({ teamA, teamB, capProjections, currentYear }) => {
                     checked={teamASends.includes(p)}
                     onChange={() => toggleItem(p, teamASends, setTeamASends)}
                   />
-                  {p.name} – $
+                  {playersMap[p.name]?.display_name || formatName(p.name)} – $
                   {p.contract_clean?.salaries_by_year?.[
                     yearKey
                   ]?.salary?.toLocaleString() || 0}
@@ -104,7 +111,7 @@ const TradeEditor = ({ teamA, teamB, capProjections, currentYear }) => {
                     checked={teamBSends.includes(p)}
                     onChange={() => toggleItem(p, teamBSends, setTeamBSends)}
                   />
-                  {p.name} – $
+                  {playersMap[p.name]?.display_name || formatName(p.name)} – $
                   {p.contract_clean?.salaries_by_year?.[
                     yearKey
                   ]?.salary?.toLocaleString() || 0}

--- a/src/utils/formatting/formatName.js
+++ b/src/utils/formatting/formatName.js
@@ -1,0 +1,21 @@
+export function formatName(name = '') {
+  if (!name) return '';
+  const suffixes = ['jr', 'sr', 'ii', 'iii', 'iv', 'v'];
+  return name
+    .trim()
+    .split(' ')
+    .map((word) => {
+      if (suffixes.includes(word.toLowerCase())) return word.toUpperCase();
+      if (word.length <= 2 && word === word.toUpperCase()) return word;
+      if (word.includes("'")) {
+        return word
+          .split("'")
+          .map(
+            (part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+          )
+          .join("'");
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join(' ');
+}

--- a/src/utils/formatting/index.js
+++ b/src/utils/formatting/index.js
@@ -2,3 +2,4 @@ export * from './formatHeight.js';
 export * from './formatSalary.js';
 export * from './teamColors.js';
 export * from './teamLogos.js';
+export * from './formatName.js';


### PR DESCRIPTION
## Summary
- standardize name formatting in Architect views
- add `formatName` utility
- use Firestore `display_name` when available

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_68775b05ba288326b5360963d3e70c70