### PR TITLE
feat: improve Trade Machine player rows

### DIFF
--- a/src/features/architect/tradeMachine/OutgoingPicksList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPicksList.jsx
@@ -10,7 +10,7 @@ export const OutgoingPicksList = ({
 }) => (
   <div>
     <h4 className="text-sm text-white/70 mb-1">Outgoing Picks</h4>
-    <div className="space-y-1">
+    <div className="space-y-1 max-h-[300px] overflow-y-auto pr-1">
       {team.picks?.map((p) => {
         const exists = picks.some((pk) => areSamePick(pk, p));
         return (

--- a/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { formatSalary } from '@/utils/formatting';
+import TradePlayerRow from './TradePlayerRow';
 import EditContractModal from '@/components/shared/EditContractModal';
 import TradeExceptionModal from '@/components/shared/TradeExceptionModal';
 
@@ -17,87 +17,22 @@ export const OutgoingPlayersList = ({
   return (
     <div>
       <h4 className="text-sm text-white/70 mb-1">Outgoing Players</h4>
-      <div className="space-y-1">
+      <div className="space-y-1 max-h-[300px] overflow-y-auto pr-1">
         {team.players?.map((p) => {
           const included = sends.includes(p);
-          const salary =
-            p.contract_clean?.salaries_by_year?.[yearKey]?.salary || 0;
           return (
-            <div
+            <TradePlayerRow
               key={p.id || p.name}
-              className={`flex items-center px-3 py-1 rounded-md text-sm transition-colors ${
-                included ? 'bg-green-800/40' : 'bg-white/10'
-              }`}
-            >
-              <span className="flex-1">{p.name}</span>
-              <span className="w-20 text-right text-white/70">
-                {formatSalary(salary)}
-              </span>
-              <div className="flex items-center gap-2 ml-3 relative">
-                <button
-                  onClick={() =>
-                    setOpenMenu(openMenu === p.name ? null : p.name)
-                  }
-                  className="text-xs text-blue-400 hover:underline"
-                >
-                  •••
-                </button>
-                {openMenu === p.name && (
-                  <div className="absolute right-0 top-5 bg-[#222] border border-white/20 rounded z-20 text-xs min-w-[8rem]">
-                    {otherTeams.map((t) => (
-                      <button
-                        key={t.id}
-                        onClick={() => {
-                          onSetPlayerTrade(p, included ? 'keep' : 'trade');
-                          setOpenMenu(null);
-                        }}
-                        className="block w-full text-left px-3 py-1 hover:bg-[#333]"
-                      >
-                        {`Trade to ${t.teamName}`}
-                      </button>
-                    ))}
-                    <button
-                      onClick={() => {
-                        setContractPlayer(p);
-                        setOpenMenu(null);
-                      }}
-                      className="block w-full text-left px-3 py-1 hover:bg-[#333]"
-                    >
-                      Modify Contract
-                    </button>
-                    <button
-                      onClick={() => {
-                        setTpePlayer(p);
-                        setOpenMenu(null);
-                      }}
-                      className="block w-full text-left px-3 py-1 hover:bg-[#333]"
-                    >
-                      Trade Exception
-                    </button>
-                    <button
-                      onClick={() => {
-                        window.location.href = `/profiles?player=${p.id || p.player_id}`;
-                      }}
-                      className="block w-full text-left px-3 py-1 hover:bg-[#333]"
-                    >
-                      View Profile
-                    </button>
-                  </div>
-                )}
-                {included && (
-                  <label className="flex items-center gap-1 text-xs">
-                    <input
-                      type="checkbox"
-                      checked={!!p.signAndTrade}
-                      onChange={() =>
-                        onSetPlayerTrade(p, 'signAndTrade', !p.signAndTrade)
-                      }
-                    />
-                    S&T
-                  </label>
-                )}
-              </div>
-            </div>
+              player={p}
+              included={included}
+              yearKey={yearKey}
+              otherTeams={otherTeams}
+              onSetPlayerTrade={onSetPlayerTrade}
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              setContractPlayer={setContractPlayer}
+              setTpePlayer={setTpePlayer}
+            />
           );
         })}
         {team.players?.length === 0 && (

--- a/src/features/architect/tradeMachine/TradePlayerRow.jsx
+++ b/src/features/architect/tradeMachine/TradePlayerRow.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import PlayerNameMini from '@/features/table/PlayerTable/PlayerRow/PlayerNameMini';
+import TeamLogo from '@/components/shared/TeamLogo';
+import { getPlayerPositionLabel } from '@/utils/roles';
+import { formatSalary } from '@/utils/formatting';
+
+const parseYear = (key) => {
+  if (typeof key === 'number') return key;
+  const match = String(key).match(/\d{4}/);
+  return match ? parseInt(match[0], 10) : NaN;
+};
+
+const TradePlayerRow = ({
+  player,
+  included,
+  yearKey,
+  otherTeams = [],
+  onSetPlayerTrade,
+  openMenu,
+  setOpenMenu,
+  setContractPlayer,
+  setTpePlayer,
+}) => {
+  const year = parseYear(yearKey);
+  const salary =
+    player.contract_clean?.salaries_by_year?.[yearKey]?.salary ||
+    player.contract?.annual_salaries?.find((s) => parseYear(s.year) === year)?.salary ||
+    0;
+  const yearsLeft = player.free_agency_year
+    ? Math.max(0, player.free_agency_year - year)
+    : 0;
+  const contractInfo = `${formatSalary(salary)} / ${yearsLeft} YRS`;
+
+  const headshot =
+    player.headshotUrl ||
+    player.headshot ||
+    `/assets/headshots/${player.id || player.player_id}.png`;
+
+  const rawPosition = player.bio?.Position || player.formattedPosition || player.position || '';
+  const position = getPlayerPositionLabel(rawPosition) || '—';
+
+  return (
+    <div
+      className={`w-full h-[90px] flex items-center overflow-hidden border border-black rounded-sm pr-2 ${
+        included ? 'bg-green-800/40' : 'bg-neutral-800'
+      }`}
+    >
+      {/* Position Bar */}
+      <div className="h-full w-12 flex flex-col items-center justify-center bg-neutral-700 text-white font-bold text-base font-mono relative">
+        <div>{position}</div>
+        <div className="absolute right-0 top-0 h-full w-[2px] bg-neutral-950"></div>
+      </div>
+
+      {/* Headshot */}
+      <div className="h-full w-[70px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden">
+        <img
+          src={headshot}
+          onError={(e) => {
+            e.target.src = '/assets/headshots/default.png';
+          }}
+          alt={player.name}
+          className="h-full w-full object-cover"
+        />
+      </div>
+
+      {/* Main Info */}
+      <div className="flex flex-col justify-center ml-3">
+        <div className="h-[40px] flex items-center">
+          <PlayerNameMini name={player.display_name || player.name} />
+        </div>
+        <div className="flex items-center mt-[11px] -mb-1 gap-2 text-white/50 text-[13px]">
+          <TeamLogo teamAbbr={player.bio?.Team} className="w-5 h-5" />
+          <div>
+            {player.bio?.HT || '—'} <span className="text-white/30">|</span> {player.bio?.WT || '—'} lbs
+          </div>
+        </div>
+      </div>
+
+      {/* Contract Info */}
+      <div className="ml-auto text-white/60 text-xs font-semibold whitespace-nowrap mr-2">
+        {contractInfo}
+      </div>
+
+      {/* Options */}
+      <div className="flex items-center gap-2 relative">
+        <button
+          onClick={() => setOpenMenu(openMenu === player.name ? null : player.name)}
+          className="text-xs text-blue-400 hover:underline"
+        >
+          •••
+        </button>
+        {openMenu === player.name && (
+          <div className="absolute right-0 top-5 bg-[#222] border border-white/20 rounded z-20 text-xs min-w-[8rem]">
+            {otherTeams.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => {
+                  onSetPlayerTrade(player, included ? 'keep' : 'trade');
+                  setOpenMenu(null);
+                }}
+                className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+              >
+                {`Trade to ${t.teamName}`}
+              </button>
+            ))}
+            <button
+              onClick={() => {
+                setContractPlayer(player);
+                setOpenMenu(null);
+              }}
+              className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+            >
+              Modify Contract
+            </button>
+            <button
+              onClick={() => {
+                setTpePlayer(player);
+                setOpenMenu(null);
+              }}
+              className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+            >
+              Trade Exception
+            </button>
+            <button
+              onClick={() => {
+                window.location.href = `/profiles?player=${player.id || player.player_id}`;
+              }}
+              className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+            >
+              View Profile
+            </button>
+          </div>
+        )}
+        {included && (
+          <label className="flex items-center gap-1 text-xs">
+            <input
+              type="checkbox"
+              checked={!!player.signAndTrade}
+              onChange={() => onSetPlayerTrade(player, 'signAndTrade', !player.signAndTrade)}
+            />
+            S&T
+          </label>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TradePlayerRow;


### PR DESCRIPTION
## Summary
- add `TradePlayerRow` styled like export rows but with contract info
- update outgoing player list to use new row component
- limit team player and pick lists height so they scroll independently

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a0e998b883269b5f357df50626ad