### PR TITLE
refactor: switch to TeamListFull objects

### DIFF
--- a/src/components/shared/TeamLogo.jsx
+++ b/src/components/shared/TeamLogo.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { getTeamLogoFilename } from '@/utils/formatting';
 
-const TeamLogo = ({ teamAbbr, className = '' }) => {
-  const fileName = getTeamLogoFilename(teamAbbr);
+const TeamLogo = ({ teamAbbr, teamId, className = '' }) => {
+  const key = teamId || teamAbbr;
+  const fileName = getTeamLogoFilename(key);
   const logoPath = `/assets/logos/${fileName}.png`;
   const sizeClasses = className || 'w-[3.5rem] h-[3.5rem]';
 
@@ -10,7 +11,7 @@ const TeamLogo = ({ teamAbbr, className = '' }) => {
     <div className={`relative ${sizeClasses}`}>
       <img
         src={logoPath}
-        alt={`${teamAbbr} logo`}
+        alt={`${key} logo`}
         className="w-full h-full object-contain"
         onError={(e) => {
           e.target.onerror = null;

--- a/src/components/shared/ui/filters/MultiSelectFilter.jsx
+++ b/src/components/shared/ui/filters/MultiSelectFilter.jsx
@@ -27,11 +27,16 @@ const MultiSelectFilter = ({
         )}
       >
         <option value="">{allLabel}</option>
-        {options.map((opt) => (
-          <option key={opt} value={opt}>
-            {opt}
-          </option>
-        ))}
+        {options.map((opt) => {
+          const isObj = typeof opt === 'object';
+          const val = isObj ? opt.id : opt;
+          const label = isObj ? opt.teamName || opt.label : opt;
+          return (
+            <option key={val} value={val}>
+              {label}
+            </option>
+          );
+        })}
       </select>
     </div>
   );

--- a/src/features/architect/LeagueView.jsx
+++ b/src/features/architect/LeagueView.jsx
@@ -1,39 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { loadTeamCapSheet } from '@/utils/architect/firebaseHelpers';
 import { useNavigate } from 'react-router-dom';
+import { TeamListFull } from '@/constants/teamList';
 
-const teamsList = [
-  'Lakers',
-  'Warriors',
-  'Nuggets',
-  'Suns',
-  'Clippers',
-  'Celtics',
-  'Bucks',
-  '76ers',
-  'Knicks',
-  'Heat',
-  'Mavericks',
-  'Grizzlies',
-  'Timberwolves',
-  'Pelicans',
-  'Kings',
-  'Hawks',
-  'Raptors',
-  'Bulls',
-  'Cavaliers',
-  'Pacers',
-  'Thunder',
-  'Jazz',
-  'Trail Blazers',
-  'Spurs',
-  'Rockets',
-  'Wizards',
-  'Magic',
-  'Pistons',
-  'Hornets',
-  'Nets',
-];
+const teamsList = TeamListFull;
 
 const LeagueView = () => {
   const [teamSummaries, setTeamSummaries] = useState([]);
@@ -42,8 +12,8 @@ const LeagueView = () => {
   useEffect(() => {
     const loadAllTeams = async () => {
       const summaries = [];
-      for (const name of teamsList) {
-        const capSheet = await loadTeamCapSheet(name.toLowerCase());
+      for (const t of teamsList) {
+        const capSheet = await loadTeamCapSheet(t.id);
         if (capSheet) {
           const totalSalary =
             capSheet.players?.reduce((sum, p) => {
@@ -51,9 +21,9 @@ const LeagueView = () => {
                 sum + (p.contract_clean?.salaries_by_year?.[2025]?.salary || 0)
               );
             }, 0) || 0;
-          summaries.push({ teamName: name, totalSalary });
+          summaries.push({ id: t.id, teamName: t.teamName, totalSalary });
         } else {
-          summaries.push({ teamName: name, totalSalary: 0 });
+          summaries.push({ id: t.id, teamName: t.teamName, totalSalary: 0 });
         }
       }
       setTeamSummaries(summaries);
@@ -80,12 +50,12 @@ const LeagueView = () => {
         </thead>
         <tbody>
           {teamSummaries.map((team) => (
-            <tr key={team.teamName} className="odd:bg-[#171717]">
+            <tr key={team.id} className="odd:bg-[#171717]">
               <td className="p-2">{team.teamName}</td>
               <td className="p-2">${team.totalSalary.toLocaleString()}</td>
               <td className="p-2 text-right">
                 <button
-                  onClick={() => goToTeam(team.teamName)}
+                  onClick={() => goToTeam(team.id)}
                   className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded text-xs"
                 >
                   Manage Team

--- a/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
@@ -7,7 +7,7 @@ export const OutgoingPlayersList = ({
   team,
   sends,
   yearKey,
-  otherTeamNames = [],
+  otherTeams = [],
   onSetPlayerTrade,
 }) => {
   const [openMenu, setOpenMenu] = useState(null);
@@ -44,16 +44,16 @@ export const OutgoingPlayersList = ({
                 </button>
                 {openMenu === p.name && (
                   <div className="absolute right-0 top-5 bg-[#222] border border-white/20 rounded z-20 text-xs min-w-[8rem]">
-                    {otherTeamNames.map((n) => (
+                    {otherTeams.map((t) => (
                       <button
-                        key={n}
+                        key={t.id}
                         onClick={() => {
                           onSetPlayerTrade(p, included ? 'keep' : 'trade');
                           setOpenMenu(null);
                         }}
                         className="block w-full text-left px-3 py-1 hover:bg-[#333]"
                       >
-                        {`Trade to ${n}`}
+                        {`Trade to ${t.teamName}`}
                       </button>
                     ))}
                     <button

--- a/src/features/architect/tradeMachine/TradeEditor.jsx
+++ b/src/features/architect/tradeMachine/TradeEditor.jsx
@@ -50,9 +50,9 @@ const TradeEditor = ({ primaryTeam, capProjections, currentYear }) => {
       {/* Team Cards */}
       <div className="flex flex-col md:flex-row flex-wrap gap-6">
         {teams.map((t, idx) => {
-          const otherNames = teams
+          const otherTeams = teams
             .filter((_, j) => j !== idx && teams[j].team)
-            .map((tm) => tm.team.teamName);
+            .map((tm) => tm.team);
           return (
             <TradeTeamCard
               key={idx}
@@ -62,7 +62,7 @@ const TradeEditor = ({ primaryTeam, capProjections, currentYear }) => {
               incomingPlayers={incomingAssets[idx]?.players || []}
               incomingPicks={incomingAssets[idx]?.picks || []}
               yearKey={yearKey}
-              otherTeamNames={otherNames}
+              otherTeams={otherTeams}
               onSetPlayerTrade={(p, action) => setPlayerTrade(idx, p, action)}
               onTogglePick={(p) => togglePick(idx, p)}
               onEditPick={(p, field, value) =>

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -17,7 +17,7 @@ const TradeTeamCard = ({
   sends,
   picks,
   yearKey,
-  otherTeamNames = [],
+  otherTeams = [],
   incomingPlayers = [],
   incomingPicks = [],
   capImpact = null,
@@ -33,7 +33,7 @@ const TradeTeamCard = ({
   }
 
   const outgoingSalary = getSalaryForYear(sends, yearKey);
-  const { primary } = getTeamColors(team.teamName);
+  const { primary } = getTeamColors(team.id);
 
   return (
     <div
@@ -52,10 +52,7 @@ const TradeTeamCard = ({
       {/* Team Header */}
       <div className="flex items-center justify-between border-b border-white/10 pb-2">
         <div className="flex items-center gap-2">
-          <TeamLogo
-            teamAbbr={team.teamId || team.id || team.teamName}
-            className="w-8 h-8"
-          />
+          <TeamLogo teamAbbr={team.id} className="w-8 h-8" />
           <h3 className="text-lg font-semibold" style={{ color: primary }}>
             {team.teamName}
           </h3>
@@ -96,7 +93,7 @@ const TradeTeamCard = ({
           team={team}
           sends={sends}
           yearKey={yearKey}
-          otherTeamNames={otherTeamNames}
+          otherTeams={otherTeams}
           onSetPlayerTrade={onSetPlayerTrade}
         />
       )}

--- a/src/features/filters/FiltersPanel/FilterPanel/sections/MetadataFilters.jsx
+++ b/src/features/filters/FiltersPanel/FilterPanel/sections/MetadataFilters.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import MultiSelectFilter from '@/components/shared/ui/filters/MultiSelectFilter';
-import { teamOptions } from '@/utils/filtering';
+import { TeamListFull } from '@/constants/teamList';
 
 const MetadataFilters = ({ filters, setFilters }) => {
   const update = (key, value) => {
@@ -16,7 +16,7 @@ const MetadataFilters = ({ filters, setFilters }) => {
         <MultiSelectFilter
           label="Team"
           value={filters.team || ''}
-          options={teamOptions.sort()}
+          options={TeamListFull}
           onChange={(val) => update('team', val)}
           allLabel="All"
           selectClass="w-[125px]"

--- a/src/features/filters/FiltersPanel/FilterPanelCondensed.jsx
+++ b/src/features/filters/FiltersPanel/FilterPanelCondensed.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import MultiSelectFilter from '@/components/shared/ui/filters/MultiSelectFilter';
-import { teamOptions } from '@/utils/filtering';
+import { TeamListFull } from '@/constants/teamList';
 import {
   offensiveRoles,
   defensiveRoles,
@@ -22,7 +22,7 @@ const FilterPanelCondensed = ({ filters, setFilters }) => {
       <div className="flex flex-wrap gap-3 items-end">
         <MultiSelectFilter
           value={filters.team || ''}
-          options={teamOptions.sort()}
+          options={TeamListFull}
           onChange={(val) => update('team', val)}
           allLabel="All Teams"
           containerClass="shrink-0"

--- a/src/features/roster/AddPlayerDrawer/addPlayer/BasicFilters.jsx
+++ b/src/features/roster/AddPlayerDrawer/addPlayer/BasicFilters.jsx
@@ -18,9 +18,9 @@ const BasicFilters = ({ filters, setFilters }) => {
             className="w-full bg-[#2a2a2a] text-white px-2 py-1 rounded text-xs"
           >
             <option value="">All Teams</option>
-            {teamOptions.sort().map((team) => (
-              <option key={team} value={team}>
-                {team}
+            {teamOptions.map((team) => (
+              <option key={team.id} value={team.id}>
+                {team.teamName}
               </option>
             ))}
           </select>

--- a/src/features/roster/AddPlayerDrawer/index.jsx
+++ b/src/features/roster/AddPlayerDrawer/index.jsx
@@ -33,7 +33,8 @@ const AddPlayerDrawer = ({ onClose, allPlayers, onSelect }) => {
     return allPlayers
       .filter((p) => {
         if (searchTerm && !p.name.includes(searchTerm)) return false;
-        if (team && p.team !== team.toLowerCase()) return false;
+        const playerTeamId = (p.team || '').toLowerCase().replace(/\s+/g, '');
+        if (team && playerTeamId !== team) return false;
         if (positionOptions && !positionOptions.includes(p.position))
           return false;
         if (

--- a/src/features/roster/RosterControls.jsx
+++ b/src/features/roster/RosterControls.jsx
@@ -1,6 +1,6 @@
 // src/components/roster/RosterControls.jsx
 import React from 'react';
-import { teamOptions } from '@/utils/filtering';
+import { TeamListFull, TeamMap } from '@/constants/teamList';
 
 const RosterControls = ({
   selectedTeam,
@@ -11,7 +11,7 @@ const RosterControls = ({
 }) => {
   const filteredRosters = savedRosters.filter((r) => {
     if (selectedTeam) {
-      return r.team?.toLowerCase() === selectedTeam.toLowerCase() || !r.team;
+      return r.team === selectedTeam.id || !r.team;
     }
     return true;
   });
@@ -22,14 +22,14 @@ const RosterControls = ({
       <div className="flex gap-2 items-center">
         <label className="text-sm text-white/60">Team:</label>
         <select
-          value={selectedTeam}
-          onChange={(e) => onTeamChange(e.target.value)}
+          value={selectedTeam?.id || ''}
+          onChange={(e) => onTeamChange(TeamMap[e.target.value])}
           className="bg-[#1a1a1a] text-white text-sm px-3 py-1 rounded border border-white/10"
         >
           <option value="">— Select Team —</option>
-          {teamOptions.sort().map((team) => (
-            <option key={team} value={team}>
-              {team}
+          {TeamListFull.map((team) => (
+            <option key={team.id} value={team.id}>
+              {team.teamName}
             </option>
           ))}
         </select>

--- a/src/features/roster/RosterExportCapture.jsx
+++ b/src/features/roster/RosterExportCapture.jsx
@@ -6,7 +6,7 @@ import RosterSection from './RosterSection';
 import '@/styles/antonFont.css';
 
 const RosterExportCapture = React.forwardRef(({ roster, team }, ref) => {
-  const { primary, secondary } = getTeamColors(team);
+  const { primary, secondary } = getTeamColors(team?.id);
 
   return (
     <div
@@ -16,7 +16,7 @@ const RosterExportCapture = React.forwardRef(({ roster, team }, ref) => {
     >
       {team && (
         <img
-          src={`/assets/logos/${getTeamLogoFilename(team)}.png`}
+          src={`/assets/logos/${getTeamLogoFilename(team.id)}.png`}
           alt=""
           className="absolute inset-0 w-full h-full object-contain opacity-20 blur-sm mt-6 pointer-events-none select-none"
         />
@@ -34,7 +34,7 @@ const RosterExportCapture = React.forwardRef(({ roster, team }, ref) => {
               textShadow: `0 0 8px ${primary}, 0 0 16px ${secondary}`,
             }}
           >
-            {team}
+            {team.nickname}
           </h2>
         </div>
 

--- a/src/features/roster/RosterPreviewModal.jsx
+++ b/src/features/roster/RosterPreviewModal.jsx
@@ -11,7 +11,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
   if (!open || !roster) return null;
 
   const exportRef = useRef(null); // ✅ used for PNG export
-  const { primary, secondary } = getTeamColors(team);
+  const { primary, secondary } = getTeamColors(team?.id);
 
   const handleDownload = async () => {
     if (!exportRef.current) return;
@@ -34,7 +34,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
       });
 
       const link = document.createElement('a');
-      link.download = `${team || 'roster'}.png`;
+      link.download = `${team?.nickname || 'roster'}.png`;
       link.href = dataUrl;
       link.click();
     } catch (err) {
@@ -80,7 +80,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
             {/* Background logo */}
             {team && (
               <img
-                src={`/assets/logos/${getTeamLogoFilename(team)}.png`}
+                src={`/assets/logos/${getTeamLogoFilename(team.id)}.png`}
                 alt=""
                 className="absolute inset-0 w-full h-full object-contain opacity-20 blur-sm mt-6 pointer-events-none select-none"
               />
@@ -107,7 +107,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
                   textShadow: `0 0 8px ${primary}, 0 0 16px ${secondary}`,
                 }}
               >
-                {team}
+                {team.nickname}
               </h2>
             </div>
 

--- a/src/features/roster/RosterViewer.jsx
+++ b/src/features/roster/RosterViewer.jsx
@@ -10,6 +10,7 @@ import SaveRosterModal from './SaveRosterModal';
 import RosterPreviewModal from './RosterPreviewModal';
 import { getTeamColors } from '@/utils/formatting/teamColors';
 import { getTeamLogoFilename } from '@/utils/formatting/teamLogos';
+import { TeamMap } from '@/constants/teamList';
 import { useRosterManager } from '@/hooks/useRosterManager';
 
 const RosterViewer = ({ isExport = false, initialRosterId }) => {
@@ -42,7 +43,7 @@ const RosterViewer = ({ isExport = false, initialRosterId }) => {
     if (!initialRosterId || savedRosters.length === 0) return;
     const match = savedRosters.find((r) => r.id === initialRosterId);
     if (match) {
-      setSelectedTeam(match.team);
+      setSelectedTeam(TeamMap[match.team] || null);
       setLoadMethod(match.id);
     }
   }, [initialRosterId, savedRosters, setSelectedTeam, setLoadMethod]);
@@ -67,7 +68,7 @@ const RosterViewer = ({ isExport = false, initialRosterId }) => {
     setPreviewOpen(true);
   };
 
-  const { primary, secondary } = getTeamColors(selectedTeam);
+  const { primary, secondary } = getTeamColors(selectedTeam?.id);
 
   return (
     <div className="flex relative">
@@ -108,7 +109,7 @@ const RosterViewer = ({ isExport = false, initialRosterId }) => {
           {/* Team Branding Background */}
           {selectedTeam && (
             <img
-              src={`/assets/logos/${getTeamLogoFilename(selectedTeam)}.png`}
+              src={`/assets/logos/${getTeamLogoFilename(selectedTeam.id)}.png`}
               alt=""
               className="absolute inset-0 w-full h-full object-contain opacity-20 blur-sm mt-4 pointer-events-none select-none"
               style={{ zIndex: 0 }}
@@ -141,7 +142,7 @@ const RosterViewer = ({ isExport = false, initialRosterId }) => {
                   transform: 'translateX(3px)',
                 }}
               >
-                {selectedTeam}
+                {selectedTeam.nickname}
               </h2>
             </div>
           )}

--- a/src/features/tierMaker/TierMakerBoard.jsx
+++ b/src/features/tierMaker/TierMakerBoard.jsx
@@ -5,7 +5,7 @@ import TierRow from '@/features/tierMaker/TierRow';
 import usePlayerData from '@/hooks/usePlayerData.js';
 import useFirebaseQuery from '@/hooks/useFirebaseQuery';
 import { POSITION_MAP } from '@/utils/roles';
-import { teamOptions } from '@/utils/filtering';
+import { TeamListFull } from '@/constants/teamList';
 import DrawerShell from '@/components/shared/ui/drawers/DrawerShell';
 import OpenDrawerButton from '@/components/shared/ui/drawers/OpenDrawerButton';
 import AddPlayerDrawer from '@/features/roster/AddPlayerDrawer';
@@ -100,7 +100,7 @@ const TierMakerBoard = ({ players = [], initialTierListId = '' }) => {
   const [tierOrder, setTierOrder] = useState([...DEFAULT_TIERS, 'Pool']);
   const [screenshotMode, setScreenshotMode] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selectedTeam, setSelectedTeam] = useState('');
+  const [selectedTeam, setSelectedTeam] = useState(null);
   const [selectedList, setSelectedList] = useState('');
   const [selectedTierList, setSelectedTierList] = useState('');
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -183,10 +183,10 @@ const TierMakerBoard = ({ players = [], initialTierListId = '' }) => {
   const handleAddTeamRoster = () => {
     if (!selectedTeam) return;
     const teamPlayers = allPlayers.filter(
-      (p) => (p.bio?.Team || '').toLowerCase() === selectedTeam.toLowerCase()
+      (p) => (p.bio?.Team || '').toLowerCase() === selectedTeam.id
     );
     addPlayersToPool(teamPlayers);
-    setSelectedTeam('');
+    setSelectedTeam(null);
   };
 
   const handleAddList = () => {
@@ -331,14 +331,14 @@ const TierMakerBoard = ({ players = [], initialTierListId = '' }) => {
             <div className="flex items-center gap-2 flex-wrap mt-4 justify-center">
               <div className="flex items-center gap-1">
                 <select
-                  value={selectedTeam}
-                  onChange={(e) => setSelectedTeam(e.target.value)}
+                  value={selectedTeam?.id || ''}
+                  onChange={(e) => setSelectedTeam(TeamListFull.find((t) => t.id === e.target.value) || null)}
                   className="bg-[#1a1a1a] text-white text-sm px-2 py-1 rounded border border-white/10"
                 >
                   <option value="">Add Team...</option>
-                  {teamOptions.sort().map((team) => (
-                    <option key={team} value={team}>
-                      {team}
+                  {TeamListFull.map((team) => (
+                    <option key={team.id} value={team.id}>
+                      {team.teamName}
                     </option>
                   ))}
                 </select>

--- a/src/hooks/useRosterManager.js
+++ b/src/hooks/useRosterManager.js
@@ -11,6 +11,7 @@ import {
   loadRosterProject,
   updateRosterProject,
 } from '@/firebase/rosterHelpers';
+import { TeamMap } from '@/constants/teamList';
 
 export const emptyRoster = {
   starters: [null, null, null, null, null],
@@ -20,7 +21,7 @@ export const emptyRoster = {
 
 export const useRosterManager = (allPlayers = [], isLoading = false) => {
   const [roster, setRoster] = useState(emptyRoster);
-  const [selectedTeam, setSelectedTeam] = useState('');
+  const [selectedTeam, setSelectedTeam] = useState(null);
   const [loadMethod, setLoadMethod] = useState('current');
   const [savedRosters, setSavedRosters] = useState([]);
 
@@ -98,7 +99,7 @@ export const useRosterManager = (allPlayers = [], isLoading = false) => {
       if (loadMethod === 'current') {
         if (!selectedTeam) return;
         const rawTeamPlayers = allPlayers.filter(
-          (p) => p.bio?.Team?.toLowerCase() === selectedTeam.toLowerCase()
+          (p) => (p.bio?.Team || '').toLowerCase() === selectedTeam.id
         );
 
         const teamPlayers = rawTeamPlayers
@@ -115,7 +116,7 @@ export const useRosterManager = (allPlayers = [], isLoading = false) => {
 
       const loaded = await loadRosterProject(loadMethod);
       if (loaded) {
-        setSelectedTeam(loaded.team || '');
+        setSelectedTeam(TeamMap[loaded.team] || null);
         setRosterId(loaded.id);
         setRosterName(loaded.name);
         setRoster({
@@ -170,7 +171,7 @@ export const useRosterManager = (allPlayers = [], isLoading = false) => {
       roster.starters.map((p) => (p ? p.id : null)),
       roster.rotation.map((p) => (p ? p.id : null)),
       roster.bench.map((p) => (p ? p.id : null)),
-      selectedTeam
+      selectedTeam?.id || ''
     );
     setRosterId(created.id);
     setSavedRosters((prev) => [...prev, created]);
@@ -198,7 +199,7 @@ export const useRosterManager = (allPlayers = [], isLoading = false) => {
     async (id) => {
       const loaded = await loadRosterProject(id);
       if (loaded) {
-        setSelectedTeam(loaded.team || '');
+        setSelectedTeam(TeamMap[loaded.team] || null);
         setRosterId(loaded.id);
         setRosterName(loaded.name);
         setRoster({

--- a/src/utils/filtering/teamOptions.js
+++ b/src/utils/filtering/teamOptions.js
@@ -1,32 +1,4 @@
-export const teamOptions = [
-  'Hawks',
-  'Celtics',
-  'Nets',
-  'Hornets',
-  'Bulls',
-  'Cavaliers',
-  'Mavericks',
-  'Nuggets',
-  'Pistons',
-  'Warriors',
-  'Rockets',
-  'Pacers',
-  'Clippers',
-  'Lakers',
-  'Grizzlies',
-  'Heat',
-  'Bucks',
-  'Timberwolves',
-  'Pelicans',
-  'Knicks',
-  'Thunder',
-  'Magic',
-  '76ers',
-  'Suns',
-  'Trail Blazers',
-  'Kings',
-  'Spurs',
-  'Raptors',
-  'Jazz',
-  'Wizards',
-];
+import { TeamListFull } from '@/constants/teamList';
+
+// Export full team objects for use across filters and dropdowns
+export const teamOptions = TeamListFull;


### PR DESCRIPTION
## Summary
- move teamOptions to export TeamListFull objects
- allow MultiSelectFilter to read arrays of team objects
- rework team dropdowns and lists to use team objects
- adjust roster manager hooks and views for team.id and team.nickname
- update league view and trade machine components to use TeamMap
- tweak TeamLogo to accept ids

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_6880934d13a483268e65a9c67a2ee549