### PR TITLE
fix: embed Anton font in exports

### DIFF
--- a/src/features/architect/tradeMachine/TradeExportCapture.jsx
+++ b/src/features/architect/tradeMachine/TradeExportCapture.jsx
@@ -65,14 +65,14 @@ const TradeExportCapture = React.forwardRef(
       <div
         ref={ref}
         className="w-[1200px] bg-[#0b0b0b] text-white rounded-xl overflow-hidden shadow-2xl border border-white/10"
-        style={{ fontFamily: 'AntonBase64, sans-serif' }}
+        style={{ fontFamily: 'AntonLocal, AntonBase64, sans-serif' }}
       >
         {/* 🧾 Header */}
         <div
           style={{
             opacity: 0,
             position: 'absolute',
-            fontFamily: 'AntonBase64, sans-serif',
+            fontFamily: 'AntonLocal, AntonBase64, sans-serif',
           }}
         >
           preload

--- a/src/features/lists/ListPreviewModal/index.jsx
+++ b/src/features/lists/ListPreviewModal/index.jsx
@@ -75,7 +75,7 @@ const ListPreviewModal = ({
         >
           <div
             style={{
-              fontFamily: 'AntonLocal',
+              fontFamily: 'AntonLocal, AntonBase64',
               opacity: 0,
               position: 'absolute',
             }}

--- a/src/features/roster/RosterExportCapture.jsx
+++ b/src/features/roster/RosterExportCapture.jsx
@@ -11,7 +11,7 @@ const RosterExportCapture = React.forwardRef(({ roster, team }, ref) => {
     <div
       ref={ref}
       className="w-[1200px] h-[975px] bg-neutral-900 text-white relative rounded-2xl overflow-hidden border border-white/20 shadow-2xl"
-      style={{ fontFamily: 'AntonLocal, sans-serif' }}
+      style={{ fontFamily: 'AntonLocal, AntonBase64, sans-serif' }}
     >
       {team && (
         <img
@@ -28,7 +28,7 @@ const RosterExportCapture = React.forwardRef(({ roster, team }, ref) => {
           <h2
             className="w-full text-center text-7xl font-black uppercase leading-none"
             style={{
-              fontFamily: 'AntonLocal, sans-serif',
+              fontFamily: 'AntonLocal, AntonBase64, sans-serif',
               color: '#1e1e1e',
               textShadow: `0 0 8px ${primary}, 0 0 16px ${secondary}`,
             }}

--- a/src/features/roster/RosterPreviewModal.jsx
+++ b/src/features/roster/RosterPreviewModal.jsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { X } from 'lucide-react';
-import { toPng } from 'html-to-image';
+import useImageDownload from '@/hooks/useImageDownload';
 import RosterExportCapture from './RosterExportCapture';
 import { getTeamColors } from '@/utils/formatting/teamColors';
 import { getTeamLogoFilename } from '@/utils/formatting/teamLogos';
@@ -12,35 +12,9 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
   const exportRef = useRef(null); // ✅ used for PNG export
   const { primary, secondary } = getTeamColors(team?.id);
 
-  const handleDownload = async () => {
-    if (!exportRef.current) return;
-
-    try {
-      const font = new FontFace(
-        'AntonLocal',
-        `url('${import.meta.env.BASE_URL}fonts/Anton.woff2') format('woff2')`,
-        { display: 'swap' }
-      );
-      await font.load();
-      document.fonts.add(font);
-      await document.fonts.load('1em AntonLocal');
-      await document.fonts.ready;
-      await new Promise((r) => requestAnimationFrame(r));
-      await new Promise((r) => setTimeout(r, 100));
-
-      const dataUrl = await toPng(exportRef.current, {
-        cacheBust: true,
-        skipFonts: true,
-        pixelRatio: 3,
-      });
-
-      const link = document.createElement('a');
-      link.download = `${team?.nickname || 'roster'}.png`;
-      link.href = dataUrl;
-      link.click();
-    } catch (err) {
-      console.error('Export failed:', err);
-    }
+  const downloadImage = useImageDownload(exportRef);
+  const handleDownload = () => {
+    downloadImage(`${team?.nickname || 'roster'}.png`, { pixelRatio: 3 });
   };
 
   return (
@@ -67,7 +41,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
         >
           <div
             className="rounded-2xl w-full h-full border border-white/20 shadow-2xl bg-neutral-900 relative overflow-hidden"
-            style={{ fontFamily: 'AntonLocal, sans-serif' }}
+            style={{ fontFamily: 'AntonLocal, AntonBase64, sans-serif' }}
           >
             {/* Close Button */}
             <button
@@ -92,7 +66,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
               style={{
                 opacity: 0,
                 position: 'absolute',
-                fontFamily: 'AntonLocal, sans-serif',
+                fontFamily: 'AntonLocal, AntonBase64, sans-serif',
               }}
             >
               preload
@@ -103,7 +77,7 @@ const RosterPreviewModal = ({ open, onClose, roster, team }) => {
               <h2
                 className="w-full text-center text-7xl font-black uppercase leading-none"
                 style={{
-                  fontFamily: 'AntonLocal, sans-serif',
+                  fontFamily: 'AntonLocal, AntonBase64, sans-serif',
                   color: '#1e1e1e',
                   textShadow: `0 0 8px ${primary}, 0 0 16px ${secondary}`,
                 }}

--- a/src/hooks/useImageDownload.js
+++ b/src/hooks/useImageDownload.js
@@ -5,8 +5,9 @@ const useImageDownload = (ref) => {
   const download = async (filename, options = {}) => {
     if (!ref.current) return;
     try {
-      // 1. Ensure the Base64 font is loaded before export
+      // 1. Ensure the Base64 font is loaded and injected before export
       const match = antonBase64CSS.match(/base64,([^)]+)\)/);
+      let styleEl;
       if (match) {
         const font = new FontFace(
           'AntonBase64',
@@ -17,6 +18,11 @@ const useImageDownload = (ref) => {
         document.fonts.add(font);
         await document.fonts.load('1em AntonBase64');
         await document.fonts.ready;
+
+        // Inject @font-face so html-to-image clone retains the font
+        styleEl = document.createElement('style');
+        styleEl.textContent = antonBase64CSS;
+        ref.current.prepend(styleEl);
       }
 
       // 2. Wait a frame so layout has time to settle
@@ -38,6 +44,8 @@ const useImageDownload = (ref) => {
       link.download = filename;
       link.href = dataUrl;
       link.click();
+
+      if (styleEl) styleEl.remove();
     } catch (err) {
       console.error('Failed to download image', err);
     }


### PR DESCRIPTION
## Summary
- inject Anton Base64 font when exporting images
- use image download hook for roster export preview
- allow fallback to AntonLocal everywhere

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885ae4a3bac8326806a02d4b800f3e9