### PR TITLE
feat: expose rule-level trade checks

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -53,20 +53,27 @@ export function validateTrade({
   );
 
   const teamResults = teams.map((t, idx) => {
+    const evaluation = evaluateTeam({
+      team: t.team,
+      salaryOut: salaryOut[idx],
+      salaryIn: salaryIn[idx],
+      rosterOut: rosterOut[idx],
+      rosterIn: rosterIn[idx],
+      hardCapped: t.hardCapped ?? t.team?.hardCapped,
+      signAndTrade: t.sends.some((p) => p.signAndTrade),
+      outgoingCount: t.sends.length,
+      incomingCount: rosterIn[idx],
+      capSettings,
+    });
+
     return {
       teamName: t.team.teamName,
-      ...evaluateTeam({
-        team: t.team,
-        salaryOut: salaryOut[idx],
-        salaryIn: salaryIn[idx],
-        rosterOut: rosterOut[idx],
-        rosterIn: rosterIn[idx],
-        hardCapped: t.hardCapped ?? t.team?.hardCapped,
-        signAndTrade: t.sends.some((p) => p.signAndTrade),
-        outgoingCount: t.sends.length,
-        incomingCount: rosterIn[idx],
-        capSettings,
-      }),
+      ...evaluation,
+      checks: {
+        ...evaluation.checks,
+        signAndTrade: true,
+        stepien: true,
+      },
     };
   });
 
@@ -77,6 +84,7 @@ export function validateTrade({
         teamResults[idx].reasons.push(
           'Sign-and-trade player must be traded alone.'
         );
+        teamResults[idx].checks.signAndTrade = false;
       }
       teamResults.forEach((res, j) => {
         const projected = res.projectedSalary;
@@ -84,6 +92,7 @@ export function validateTrade({
           res.reasons.push(
             'Receiving team exceeds first apron with a sign-and-trade.'
           );
+          res.checks.signAndTrade = false;
         }
       });
     }
@@ -95,6 +104,7 @@ export function validateTrade({
       teamResults[i].reasons.push(
         'Violates Stepien Rule (consecutive future 1sts).'
       );
+      teamResults[i].checks.stepien = false;
     }
   });
 
@@ -164,25 +174,35 @@ function evaluateTeam({
   }
 
   const reasons = [];
+  const checks = {
+    secondApronAggregation: true,
+    firstApronLimit: true,
+    hardCap: true,
+    salaryMatching: true,
+  };
 
   // 2nd Apron: No aggregation
   if ((overSecond || willBeOverSecond) && outgoingCount > 1) {
     reasons.push('2nd Apron Rule: Cannot aggregate multiple salaries in trade');
+    checks.secondApronAggregation = false;
   }
 
   // 1st Apron: Cannot receive more than sent
   if ((overFirst || willBeOverFirst) && salaryIn > salaryOut) {
     reasons.push('1st Apron Rule: Cannot receive more salary than sent');
+    checks.firstApronLimit = false;
   }
 
   // Hard cap enforcement
   if (hardCapped && projectedSalary > firstApron) {
     reasons.push('Hard cap exceeded (1st Apron)');
+    checks.hardCap = false;
   }
 
   // Standard over-cap matching
   if (overCap && salaryIn > allowableIn) {
     reasons.push('Incoming salary exceeds allowed amount');
+    checks.salaryMatching = false;
   }
 
   return {
@@ -194,6 +214,7 @@ function evaluateTeam({
     salaryOut,
     projectedSalary,
     apronStatus,
+    checks,
   };
 }
 

--- a/tests/tradeValidator.test.js
+++ b/tests/tradeValidator.test.js
@@ -39,6 +39,7 @@ describe('tradeValidator', () => {
     expect(result.overallLegal).toBe(false);
     expect(result.teamResults[0].legal).toBe(false);
     expect(result.teamResults[0].reason).toMatch(/Incoming salary exceeds/);
+    expect(result.teamResults[0].checks.salaryMatching).toBe(false);
   });
 
   it('flags trades that would violate a hard cap', () => {
@@ -61,6 +62,7 @@ describe('tradeValidator', () => {
     expect(result.teamResults[0].reason).toContain(
       'Hard cap exceeded (1st Apron)'
     );
+    expect(result.teamResults[0].checks.hardCap).toBe(false);
   });
 
   it('enforces sign-and-trade restrictions', () => {
@@ -86,7 +88,9 @@ describe('tradeValidator', () => {
     expect(result.teamResults[0].reason).toContain(
       'Sign-and-trade player must be traded alone.'
     );
+    expect(result.teamResults[0].checks.signAndTrade).toBe(false);
     expect(result.teamResults[1].legal).toBe(true);
+    expect(result.teamResults[1].checks.signAndTrade).toBe(true);
   });
 
   it('detects Stepien Rule violations', () => {
@@ -114,5 +118,7 @@ describe('tradeValidator', () => {
     expect(result.teamResults[0].reason).toContain(
       'Violates Stepien Rule (consecutive future 1sts).'
     );
+    expect(result.teamResults[0].checks.stepien).toBe(false);
+    expect(result.teamResults[1].checks.stepien).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- report per-rule validation results for trades
- update tests for new `checks` structure

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c35fbbcc8326b2a236423a8caa62