### PR TITLE
fix: keep pick menus working

### DIFF
--- a/src/features/architect/tradeMachine/OutgoingPicksList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPicksList.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { areSamePick } from '@/utils/architect/tradeHelpers';
 import { TradePickRow } from './TradePickRow';
 
@@ -8,27 +8,34 @@ export const OutgoingPicksList = ({
   otherTeams = [],
   onTogglePick,
   onEditPick,
-}) => (
-  <div>
-    <h4 className="text-sm text-white/70 mb-1">Outgoing Picks</h4>
-    <div className="space-y-1 max-h-[375px] overflow-y-auto pr-1">
-      {team.picks?.map((p) => {
-        const pickObj = picks.find((pk) => areSamePick(pk, p));
-        return (
-          <TradePickRow
-            key={`${p.year}-${p.round}-${p.via || ''}`}
-            pick={p}
-            pickObj={pickObj}
-            teamId={team.id}
-            otherTeams={otherTeams}
-            onToggle={onTogglePick}
-            onEdit={onEditPick}
-          />
-        );
-      })}
-      {team.picks?.length === 0 && (
-        <div className="text-xs text-white/40">No picks available</div>
-      )}
+}) => {
+  const [openMenu, setOpenMenu] = useState(null);
+  return (
+    <div>
+      <h4 className="text-sm text-white/70 mb-1">Outgoing Picks</h4>
+      <div className="space-y-1 max-h-[375px] overflow-y-auto pr-1">
+        {team.picks?.map((p, idx) => {
+          const pickObj = picks.find((pk) => areSamePick(pk, p));
+          const rowKey = `${idx}-${p.year}-${p.round}-${p.via || ''}`;
+          return (
+            <TradePickRow
+              key={rowKey}
+              rowKey={rowKey}
+              pick={p}
+              pickObj={pickObj}
+              teamId={team.id}
+              otherTeams={otherTeams}
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              onToggle={onTogglePick}
+              onEdit={onEditPick}
+            />
+          );
+        })}
+        {team.picks?.length === 0 && (
+          <div className="text-xs text-white/40">No picks available</div>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/features/architect/tradeMachine/TradePickRow.jsx
+++ b/src/features/architect/tradeMachine/TradePickRow.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { formatPick } from '@/utils/architect/tradeHelpers';
 import { getPickOptions } from '@/utils/architect/tradeMachine/pickOptions';
 import { getTeamColors } from '@/utils/formatting';
@@ -17,15 +17,19 @@ export const TradePickRow = ({
   pickObj,
   teamId,
   otherTeams = [],
+  rowKey,
+  openMenu,
+  setOpenMenu,
   onToggle,
   onEdit,
 }) => {
-  const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef(null);
   const buttonRef = useRef(null);
 
+  const key = rowKey || `${pick.year}-${pick.round}-${pick.via || ''}`;
+
   useEffect(() => {
-    if (!menuOpen) return undefined;
+    if (openMenu !== key) return undefined;
     const handleClick = (e) => {
       if (
         menuRef.current &&
@@ -33,12 +37,12 @@ export const TradePickRow = ({
         buttonRef.current &&
         !buttonRef.current.contains(e.target)
       ) {
-        setMenuOpen(false);
+        setOpenMenu(null);
       }
     };
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, [menuOpen]);
+  }, [openMenu, key, setOpenMenu]);
 
   const exists = !!pickObj;
   const { primary } = getTeamColors(teamId);
@@ -88,12 +92,14 @@ export const TradePickRow = ({
           <>
             <button
               ref={buttonRef}
-              onClick={() => setMenuOpen(!menuOpen)}
+              onClick={() =>
+                setOpenMenu(openMenu === key ? null : key)
+              }
               className="text-blue-400 hover:underline"
             >
               •••
             </button>
-            {menuOpen && (
+            {openMenu === key && (
               <div
                 ref={menuRef}
                 className="absolute right-0 top-5 bg-[#222] border border-white/20 rounded z-20 text-xs min-w-[8rem]"
@@ -101,20 +107,20 @@ export const TradePickRow = ({
                 {otherTeams.map((t) => (
                   <button
                     key={t.id}
-                    onClick={() => {
-                      onToggle(pick);
-                      onEdit(pick, 'toTeamId', t.id);
-                      setMenuOpen(false);
-                    }}
-                    className="block w-full text-left px-3 py-1 hover:bg-[#333]"
-                  >
-                    {`Trade to ${t.teamName}`}
-                  </button>
+                      onClick={() => {
+                        onToggle(pick);
+                        onEdit(pick, 'toTeamId', t.id);
+                        setOpenMenu(null);
+                      }}
+                      className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+                    >
+                      {`Trade to ${t.teamName}`}
+                    </button>
                 ))}
                 <button
                   onClick={() => {
                     onToggle(pick);
-                    setMenuOpen(false);
+                    setOpenMenu(null);
                   }}
                   className="block w-full text-left px-3 py-1 hover:bg-[#333]"
                 >


### PR DESCRIPTION
## Summary
- ensure each pick row uses a unique rowKey
- pass rowKey from OutgoingPicksList to TradePickRow
- continue closing menus via shared openMenu state

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835000dd308326ba3f8e0b23c81ccb