### PR TITLE
feat: centralize contract years logic

### DIFF
--- a/src/features/architect/tradeMachine/TradePlayerRow.jsx
+++ b/src/features/architect/tradeMachine/TradePlayerRow.jsx
@@ -3,6 +3,7 @@ import PlayerNameMini from '@/features/table/PlayerTable/PlayerRow/PlayerNameMin
 import TeamLogo from '@/components/shared/TeamLogo';
 import { getPlayerPositionLabel } from '@/utils/roles';
 import { formatSalary } from '@/utils/formatting';
+import { getYearsRemaining } from '@/utils/contracts';
 
 const parseYear = (key) => {
   if (typeof key === 'number') return key;
@@ -28,9 +29,11 @@ const TradePlayerRow = ({
     player.contract?.annual_salaries?.find((s) => parseYear(s.year) === year)
       ?.salary ||
     0;
-  const yearsLeft = player.free_agency_year
-    ? Math.max(0, player.free_agency_year - year)
-    : 0;
+  const faYear =
+    player.contract_clean?.fa_year ??
+    player.fa_year ??
+    player.free_agency_year;
+  const yearsLeft = getYearsRemaining(faYear, year);
   const contractInfo = `${formatSalary(salary)} / ${yearsLeft} YRS`;
 
   const details = playersMap[player.name] || {};

--- a/src/features/table/PlayerTable/PlayerRow/index.jsx
+++ b/src/features/table/PlayerTable/PlayerRow/index.jsx
@@ -7,6 +7,7 @@ import PlayerDrawer from '@/features/table/PlayerTable/PlayerRow/PlayerDrawer';
 import TeamLogo from '@/components/shared/TeamLogo';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import AddToListButton from '@/features/lists/AddToListButton';
+import { getCurrentSeasonYear, getYearsRemaining } from '@/utils/contracts';
 
 const PlayerRow = ({ player, ranking = '—' }) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -82,12 +83,7 @@ const PlayerRow = ({ player, ranking = '—' }) => {
         <div className="ml-0 border-l border-[#333] text-[11px] tracking-wide w-[140px] leading-tight text-center break-words">
           {player.contract?.annual_salaries && player.free_agency_year ? (
             (() => {
-              const today = new Date();
-              // NBA season year changes on July 1 (free agency begins)
-              // Before July 1: Previous season (2023-24)
-              // After July 1: New season (2024-25)
-              const CURRENT_YEAR =
-                today.getFullYear() - (today.getMonth() < 6 ? 1 : 0);
+              const CURRENT_YEAR = getCurrentSeasonYear();
 
               const currentSalary =
                 player.contract.annual_salaries.find(
@@ -98,9 +94,9 @@ const PlayerRow = ({ player, ranking = '—' }) => {
                 )?.salary ??
                 0;
 
-              const yearsLeft = Math.max(
-                0,
-                player.free_agency_year - CURRENT_YEAR
+              const yearsLeft = getYearsRemaining(
+                player.fa_year ?? player.free_agency_year,
+                CURRENT_YEAR
               );
               const formattedSalary = `$${(currentSalary / 1_000_000).toFixed(1)}M`;
 

--- a/src/utils/contracts/getCurrentSeasonYear.js
+++ b/src/utils/contracts/getCurrentSeasonYear.js
@@ -1,0 +1,5 @@
+export function getCurrentSeasonYear(date = new Date()) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  return month >= 6 ? year : year - 1;
+}

--- a/src/utils/contracts/getYearsRemaining.js
+++ b/src/utils/contracts/getYearsRemaining.js
@@ -1,0 +1,6 @@
+import { getCurrentSeasonYear } from './getCurrentSeasonYear.js';
+
+export function getYearsRemaining(freeAgencyYear, currentSeason = getCurrentSeasonYear()) {
+  if (typeof freeAgencyYear !== 'number') return 0;
+  return Math.max(0, freeAgencyYear - currentSeason);
+}

--- a/src/utils/contracts/index.js
+++ b/src/utils/contracts/index.js
@@ -1,0 +1,2 @@
+export * from './getCurrentSeasonYear.js';
+export * from './getYearsRemaining.js';

--- a/tests/contractYears.test.js
+++ b/tests/contractYears.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { getCurrentSeasonYear, getYearsRemaining } from '../src/utils/contracts/index.js';
+
+describe('contract year helpers', () => {
+  it('computes current season based on date', () => {
+    expect(getCurrentSeasonYear(new Date('2024-06-30'))).toBe(2023);
+    expect(getCurrentSeasonYear(new Date('2024-07-01'))).toBe(2024);
+  });
+
+  it('calculates years remaining', () => {
+    expect(getYearsRemaining(2026, 2024)).toBe(2);
+    expect(getYearsRemaining(2023, 2024)).toBe(0);
+  });
+
+  it('handles invalid free agency year', () => {
+    expect(getYearsRemaining()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `getCurrentSeasonYear` and `getYearsRemaining` helpers
- use the helpers in PlayerRow and TradePlayerRow
- test the contract year utilities

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880aed981388326b5e2351a265b4874