### PR TITLE
feat: move traded players to new team

### DIFF
--- a/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
@@ -12,6 +12,7 @@ const parseYear = (key) => {
 export const OutgoingPlayersList = ({
   team,
   sends,
+  incomingPlayers = [],
   yearKey,
   otherTeams = [],
   playersMap = {},
@@ -25,37 +26,39 @@ export const OutgoingPlayersList = ({
     <div>
       <h4 className="text-sm text-white/70 mb-1">Outgoing Players</h4>
       <div className="space-y-1 max-h-[375px] overflow-y-auto pr-1">
-        {team.players
-          ?.slice()
+        {[
+          ...(team.players || []).filter((p) => !sends.includes(p)),
+          ...incomingPlayers,
+        ]
+          .slice()
           .sort((a, b) => {
             const yr = parseYear(yearKey);
             const getSalary = (player) =>
               player.contract_clean?.salaries_by_year?.[yearKey]?.salary ||
               player.contract?.annual_salaries?.find(
                 (s) => parseYear(s.year) === yr
-              )?.salary ||
-              0;
+              )?.salary || 0;
             return getSalary(b) - getSalary(a);
           })
-          .map((p) => {
-            const included = sends.includes(p);
-            return (
-              <TradePlayerRow
-                key={p.id || p.name}
-                player={p}
-                included={included}
-                yearKey={yearKey}
-                otherTeams={otherTeams}
-                playersMap={playersMap}
-                onSetPlayerTrade={onSetPlayerTrade}
-                openMenu={openMenu}
-                setOpenMenu={setOpenMenu}
-                setContractPlayer={setContractPlayer}
-                setTpePlayer={setTpePlayer}
-              />
-            );
-          })}
-        {team.players?.length === 0 && (
+          .map((p) => (
+            <TradePlayerRow
+              key={p.id || p.name}
+              player={p}
+              included={false}
+              yearKey={yearKey}
+              otherTeams={otherTeams}
+              playersMap={playersMap}
+              onSetPlayerTrade={onSetPlayerTrade}
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              setContractPlayer={setContractPlayer}
+              setTpePlayer={setTpePlayer}
+            />
+          ))}
+        {[
+          ...(team.players || []).filter((p) => !sends.includes(p)),
+          ...incomingPlayers,
+        ].length === 0 && (
           <div className="text-xs text-white/40">No players available</div>
         )}
       </div>

--- a/src/features/architect/tradeMachine/TradeEditor.jsx
+++ b/src/features/architect/tradeMachine/TradeEditor.jsx
@@ -35,7 +35,11 @@ const TradeEditor = ({
     const picks = [];
     teams.forEach((t, j) => {
       if (j !== idx && t.team) {
-        players.push(...t.sends);
+        t.sends.forEach((p) => {
+          if (!p.tradeTo || p.tradeTo === tm.team?.id) {
+            players.push(p);
+          }
+        });
         t.picksOut.forEach((p) => {
           if (!p.toTeamId || p.toTeamId === tm.team?.id) {
             picks.push(p);
@@ -92,7 +96,7 @@ const TradeEditor = ({
               yearKey={yearKey}
               otherTeams={otherTeams}
               playersMap={playersMap}
-              onSetPlayerTrade={(p, action) => setPlayerTrade(idx, p, action)}
+              onSetPlayerTrade={(p, action, dest) => setPlayerTrade(idx, p, action, dest)}
               onTogglePick={(p) => togglePick(idx, p)}
               onEditPick={(p, field, value) =>
                 updatePickField(idx, p, field, value)

--- a/src/features/architect/tradeMachine/TradePlayerRow.jsx
+++ b/src/features/architect/tradeMachine/TradePlayerRow.jsx
@@ -79,6 +79,7 @@ const TradePlayerRow = ({
   const position = getPlayerPositionLabel(rawPosition) || '—';
 
   const team =
+    player.tradeTo ||
     player.bio?.Team ||
     player.team ||
     player.teamId ||
@@ -174,9 +175,13 @@ const TradePlayerRow = ({
               <button
                 key={t.id}
                 onClick={() => {
-                  onSetPlayerTrade(player, included ? 'keep' : 'trade');
-                  if (!included && isFreeAgent) {
-                    onSetPlayerTrade(player, 'signAndTrade', true);
+                  if (included && player.tradeTo === t.id) {
+                    onSetPlayerTrade(player, 'keep');
+                  } else {
+                    onSetPlayerTrade(player, 'trade', t.id);
+                    if (!included && isFreeAgent) {
+                      onSetPlayerTrade(player, 'signAndTrade', t.id, true);
+                    }
                   }
                   setOpenMenu(null);
                 }}

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -134,6 +134,7 @@ const TradeTeamCard = ({
         <OutgoingPlayersList
           team={team}
           sends={sends}
+          incomingPlayers={incomingPlayers}
           yearKey={yearKey}
           otherTeams={otherTeams}
           playersMap={playersMap}

--- a/src/hooks/tradeMachine/useTradeMachine.js
+++ b/src/hooks/tradeMachine/useTradeMachine.js
@@ -29,16 +29,21 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
     init();
   }, [primaryTeam]);
 
-  const setPlayerTrade = (index, player, action, flag = false) => {
+  const setPlayerTrade = (index, player, action, destTeamId = null, flag = false) => {
     setTeams((prev) => {
       const copy = [...prev];
       const list = copy[index].sends;
       const exists = list.includes(player);
       if (action === 'trade' && !exists) {
         player.signAndTrade = false;
+        player.tradeTo = destTeamId;
         copy[index].sends = [...list, player];
+      } else if (action === 'trade' && exists) {
+        player.tradeTo = destTeamId;
+        copy[index].sends = list;
       } else if (action === 'keep' && exists) {
         player.signAndTrade = false;
+        player.tradeTo = null;
         copy[index].sends = list.filter((i) => i !== player);
       } else if (action === 'signAndTrade' && exists) {
         player.signAndTrade = flag;
@@ -166,7 +171,11 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
 
       teams.forEach((other, j) => {
         if (j !== idx && other.team) {
-          incomingPlayers.push(...other.sends);
+          other.sends.forEach((p) => {
+            if (!p.tradeTo || p.tradeTo === t.team.id || p.tradeTo === t.team.teamId) {
+              incomingPlayers.push(p);
+            }
+          });
           other.picksOut.forEach((p) => {
             if (
               !p.toTeamId ||

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -126,7 +126,11 @@ export function validateTrade({
     const picksIn = [];
     teams.forEach((other, j) => {
       if (j !== idx && other.team) {
-        playersIn.push(...other.sends);
+        other.sends.forEach((pl) => {
+          if (!pl.tradeTo || pl.tradeTo === t.team.id || pl.tradeTo === t.team.teamId) {
+            playersIn.push(pl);
+          }
+        });
         other.picksOut.forEach((p) => {
           if (
             !p.toTeamId ||


### PR DESCRIPTION
## Summary
- show players on their new teams in Trade Machine
- keep updated team logo in TradePlayerRow
- track trade destination in trade state
- filter incoming assets by player destination

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find eslint-plugin-react)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688372a786108326951ab17c67696b01