### PR TITLE
chore: simplify trade validator debug

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.debug.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.debug.js
@@ -1,5 +1,8 @@
 // tradeValidator.debug.js - Complete File Replacement
-import { validateTrade } from './tradeValidator';
+import { validateTrade, tradeDebug } from './tradeValidator';
+
+const debug = tradeDebug;
+debug.logs = [];
 
 // Helper function for cleaner salary formatting
 const formatSalary = (amount) => `$${(amount || 0).toLocaleString()}`;
@@ -219,35 +222,9 @@ function runTradeTest(testCase) {
   const teamResult = result.teamResults[0]; // First team only
 
   console.log(`\n=== ${testCase.description} ===`);
-  console.log(`Team: ${teamResult.team.teamName}`);
-
-  const outgoing = testCase.tradeData.teams[0].sends
-    .map(
-      (p) =>
-        `${p.name} ${formatSalary(p.contract_clean.salaries_by_year['2024'].salary)}`
-    )
-    .join(' + ');
-
-  const incoming = testCase.tradeData.teams[0].incomingPlayers
-    .map(
-      (p) =>
-        `${p.name} ${formatSalary(p.contract_clean.salaries_by_year['2024'].salary)}`
-    )
-    .join(' + ');
-
-  console.log(`OUT: ${outgoing}`);
-  console.log(`IN: ${incoming}`);
-  console.log(`Legal? ${result.overallLegal ? '✅' : '❌'}`);
-
-  if (teamResult.violations.length > 0) {
-    console.log(`Violation: ${teamResult.violations[0]}`);
-  }
-
-  // Verify test matches expected
-  if (result.overallLegal === testCase.expected.legal) {
-    console.log('✅ TEST PASSED (Matched expected result)');
-  } else {
-    console.error('❌ TEST FAILED (Did not match expected result)');
+  console.log(`Legal? ${result.overallLegal ? 'PASS' : 'FAIL'}`);
+  if (teamResult.violations.length) {
+    console.log(`Violation: ${teamResult.violations.join('; ')}`);
   }
 }
 
@@ -498,4 +475,5 @@ const testCases = [
 
 // ===== EXECUTE ALL TESTS =====
 console.log('=== NBA 2nd APRON TRADE VALIDATOR TESTS ===');
-[warriorsTrade, lakersTrade, bucksTrade].forEach(runTradeTest);
+testCases.forEach(runTradeTest);
+debug.flush();

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -3,41 +3,47 @@
 // ===== DEBUGGER =====
 const debug = {
   enabled: true,
+  logs: [],
 
-  logTrade: (team) => {
-    console.log(`\n=== VALIDATING ${team.teamName} ===`);
-    console.log(`Current Salary: $${team.team.totalSalary.toLocaleString()}`);
-    console.log(
+  write(msg) {
+    if (!this.enabled) return;
+    this.logs.push(msg);
+    console.log(msg);
+  },
+
+  logTrade(team) {
+    this.write(`\n=== ${team.teamName} ===`);
+    this.write(`Current Salary: $${team.team.totalSalary.toLocaleString()}`);
+    this.write(
       `Status: ${getApronStatus(team.team.totalSalary, team.context.capSettings)}`
     );
   },
 
-  logSalaries: (team) => {
-    console.log('\n🔢 SALARY BREAKDOWN:');
-    console.log('OUTGOING:');
+  logSalaries(team) {
+    this.write('Outgoing:');
     team.sends.forEach((p) => {
       const salary =
         p.contract_clean?.salaries_by_year?.[team.context.yearKey]?.salary || 0;
-      console.log(`- ${p.name}: $${salary.toLocaleString()}`);
+      this.write(`- ${p.name}: $${salary.toLocaleString()}`);
     });
 
-    console.log('\nINCOMING:');
+    this.write('Incoming:');
     team.incomingPlayers.forEach((p) => {
       const salary =
         p.contract_clean?.salaries_by_year?.[team.context.yearKey]?.salary || 0;
-      console.log(`- ${p.name}: $${salary.toLocaleString()}`);
+      this.write(`- ${p.name}: $${salary.toLocaleString()}`);
     });
 
-    console.log(
-      `\nTOTALS: OUT $${team.salaryOut.toLocaleString()} | IN $${team.salaryIn.toLocaleString()}`
+    this.write(
+      `Totals: OUT $${team.salaryOut.toLocaleString()} | IN $${team.salaryIn.toLocaleString()}`
     );
   },
 
-  logSecondApron: (team, violations) => {
+  logSecondApron(team, violations) {
     if (!team.overSecondApron && !team.willBeOverSecond) return;
 
-    console.log('\n🔴 SECOND APRON RULES:');
-    console.log(
+    this.write('Second Apron Rules:');
+    this.write(
       `Trade Type: ${team.sends.length}-for-${team.incomingPlayers.length}`
     );
 
@@ -45,21 +51,28 @@ const debug = {
       const outgoing =
         team.sends[0].contract_clean?.salaries_by_year?.[team.context.yearKey]
           ?.salary || 0;
-      console.log(
-        `\n1-TO-MANY RULE: No incoming > $${outgoing.toLocaleString()}`
-      );
+      this.write(`1-to-Many max incoming: $${outgoing.toLocaleString()}`);
     } else {
-      console.log('\nMANY-TO-MANY RULE: Incoming must pair with outgoing');
+      this.write('Many-to-Many: pair incoming with outgoing');
     }
 
     if (violations.length) {
-      console.log('\n🚨 VIOLATIONS:');
-      violations.forEach((v) => console.log(`- ${v}`));
+      this.write('Violations:');
+      violations.forEach((v) => this.write(`- ${v}`));
     } else {
-      console.log('\n✅ ALL RULES SATISFIED');
+      this.write('All rules satisfied');
+    }
+  },
+
+  async flush(file = 'trade-debug.txt') {
+    if (typeof process !== 'undefined' && process.versions?.node) {
+      const fs = await import('fs');
+      await fs.promises.writeFile(file, this.logs.join('\n'), 'utf8');
     }
   },
 };
+
+export { debug as tradeDebug };
 
 // ===== HELPERS =====
 const getApronStatus = (salary, { firstApron, secondApron } = {}) => {
@@ -97,11 +110,12 @@ const TRADE_RULES = {
       );
       const passes = team.salaryIn <= allowable;
 
-      console.log('\n💵 SALARY MATCHING:');
-      console.log(
+      debug.write('');
+      debug.write('Salary Matching:');
+      debug.write(
         `Allowed: $${allowable.toLocaleString()} | Actual: $${team.salaryIn.toLocaleString()}`
       );
-      console.log(passes ? '✅ PASS' : '❌ FAIL');
+      debug.write(passes ? 'PASS' : 'FAIL');
 
       return passes;
     },


### PR DESCRIPTION
## Summary
- clean up trade validator console output
- send debug logs to `trade-debug.txt`
- trim debug script output and run all cases

## Testing
- `npm install` *(fails: registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6886d620e0788326b812c3b1130fb67f