### PR TITLE
fix: show correct team logos in trade export

### DIFF
--- a/src/features/architect/tradeMachine/TradeExportCapture.jsx
+++ b/src/features/architect/tradeMachine/TradeExportCapture.jsx
@@ -10,6 +10,12 @@ import {
 } from '@/utils/architect/tradeHelpers';
 import { format } from 'date-fns';
 
+const getPlayerTeamKey = (p) =>
+  p.teamId || p.team || p.teamAbbr || p.bio?.Team || p.originTeamId;
+
+const getPickTeamKey = (p) =>
+  p.fromTeamId || p.teamId || p.team || p.originTeamId;
+
 const TradeExportCapture = React.forwardRef(
   (
     { teams = [], result, yearKey, label = 'Trade Summary', date = new Date() },
@@ -151,7 +157,7 @@ const TradeExportCapture = React.forwardRef(
                                     </div>
                                   </div>
                                   <TeamLogo
-                                    teamId={p.teamId || p.originTeamId}
+                                    teamId={getPlayerTeamKey(p)}
                                     className="w-6 h-6 ml-2 shrink-0"
                                   />
                                 </div>
@@ -179,7 +185,7 @@ const TradeExportCapture = React.forwardRef(
                               >
                                 <span>{formatPick(p)}</span>
                                 <TeamLogo
-                                  teamId={p.fromTeamId || p.originTeamId}
+                                  teamId={getPickTeamKey(p)}
                                   className="w-5 h-5 ml-2 shrink-0"
                                 />
                               </div>


### PR DESCRIPTION
## Summary
- ensure TradeExportCapture shows the proper team logo for traded players and picks

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856aa114c88326bc91d7a8be98b3d0