### PR TITLE
feat: add trade pick metadata fields

### DIFF
--- a/src/features/architect/TradeEditor.jsx
+++ b/src/features/architect/TradeEditor.jsx
@@ -48,6 +48,17 @@ const TradeEditor = ({ primaryTeam, capProjections, currentYear }) => {
     });
   };
 
+  const updatePickField = (index, pick, field, value) => {
+    setTeams((prev) => {
+      const copy = [...prev];
+      const pickObj = copy[index].picksOut.find((p) => p === pick);
+      if (pickObj) {
+        pickObj[field] = value;
+      }
+      return copy;
+    });
+  };
+
   const selectTeam = async (index, teamId) => {
     if (!teamId) {
       setTeams((prev) => {
@@ -185,6 +196,9 @@ const TradeEditor = ({ primaryTeam, capProjections, currentYear }) => {
             }
             onSetPlayerTrade={(p, action) => setPlayerTrade(idx, p, action)}
             onTogglePick={(p) => togglePick(idx, p)}
+            onEditPick={(p, field, value) =>
+              updatePickField(idx, p, field, value)
+            }
             onSelectTeam={(teamId) => selectTeam(idx, teamId)}
             onRemove={() => removeTeam(idx)}
           />

--- a/src/features/architect/TradeTeamBlock.jsx
+++ b/src/features/architect/TradeTeamBlock.jsx
@@ -18,6 +18,7 @@ const TradeTeamBlock = ({
   capImpact = null,
   onSetPlayerTrade,
   onTogglePick,
+  onEditPick,
   onSelectTeam,
   onRemove,
 }) => {
@@ -46,6 +47,15 @@ const TradeTeamBlock = ({
         </select>
       </div>
     );
+  }
+
+  // DEV: Placeholder picks
+  if (!team.picks || team.picks.length === 0) {
+    team.picks = [
+      { year: 2026, round: 1 },
+      { year: 2028, round: 2 },
+      { year: 2029, round: 1, via: 'MEM' },
+    ];
   }
 
   return (
@@ -108,6 +118,36 @@ const TradeTeamBlock = ({
               {pick.year} {pick.round} Round{' '}
               {pick.via ? `(via ${pick.via})` : ''}
             </label>
+            {picks.includes(pick) && (
+              <div className="ml-6 mt-1 flex flex-col gap-1 text-xs">
+                <input
+                  type="text"
+                  placeholder="Protection"
+                  value={pick.protection || ''}
+                  onChange={(e) =>
+                    onEditPick(pick, 'protection', e.target.value)
+                  }
+                  className="bg-[#111] text-white p-1 rounded text-xs"
+                />
+                <label className="flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={!!pick.isSwap}
+                    onChange={(e) =>
+                      onEditPick(pick, 'isSwap', e.target.checked)
+                    }
+                  />
+                  Swap
+                </label>
+                <input
+                  type="text"
+                  placeholder="Note"
+                  value={pick.note || ''}
+                  onChange={(e) => onEditPick(pick, 'note', e.target.value)}
+                  className="bg-[#111] text-white p-1 rounded text-xs"
+                />
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- allow editing protection, swap flag, and notes for traded picks
- expose update handler in `TradeEditor` to save pick fields
- add dev placeholder picks for empty team data

## Testing
- `npm run lint` *(fails: cannot find eslint plugin)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a2893437c8326901111c449baadb2