### PR TITLE
refactor: move cap tiles to top of trade card

### DIFF
--- a/src/features/architect/tradeMachine/CapImpactTiles.jsx
+++ b/src/features/architect/tradeMachine/CapImpactTiles.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import capProjections from '@/utils/architect/capProjections';
+import { formatSalary } from '@/utils/formatting';
 
 const CapImpactTiles = ({
   team,
@@ -40,19 +41,18 @@ const CapImpactTiles = ({
   const firstApronSpace = firstApron - projectedTotal;
   const secondApronSpace = secondApron - projectedTotal;
 
-  const formatMoney = (amount) =>
-    `${amount < 0 ? '-' : ''}$${Math.abs(amount).toLocaleString()}`;
+  const formatMoney = (amount) => formatSalary(amount);
 
   return (
-    <div className="grid grid-cols-2 gap-2 text-[11px] mt-2">
+    <div className="grid grid-cols-4 gap-2 text-[11px]">
       <div className="bg-[#1c1c1c] rounded p-2 text-center border border-white/10">
-        <div className="text-white/70">CAP ALLOCATIONS</div>
+        <div className="text-white/70">ALLOC</div>
         <div className="text-white font-bold text-sm">
           {formatMoney(projectedTotal)}
         </div>
       </div>
       <div className="bg-[#1c1c1c] rounded p-2 text-center border border-white/10">
-        <div className="text-white/70">CAP SPACE</div>
+        <div className="text-white/70">SPACE</div>
         <div
           className={`font-bold text-sm ${capSpace < 0 ? 'text-red-400' : 'text-green-400'}`}
         >
@@ -60,7 +60,7 @@ const CapImpactTiles = ({
         </div>
       </div>
       <div className="bg-[#1c1c1c] rounded p-2 text-center border border-white/10">
-        <div className="text-white/70">1ST APRON SPACE</div>
+        <div className="text-white/70">1ST APR</div>
         <div
           className={`font-bold text-sm ${firstApronSpace < 0 ? 'text-red-400' : 'text-green-400'}`}
         >
@@ -68,7 +68,7 @@ const CapImpactTiles = ({
         </div>
       </div>
       <div className="bg-[#1c1c1c] rounded p-2 text-center border border-white/10">
-        <div className="text-white/70">2ND APRON SPACE</div>
+        <div className="text-white/70">2ND APR</div>
         <div
           className={`font-bold text-sm ${secondApronSpace < 0 ? 'text-red-400' : 'text-green-400'}`}
         >

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -65,6 +65,13 @@ const TradeTeamCard = ({
         </div>
       </div>
 
+      <CapImpactTiles
+        team={team}
+        sends={sends}
+        incomingPlayers={incomingPlayers}
+        yearKey={yearKey}
+      />
+
       {/* Tabs */}
       <div className="flex gap-4 text-sm border-b border-white/10 pb-1">
         <button
@@ -133,12 +140,6 @@ const TradeTeamCard = ({
         </div>
       )}
 
-      <CapImpactTiles
-        team={team}
-        sends={sends}
-        incomingPlayers={incomingPlayers}
-        yearKey={yearKey}
-      />
     </div>
   );
 };

--- a/src/utils/formatting/formatSalary.js
+++ b/src/utils/formatting/formatSalary.js
@@ -2,12 +2,14 @@ export function formatSalary(salary) {
   if (!salary) return '—';
   const salaryValue =
     typeof salary === 'string'
-      ? parseFloat(salary.replace(/[^0-9.]/g, ''))
+      ? parseFloat(salary.replace(/[^0-9.-]/g, ''))
       : salary;
-  if (salaryValue >= 1000000) {
-    return `$${(salaryValue / 1000000).toFixed(1)}M`;
-  } else if (salaryValue >= 1000) {
-    return `$${(salaryValue / 1000).toFixed(0)}K`;
+  const sign = salaryValue < 0 ? '-' : '';
+  const absValue = Math.abs(salaryValue);
+  if (absValue >= 1000000) {
+    return `${sign}$${(absValue / 1000000).toFixed(1)}M`;
+  } else if (absValue >= 1000) {
+    return `${sign}$${(absValue / 1000).toFixed(0)}K`;
   }
-  return `$${salaryValue?.toLocaleString() || '—'}`;
+  return `${sign}$${absValue.toLocaleString()}`;
 }


### PR DESCRIPTION
## Summary
- show cap impact tiles after the team header on each trade team card
- display tiles in a single row with shortened labels
- format cap numbers with abbreviated dollar amounts

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-react)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881fa74f7c083268ba1ef4ea4d639e5