### PR TITLE
feat: expand trade validator output

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -120,7 +120,30 @@ export function validateTrade({
       .map((r) => r.reason)
       .join(' ') || 'All teams comply with trade rules.';
 
-  return { overallLegal, teamResults, reason };
+  const summaryByTeamIndex = teams.map((t, idx) => {
+    if (!t.team) return null;
+    const playersIn = [];
+    const picksIn = [];
+    teams.forEach((other, j) => {
+      if (j !== idx) {
+        playersIn.push(...other.sends);
+        picksIn.push(...other.picksOut);
+      }
+    });
+    const currentSalary = t.team.totalSalary || 0;
+    const projectedSalary = teamResults[idx].projectedSalary;
+    return {
+      teamName: t.team.teamName,
+      playersOut: t.sends.map((p) => p.name),
+      playersIn: playersIn.map((p) => p.name),
+      picksOut: t.picksOut,
+      picksIn,
+      rosterDelta: playersIn.length - t.sends.length,
+      capDelta: projectedSalary - currentSalary,
+    };
+  });
+
+  return { overallLegal, teamResults, reason, summaryByTeamIndex };
 }
 
 // =========================
@@ -213,6 +236,16 @@ function evaluateTeam({
     salaryIn,
     salaryOut,
     projectedSalary,
+    totalSalary,
+    capRoom,
+    willBeOverFirst,
+    willBeOverSecond,
+    overCap,
+    overFirst,
+    overSecond,
+    cap,
+    firstApron,
+    secondApron,
     apronStatus,
     checks,
   };

--- a/tests/tradeValidator.test.js
+++ b/tests/tradeValidator.test.js
@@ -121,4 +121,33 @@ describe('tradeValidator', () => {
     expect(result.teamResults[0].checks.stepien).toBe(false);
     expect(result.teamResults[1].checks.stepien).toBe(true);
   });
+
+  it('provides summary and financial deltas', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const aPlayer = makePlayer('Astar', 10_000_000);
+    const bPlayer = makePlayer('Bstar', 5_000_000);
+    teamA.players.push(aPlayer);
+    teamB.players.push(bPlayer);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [aPlayer], picksOut: [] },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    const summaryA = result.summaryByTeamIndex[0];
+    const summaryB = result.summaryByTeamIndex[1];
+
+    expect(summaryA.playersOut).toContain('Astar');
+    expect(summaryA.playersIn).toContain('Bstar');
+    expect(summaryA.capDelta).toBe(-5_000_000);
+
+    expect(summaryB.capDelta).toBe(5_000_000);
+    expect(result.teamResults[0]).toHaveProperty('totalSalary');
+    expect(result.teamResults[0]).toHaveProperty('capRoom');
+  });
 });


### PR DESCRIPTION
## Summary
- include cap change summary for each team in `validateTrade`
- expose additional financial info on `teamResults`
- test new summary and delta values

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ca17398883269f53d734ecad9fc1