### PR TITLE
feat: trade picks move to receiving team

### DIFF
--- a/src/features/architect/tradeMachine/OutgoingPicksList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPicksList.jsx
@@ -1,20 +1,32 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { areSamePick } from '@/utils/architect/tradeHelpers';
 import { TradePickRow } from './TradePickRow';
 
 export const OutgoingPicksList = ({
   team,
   picks,
+  incomingPicks = [],
   otherTeams = [],
   onTogglePick,
   onEditPick,
 }) => {
   const [openMenu, setOpenMenu] = useState(null);
+
+  const available = useMemo(
+    () => [
+      ...incomingPicks,
+      ...(team.picks || []).filter(
+        (p) => !picks.some((pk) => areSamePick(pk, p))
+      ),
+    ],
+    [team.picks, picks, incomingPicks]
+  );
+
   return (
     <div>
       <h4 className="text-sm text-white/70 mb-1">Outgoing Picks</h4>
       <div className="space-y-1 max-h-[375px] overflow-y-auto pr-1">
-        {team.picks?.map((p, idx) => {
+        {available.map((p, idx) => {
           const pickObj = picks.find((pk) => areSamePick(pk, p));
           const rowKey = `${idx}-${p.year}-${p.round}-${p.via || ''}`;
           return (
@@ -32,7 +44,7 @@ export const OutgoingPicksList = ({
             />
           );
         })}
-        {team.picks?.length === 0 && (
+        {available.length === 0 && (
           <div className="text-xs text-white/40">No picks available</div>
         )}
       </div>

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -300,6 +300,7 @@ const TradeTeamCard = ({
         <OutgoingPicksList
           team={team}
           picks={picks}
+          incomingPicks={incomingPicks}
           otherTeams={otherTeams}
           onTogglePick={onTogglePick}
           onEditPick={onEditPick}


### PR DESCRIPTION
## Summary
- show incoming picks in team pick lists
- pass incoming picks down to pick list component

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885eb37879483269f91ea634cf4a15f