### PR TITLE
feat: add options menu for free agent signing

### DIFF
--- a/src/components/shared/EditContractModal.jsx
+++ b/src/components/shared/EditContractModal.jsx
@@ -37,6 +37,8 @@ const EditContractModal = ({
   onOptionDecision,
   onExtend,
   onSignAndTrade,
+  actionsOverride = null,
+  actionLabelsOverride = {},
 }) => {
   const [selectedAction, setSelectedAction] = useState('');
   const [extension, setExtension] = useState({
@@ -79,6 +81,8 @@ const EditContractModal = ({
       : isUnderContract
         ? 'underContract'
         : null;
+
+  const actions = actionsOverride || ACTION_SETS[actionSet] || [];
 
   useEffect(() => {
     if (!player) return;
@@ -217,7 +221,7 @@ const EditContractModal = ({
 
         {/* === Radio Options === */}
         <div className="space-y-3 border border-white/10 p-3 rounded">
-          {ACTION_SETS[actionSet]?.map((type) => (
+          {actions.map((type) => (
             <label
               key={type}
               className="flex items-center gap-3 cursor-pointer"
@@ -229,7 +233,7 @@ const EditContractModal = ({
                 onChange={() => setSelectedAction(type)}
                 className="accent-orange-500"
               />
-              <span>{ACTION_LABELS[type]}</span>
+              <span>{actionLabelsOverride[type] || ACTION_LABELS[type]}</span>
             </label>
           ))}
         </div>

--- a/src/features/architect/FreeAgentPool.jsx
+++ b/src/features/architect/FreeAgentPool.jsx
@@ -3,6 +3,7 @@ import { formatName } from '@/utils/formatting';
 import { canSignFreeAgent } from '@/utils/architect/freeAgentLogic';
 import { generateDefaultFreeAgentContract } from '@/utils/architect/contractUtils';
 import FreeAgentRow from './FreeAgentRow';
+import EditContractModal from '@/components/shared/EditContractModal';
 
 const FreeAgentPool = ({
   freeAgents,
@@ -15,6 +16,8 @@ const FreeAgentPool = ({
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const [signResult, setSignResult] = useState(null);
   const [isSigning, setIsSigning] = useState(false);
+  const [openMenu, setOpenMenu] = useState(null);
+  const [contractPlayer, setContractPlayer] = useState(null);
 
   const handleSelect = (player) => {
     setSelectedPlayer(player);
@@ -55,6 +58,32 @@ const FreeAgentPool = ({
     }
   };
 
+  const handleSaveFromModal = async (playerObj, values) => {
+    const salaryByYear = {};
+    for (let i = 0; i < values.years; i++) {
+      salaryByYear[currentYear + i] = values.salaries[i] || 0;
+    }
+    const contract = {
+      salaryByYear,
+      options: {},
+      signAndTrade: false,
+      guaranteed: true,
+      isMinimum: values.salaries[0] <= 2200000,
+      yearsOfService: playerObj.yearsOfService || playerObj.yearsPro || 0,
+    };
+    await onSign(playerObj.name, contract);
+  };
+
+  const handleSignAndTrade = async (playerObj) => {
+    const contract = generateDefaultFreeAgentContract(
+      playerObj.askingSalary ?? playerObj.previousSalary ?? 0,
+      currentYear,
+      playerObj.yearsOfService || playerObj.yearsPro || 0
+    );
+    contract.signAndTrade = true;
+    await onSign(playerObj.name, contract);
+  };
+
   return (
     <div className="text-white">
       <h2 className="text-xl font-semibold mb-2">Free Agent Pool</h2>
@@ -68,6 +97,11 @@ const FreeAgentPool = ({
                 askInfo={p}
                 onSelect={() => handleSelect(p)}
                 isSelected={selectedPlayer?.name === p.name}
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+                onSign={() => {
+                  setContractPlayer(p);
+                }}
               />
             </li>
           );
@@ -107,6 +141,18 @@ const FreeAgentPool = ({
             <span className="text-red-500">{signResult.reason}</span>
           )}
         </div>
+      )}
+
+      {contractPlayer && (
+        <EditContractModal
+          player={playersMap[contractPlayer.name] || { name: contractPlayer.name }}
+          isOpen={!!contractPlayer}
+          onClose={() => setContractPlayer(null)}
+          onSave={handleSaveFromModal}
+          onSignAndTrade={() => handleSignAndTrade(contractPlayer)}
+          actionsOverride={['resign', 'signAndTrade']}
+          actionLabelsOverride={{ resign: 'Sign Free Agent' }}
+        />
       )}
     </div>
   );

--- a/src/features/architect/FreeAgentRow.jsx
+++ b/src/features/architect/FreeAgentRow.jsx
@@ -7,6 +7,9 @@ const FreeAgentRow = ({
   askInfo = {},
   onSelect,
   isSelected = false,
+  openMenu,
+  setOpenMenu,
+  onSign,
 }) => {
   const name = player.display_name || player.name || formatName(askInfo.name);
   const nameParts = name.split(' ');
@@ -48,7 +51,7 @@ const FreeAgentRow = ({
       role="button"
       tabIndex={0}
       onClick={onSelect}
-      className={`w-full h-[45px] bg-neutral-800 rounded-sm flex items-center border border-black mb-[3px] pr-0 overflow-hidden hover:bg-neutral-700 cursor-pointer focus:outline-none ${
+      className={`w-full h-[45px] bg-neutral-800 rounded-sm flex items-center border border-black mb-[3px] pr-2 overflow-hidden hover:bg-neutral-700 cursor-pointer focus:outline-none ${
         isSelected ? 'ring-1 ring-lakers' : ''
       }`}
     >
@@ -105,6 +108,40 @@ const FreeAgentRow = ({
 
         {/* Spacer between Height/Weight and Salary */}
         <span className="ml-10 w-[78px] text-right">{asking}</span>
+      </div>
+
+      {/* Options */}
+      <div className="flex items-center relative">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpenMenu(openMenu === askInfo.name ? null : askInfo.name);
+          }}
+          className="text-xs text-blue-400 hover:underline"
+        >
+          •••
+        </button>
+        {openMenu === askInfo.name && (
+          <div className="absolute right-0 top-5 bg-[#222] border border-white/20 rounded z-20 text-xs min-w-[8rem]">
+            <button
+              onClick={() => {
+                onSign?.(askInfo);
+                setOpenMenu(null);
+              }}
+              className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+            >
+              Sign Free Agent
+            </button>
+            <button
+              onClick={() => {
+                window.location.href = `/profiles?player=${player.id || player.player_id}`;
+              }}
+              className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+            >
+              View Profile
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add action overrides to `EditContractModal`
- show options menu in `FreeAgentRow`
- open `EditContractModal` from `FreeAgentPool` when signing a free agent

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880b11f65948326a2eed638ec3cd41e