### PR TITLE
fix: preload Anton font globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <!-- ✅ Preload Anton font -->
     <link
       rel="preload"
-      href="/fonts/Anton.woff2"
+      href="./fonts/Anton.woff2"
       as="font"
       type="font/woff2"
       crossorigin="anonymous"

--- a/src/features/lists/ListPreviewModal/index.jsx
+++ b/src/features/lists/ListPreviewModal/index.jsx
@@ -1,6 +1,5 @@
 // src/features/lists/ListPreviewModal.jsx
 import React, { useRef, useLayoutEffect, useState } from 'react';
-import '@/styles/antonFont.css';
 import useImageDownload from '@/hooks/useImageDownload';
 import ListExportWrapper from './ListExportWrapper';
 

--- a/src/features/roster/RosterExportCapture.jsx
+++ b/src/features/roster/RosterExportCapture.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { getTeamColors } from '@/utils/formatting/teamColors';
 import { getTeamLogoFilename } from '@/utils/formatting/teamLogos';
 import RosterSection from './RosterSection';
-import '@/styles/antonFont.css';
 
 const RosterExportCapture = React.forwardRef(({ roster, team }, ref) => {
   const { primary, secondary } = getTeamColors(team?.id);

--- a/src/features/roster/RosterPreviewModal.jsx
+++ b/src/features/roster/RosterPreviewModal.jsx
@@ -5,7 +5,6 @@ import RosterExportCapture from './RosterExportCapture';
 import { getTeamColors } from '@/utils/formatting/teamColors';
 import { getTeamLogoFilename } from '@/utils/formatting/teamLogos';
 import RosterSection from './RosterSection';
-import '@/styles/antonFont.css';
 
 const RosterPreviewModal = ({ open, onClose, roster, team }) => {
   if (!open || !roster) return null;
@@ -19,8 +18,8 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
     try {
       const font = new FontFace(
         'AntonLocal',
-        "url('/fonts/Anton.woff2') format('woff2')",
-        { display: 'swap' }
+        `url('${import.meta.env.BASE_URL}fonts/Anton.woff2') format('woff2')`,
+        { display: 'swap' },
       );
       await font.load();
       document.fonts.add(font);

--- a/src/hooks/useImageDownload.js
+++ b/src/hooks/useImageDownload.js
@@ -6,8 +6,8 @@ const useImageDownload = (ref) => {
     try {
       const font = new FontFace(
         'AntonLocal',
-        "url('/fonts/Anton.woff2') format('woff2')",
-        { display: 'swap' }
+        `url('${import.meta.env.BASE_URL}fonts/Anton.woff2') format('woff2')`,
+        { display: 'swap' },
       );
       await font.load();
       document.fonts.add(font);

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Preload Anton font globally */
+@import './styles/antonFont.css';
+
 body {
   font-family: system-ui, sans-serif;
 }

--- a/src/styles/antonFont.css
+++ b/src/styles/antonFont.css
@@ -1,5 +1,5 @@
 @font-face {
   font-family: 'AntonLocal';
-  src: url('/fonts/Anton.woff2') format('woff2');
+  src: url('../fonts/Anton.woff2') format('woff2');
   font-display: swap;
 }


### PR DESCRIPTION
## Summary
- preload Anton font once in `index.css`
- update font paths to respect Vite base URL
- drop component-level font imports

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68849f8a99188326b2d36400ef229a17