### PR TITLE
feat: add undo trade functionality

### DIFF
--- a/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
@@ -17,6 +17,7 @@ export const OutgoingPlayersList = ({
   otherTeams = [],
   playersMap = {},
   onSetPlayerTrade,
+  onUndoPlayerTrade,
 }) => {
   const [openMenu, setOpenMenu] = useState(null);
   const [contractPlayer, setContractPlayer] = useState(null);
@@ -57,6 +58,7 @@ export const OutgoingPlayersList = ({
             otherTeams={otherTeams}
             playersMap={playersMap}
             onSetPlayerTrade={onSetPlayerTrade}
+            onUndoPlayerTrade={onUndoPlayerTrade}
             openMenu={openMenu}
             setOpenMenu={setOpenMenu}
             setContractPlayer={setContractPlayer}

--- a/src/features/architect/tradeMachine/TradeEditor.jsx
+++ b/src/features/architect/tradeMachine/TradeEditor.jsx
@@ -26,6 +26,7 @@ const TradeEditor = ({
     removeTeam,
     handleValidate,
     exportCurrentTrade,
+    undoPlayerTrade,
     resetTrade,
     yearKey,
   } = useTradeMachine(primaryTeam, capProjections, currentYear);
@@ -96,11 +97,14 @@ const TradeEditor = ({
               yearKey={yearKey}
               otherTeams={otherTeams}
               playersMap={playersMap}
-              onSetPlayerTrade={(p, action, dest) => setPlayerTrade(idx, p, action, dest)}
+              onSetPlayerTrade={(p, action, dest) =>
+                setPlayerTrade(idx, p, action, dest)
+              }
               onTogglePick={(p) => togglePick(idx, p)}
               onEditPick={(p, field, value) =>
                 updatePickField(idx, p, field, value)
               }
+              onUndoPlayerTrade={undoPlayerTrade}
               onSelectTeam={(teamId) => selectTeam(idx, teamId)}
               onRemove={() => removeTeam(idx)}
             />

--- a/src/features/architect/tradeMachine/TradePlayerRow.jsx
+++ b/src/features/architect/tradeMachine/TradePlayerRow.jsx
@@ -20,6 +20,7 @@ const TradePlayerRow = ({
   otherTeams = [],
   playersMap = {},
   onSetPlayerTrade,
+  onUndoPlayerTrade,
   openMenu,
   setOpenMenu,
   setContractPlayer,
@@ -207,6 +208,17 @@ const TradePlayerRow = ({
                 {`${isFreeAgent ? 'S&T to' : 'Trade to'} ${t.teamName}`}
               </button>
             ))}
+            {onUndoPlayerTrade && (incoming || included) && (
+              <button
+                onClick={() => {
+                  onUndoPlayerTrade(player);
+                  setOpenMenu(null);
+                }}
+                className="block w-full text-left px-3 py-1 hover:bg-[#333]"
+              >
+                Undo Trade
+              </button>
+            )}
             <button
               onClick={() => {
                 setContractPlayer(player);

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -23,6 +23,7 @@ const TradeTeamCard = ({
   incomingPicks = [],
   capImpact = null,
   onSetPlayerTrade,
+  onUndoPlayerTrade,
   onTogglePick,
   onEditPick,
   onSelectTeam,
@@ -118,9 +119,17 @@ const TradeTeamCard = ({
               {sends.map((p) => (
                 <span
                   key={p.id || p.name}
-                  className="bg-[#2a2a2a] text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-white/10"
+                  className="bg-[#2a2a2a] text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-white/10 flex items-center gap-1"
                 >
                   {p.name}
+                  {onUndoPlayerTrade && (
+                    <button
+                      onClick={() => onUndoPlayerTrade(p)}
+                      className="ml-1 text-white/50 hover:text-white"
+                    >
+                      ✕
+                    </button>
+                  )}
                 </span>
               ))}
               {picks
@@ -156,9 +165,17 @@ const TradeTeamCard = ({
               {incomingPlayers.map((p) => (
                 <span
                   key={p.id || p.name}
-                  className="bg-[#2a2a2a] text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-white/10"
+                  className="bg-[#2a2a2a] text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-white/10 flex items-center gap-1"
                 >
                   {p.name}
+                  {onUndoPlayerTrade && (
+                    <button
+                      onClick={() => onUndoPlayerTrade(p)}
+                      className="ml-1 text-white/50 hover:text-white"
+                    >
+                      ✕
+                    </button>
+                  )}
                 </span>
               ))}
               {incomingPicks.map((p) => (
@@ -208,6 +225,7 @@ const TradeTeamCard = ({
           otherTeams={otherTeams}
           playersMap={playersMap}
           onSetPlayerTrade={onSetPlayerTrade}
+          onUndoPlayerTrade={onUndoPlayerTrade}
         />
       )}
 

--- a/src/hooks/tradeMachine/useTradeMachine.js
+++ b/src/hooks/tradeMachine/useTradeMachine.js
@@ -29,7 +29,13 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
     init();
   }, [primaryTeam]);
 
-  const setPlayerTrade = (index, player, action, destTeamId = null, flag = false) => {
+  const setPlayerTrade = (
+    index,
+    player,
+    action,
+    destTeamId = null,
+    flag = false
+  ) => {
     setTeams((prev) => {
       const copy = [...prev];
       const list = copy[index].sends;
@@ -172,7 +178,11 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
       teams.forEach((other, j) => {
         if (j !== idx && other.team) {
           other.sends.forEach((p) => {
-            if (!p.tradeTo || p.tradeTo === t.team.id || p.tradeTo === t.team.teamId) {
+            if (
+              !p.tradeTo ||
+              p.tradeTo === t.team.id ||
+              p.tradeTo === t.team.teamId
+            ) {
               incomingPlayers.push(p);
             }
           });
@@ -212,6 +222,22 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
     setForceTrade(false);
   };
 
+  const undoPlayerTrade = (player) => {
+    setTeams((prev) => {
+      const copy = [...prev];
+      for (let i = 0; i < copy.length; i++) {
+        const list = copy[i].sends;
+        if (list.includes(player)) {
+          player.signAndTrade = false;
+          player.tradeTo = null;
+          copy[i].sends = list.filter((p) => p !== player);
+          break;
+        }
+      }
+      return copy;
+    });
+  };
+
   return {
     teams,
     result,
@@ -225,6 +251,7 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
     removeTeam,
     handleValidate,
     exportCurrentTrade,
+    undoPlayerTrade,
     resetTrade,
     yearKey,
   };


### PR DESCRIPTION
## Summary
- add `undoPlayerTrade` helper
- pass undo callback to trade machine components
- show `Undo Trade` option in player menu
- add `✕` buttons on trade player pills

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688484a7dcec8326b9c224256f147e84