### PR TITLE
feat: format contract inputs as currency

### DIFF
--- a/src/components/shared/EditContractModal.jsx
+++ b/src/components/shared/EditContractModal.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Dialog, DialogContent } from '@/components/shared/ui/dialog';
+import { formatCurrencyFull } from '@/utils/formatting';
 import capProjections from '@/utils/architect/capProjections';
 import {
   getExtensionEligibilityReason,
@@ -110,7 +111,7 @@ const EditContractModal = ({
       contractType: 'Standard',
       salaries: [lastSalary],
     });
-    setSalaryInputs([lastSalary ? String(lastSalary) : '']);
+    setSalaryInputs([lastSalary ? formatCurrencyFull(lastSalary) : '']);
     setSelectedAction('');
 
     const key = `${CURRENT_YEAR + 1}-${String(
@@ -131,7 +132,7 @@ const EditContractModal = ({
     setSalaryInputs(
       Array(extMax.maxYears)
         .fill(extMax.maxFirstYearSalary)
-        .map((s) => (s ? String(s) : ''))
+        .map((s) => (s ? formatCurrencyFull(s) : ''))
     );
   }, [selectedAction, extMax]);
 
@@ -304,7 +305,7 @@ const EditContractModal = ({
                       });
                       setSalaryInputs((prev) => {
                         const arr = [...prev];
-                        arr[idx] = raw;
+                        arr[idx] = formatCurrencyFull(raw);
                         return arr;
                       });
                     }}

--- a/src/features/architect/ContractEditor.jsx
+++ b/src/features/architect/ContractEditor.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { formatName } from '@/utils/formatting';
+import { formatName, formatCurrencyFull } from '@/utils/formatting';
 import {
   generateContract,
   createMaxContract,
@@ -19,6 +19,9 @@ const ContractEditor = ({
   const [type, setType] = useState('Custom');
   const [years, setYears] = useState(4);
   const [baseSalary, setBaseSalary] = useState(10000000);
+  const [baseSalaryInput, setBaseSalaryInput] = useState(
+    formatCurrencyFull(10000000)
+  );
   const [raisePct, setRaisePct] = useState(0.08);
   const [options, setOptions] = useState({
     playerOption: false,
@@ -132,9 +135,15 @@ const ContractEditor = ({
 
           <label className="block">Base Salary:</label>
           <input
-            type="number"
-            value={baseSalary}
-            onChange={(e) => setBaseSalary(Number(e.target.value))}
+            type="text"
+            inputMode="decimal"
+            value={baseSalaryInput}
+            onChange={(e) => {
+              const raw = e.target.value.replace(/[^0-9]/g, '');
+              const num = Number(raw);
+              setBaseSalary(num);
+              setBaseSalaryInput(formatCurrencyFull(raw));
+            }}
             className="p-1 bg-[#1a1a1a] border border-white/20 rounded w-32"
           />
 

--- a/src/utils/formatting/formatCurrencyFull.js
+++ b/src/utils/formatting/formatCurrencyFull.js
@@ -1,0 +1,9 @@
+export function formatCurrencyFull(value) {
+  if (value === null || value === undefined || value === '') return '';
+  const num =
+    typeof value === 'number'
+      ? value
+      : Number(String(value).replace(/[^0-9]/g, ''));
+  if (Number.isNaN(num)) return '';
+  return `$${num.toLocaleString()}`;
+}

--- a/src/utils/formatting/index.js
+++ b/src/utils/formatting/index.js
@@ -3,3 +3,4 @@ export * from './formatSalary.js';
 export * from './teamColors.js';
 export * from './teamLogos.js';
 export * from './formatName.js';
+export * from './formatCurrencyFull.js';


### PR DESCRIPTION
## Summary
- add `formatCurrencyFull` helper to format numbers like `$50,000,000`
- display formatted salaries in `ContractEditor` custom contract fields
- display formatted salaries in `EditContractModal` contract fields

## Testing
- `npm run lint` *(fails: cannot find module)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f43ab240832683867d7444440945