### PR TITLE
feat: sync free agent signings across tools

### DIFF
--- a/src/features/architect/GMDashboard.jsx
+++ b/src/features/architect/GMDashboard.jsx
@@ -322,9 +322,37 @@ const GMDashboard = () => {
 
     setTeamCapSheet((prev) => {
       const active = prev?.activeContracts || [];
+      const players = prev?.players || [];
+
+      const base =
+        playersMap[playerObj.name] ||
+        playersMap[playerObj.player_id] ||
+        playersMap[playerObj.id] ||
+        {};
+
+      const position =
+        base.position ||
+        base.formattedPosition ||
+        getPlayerPositionLabel(base.bio?.Position || playerObj.position || '');
+
+      const newPlayer = {
+        ...(base || {}),
+        name: base.name || playerObj.name,
+        player_id: playerObj.id || playerObj.player_id || base.player_id,
+        display_name:
+          base.display_name || playerObj.display_name || playerObj.name,
+        position,
+        contract_clean: {
+          ...(base.contract_clean || {}),
+          salaries_by_year: toSalaryMap(contract.salaryByYear),
+          options: contract.options || base.contract_clean?.options || {},
+        },
+      };
+
       return {
         ...prev,
         activeContracts: [...active, newContract],
+        players: [...players, newPlayer],
       };
     });
 
@@ -528,6 +556,7 @@ const GMDashboard = () => {
             currentYear={currentYear}
             playersMap={playersMap}
             onApplyTrade={applyTradeToCapSheet}
+            primaryTeamData={teamCapSheet}
           />
         )}
 

--- a/src/features/architect/tradeMachine/TradeEditor.jsx
+++ b/src/features/architect/tradeMachine/TradeEditor.jsx
@@ -12,6 +12,7 @@ const TradeEditor = ({
   currentYear,
   playersMap = {},
   onApplyTrade,
+  primaryTeamData = null,
 }) => {
   const {
     teams,
@@ -29,7 +30,7 @@ const TradeEditor = ({
     undoPlayerTrade,
     resetTrade,
     yearKey,
-  } = useTradeMachine(primaryTeam, capProjections, currentYear);
+  } = useTradeMachine(primaryTeam, capProjections, currentYear, primaryTeamData);
 
   const incomingAssets = teams.map((tm, idx) => {
     const players = [];

--- a/src/hooks/tradeMachine/useTradeMachine.js
+++ b/src/hooks/tradeMachine/useTradeMachine.js
@@ -6,7 +6,12 @@ import { loadTeamCapSheet } from '@/utils/architect/firebaseTeamPlanHelpers';
 import { getSalaryForYear, areSamePick } from '@/utils/architect/tradeHelpers';
 import { TeamMap } from '@/constants/teamList';
 
-export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
+export const useTradeMachine = (
+  primaryTeam,
+  capProjections,
+  currentYear,
+  primaryTeamData = null
+) => {
   const [teams, setTeams] = useState([]);
   const [result, setResult] = useState(null);
   const [forceTrade, setForceTrade] = useState(false);
@@ -17,7 +22,7 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
       if (!primaryTeam || typeof primaryTeam !== 'string') return;
 
       const baseTeam = TeamMap[primaryTeam];
-      const data = await loadTeamCapSheet(primaryTeam);
+      const data = primaryTeamData || (await loadTeamCapSheet(primaryTeam));
 
       if (baseTeam && data) {
         setTeams([
@@ -27,7 +32,16 @@ export const useTradeMachine = (primaryTeam, capProjections, currentYear) => {
       }
     };
     init();
-  }, [primaryTeam]);
+  }, [primaryTeam, primaryTeamData]);
+
+  useEffect(() => {
+    if (!primaryTeamData || teams.length === 0) return;
+    setTeams((prev) => {
+      const copy = [...prev];
+      copy[0] = { ...copy[0], team: { ...copy[0].team, ...primaryTeamData } };
+      return copy;
+    });
+  }, [primaryTeamData]);
 
   const setPlayerTrade = (
     index,


### PR DESCRIPTION
## Summary
- update free agent signing handler to also push to `players`
- allow Trade Machine to accept updated roster data
- pass current cap sheet to TradeEditor so new signings appear

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm run test` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688497ea4d7883269ff6ba5abd705f31