### PR TITLE
feat: enforce second apron trade rules

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -95,6 +95,8 @@ const getApronStatus = (salary, { firstApron, secondApron } = {}) => {
   return 'Below Aprons ✅';
 };
 
+const MAX_FUTURE_PICK_YEARS = 7;
+
 const calculateAllowableIncoming = (team, capSettings) => {
   const { totalSalary, salaryOut, overSecondApron, overFirstApron } = team;
   if (overSecondApron) return salaryOut;
@@ -147,6 +149,8 @@ const TRADE_RULES = {
       const violations = [];
       if (!team.overSecondApron && !team.willBeOverSecond) return true;
 
+      let aggregated = false;
+
       const outgoing = team.sends
         .map(
           (p) =>
@@ -166,35 +170,23 @@ const TRADE_RULES = {
       // 1-to-Many Rule
       if (team.sends.length === 1) {
         const maxOut = outgoing[0];
-        incoming.forEach((s, i) => {
-          if (s > maxOut) {
-            violations.push(
-              `${team.incomingPlayers[i]?.name} ($${s.toLocaleString()}) > outgoing ($${maxOut.toLocaleString()})`
-            );
-          }
+        incoming.forEach((s) => {
+          if (s > maxOut) aggregated = true;
         });
       }
       // Many-to-Many Rule
       incoming.forEach((s, i) => {
         const outgoingSalary = outgoing[i] || 0;
-        if (s > outgoingSalary) {
-          const incomingName = team.incomingPlayers[i]?.name || 'Unknown';
-          const outgoingName = team.sends[i]?.name || 'N/A';
-          const outgoingSalaryStr = outgoing[i]
-            ? `$${outgoingSalary.toLocaleString()}`
-            : 'No match';
-
-          violations.push(
-            `${incomingName} ($${s.toLocaleString()}) > ${outgoingName} (${outgoingSalaryStr})`
-          );
-        }
+        if (s > outgoingSalary) aggregated = true;
       });
+
+      if (aggregated) {
+        violations.push('Second apron team cannot aggregate salaries');
+      }
 
       // Total salary check
       if (team.salaryIn > team.salaryOut) {
-        violations.push(
-          `Total incoming > outgoing by $${(team.salaryIn - team.salaryOut).toLocaleString()}`
-        );
+        violations.push('Second apron team cannot receive more salary than sent');
       }
 
       team.secondApronViolations = violations;
@@ -202,6 +194,23 @@ const TRADE_RULES = {
       return violations.length === 0;
     },
     message: (team) => team.secondApronViolations.join('\n'),
+  },
+
+  cashRestrictions: {
+    test: (team) => {
+      if (!team.overSecondApron && !team.willBeOverSecond) return true;
+      return (team.cashSent || 0) === 0;
+    },
+    message: () => 'Second apron team cannot include cash in trades',
+  },
+
+  futurePicks: {
+    test: (team) => {
+      const limit = team.context.yearKey + MAX_FUTURE_PICK_YEARS;
+      return !(team.picksOut || []).some((p) => p.year > limit);
+    },
+    message: (team) =>
+      `Cannot trade picks beyond ${team.context.yearKey + MAX_FUTURE_PICK_YEARS} (7 years out)`,
   },
 };
 
@@ -229,6 +238,8 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       ...team,
       salaryOut,
       salaryIn,
+      picksOut: team.picksOut || [],
+      cashSent: team.cashSent || 0,
       projectedSalary: team.team.totalSalary - salaryOut + salaryIn,
       context: { capSettings, yearKey },
     };
@@ -244,6 +255,8 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       overSecondApron: currentStatus.includes('2nd APRON'),
       willBeOverSecond: projectedStatus.includes('2nd APRON'),
       context: { ...team.context, teams: initialTeams },
+      picksOut: team.picksOut,
+      cashSent: team.cashSent,
     };
   });
 

--- a/src/utils/architect/tradeMachine/tradeValidatorNewRules.js
+++ b/src/utils/architect/tradeMachine/tradeValidatorNewRules.js
@@ -53,16 +53,10 @@ export function validateDraftPicks(team, allTeams) {
     }
   }
 
-  // Second Apron Pick Restrictions
-  if (team.overSecondApron) {
-    const distantPicks = team.tradedPicks.filter(
-      (p) => p.year > currentYear + CBA_THRESHOLDS.STEPIEN_YEARS
-    );
-    if (distantPicks.length > 0) {
-      violations.push(
-        `Second apron team cannot trade picks beyond ${currentYear + CBA_THRESHOLDS.STEPIEN_YEARS}`
-      );
-    }
+  const limit = currentYear + CBA_THRESHOLDS.STEPIEN_YEARS;
+  const distantPicks = team.tradedPicks.filter((p) => p.year > limit);
+  if (distantPicks.length > 0) {
+    violations.push(`Cannot trade picks beyond ${limit} (7 years out)`);
   }
 
   return violations;
@@ -97,8 +91,8 @@ export function validateCash(team) {
     );
   }
 
-  if (team.overSecondApron && team.cashSent > 0) {
-    violations.push('Second apron teams cannot send cash');
+  if ((team.overSecondApron || team.willBeOverSecond) && team.cashSent > 0) {
+    violations.push('Second apron team cannot include cash in trades');
   }
 
   return violations;
@@ -144,6 +138,37 @@ export function validateBYC(team) {
   return violations;
 }
 
+export function validateSecondApronAggregation(team) {
+  const violations = [];
+  if (!team.overSecondApron && !team.willBeOverSecond) return violations;
+
+  const outgoing = team.sends.map((p) => p.salary || 0).sort((a, b) => b - a);
+  const incoming = team.incomingPlayers
+    .map((p) => p.salary || 0)
+    .sort((a, b) => b - a);
+
+  let aggregated = false;
+  if (team.sends.length === 1) {
+    const maxOut = outgoing[0];
+    incoming.forEach((s) => {
+      if (s > maxOut) aggregated = true;
+    });
+  } else {
+    incoming.forEach((s, i) => {
+      if (s > (outgoing[i] || 0)) aggregated = true;
+    });
+  }
+
+  if (aggregated) {
+    violations.push('Second apron team cannot aggregate salaries');
+  }
+  if (incoming.reduce((a, b) => a + b, 0) > outgoing.reduce((a, b) => a + b, 0)) {
+    violations.push('Second apron team cannot receive more salary than sent');
+  }
+
+  return violations;
+}
+
 // ===== MAIN VALIDATOR INTEGRATION =====
 export function validateAllNewRules(team, allTeams) {
   return [
@@ -153,5 +178,6 @@ export function validateAllNewRules(team, allTeams) {
     ...validateCash(team),
     ...validateSignAndTrade(team),
     ...validateBYC(team),
+    ...validateSecondApronAggregation(team),
   ];
 }

--- a/tests/tradeValidator.test.js
+++ b/tests/tradeValidator.test.js
@@ -169,10 +169,74 @@ describe('tradeValidator', () => {
     });
 
     expect(result.overallLegal).toBe(false);
-    expect(result.teamResults[0].legal).toBe(false);
-    expect(result.teamResults[0].reason).toContain(
-      '2nd Apron: Cannot aggregate multiple salaries'
+    expect(result.reason).toContain('Second apron team cannot aggregate salaries');
+  });
+
+  it('prevents second apron teams from taking back more salary', () => {
+    const teamA = makeTeam('A', 190_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const aPlayer = makePlayer('A1', 10_000_000);
+    const bPlayer = makePlayer('B1', 12_000_000);
+    teamA.players.push(aPlayer);
+    teamB.players.push(bPlayer);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [aPlayer], picksOut: [] },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    expect(result.overallLegal).toBe(false);
+    expect(result.reason).toContain(
+      'Second apron team cannot receive more salary than sent'
     );
+  });
+
+  it('blocks cash considerations for second apron teams', () => {
+    const teamA = makeTeam('A', 190_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const aPlayer = makePlayer('A1', 1_000_000);
+    const bPlayer = makePlayer('B1', 1_000_000);
+    teamA.players.push(aPlayer);
+    teamB.players.push(bPlayer);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [aPlayer], picksOut: [], cashSent: 1_000_000 },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    expect(result.overallLegal).toBe(false);
+    expect(result.reason).toContain(
+      'Second apron team cannot include cash in trades'
+    );
+  });
+
+  it('restricts trading picks more than 7 years out', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+
+    const result = validateTrade({
+      teams: [
+        {
+          team: teamA,
+          sends: [],
+          picksOut: [{ year: 2033, round: '1st' }],
+        },
+        { team: teamB, sends: [], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    expect(result.overallLegal).toBe(false);
+    expect(result.reason).toContain('Cannot trade picks beyond');
   });
 
   it('handles 3-team trades correctly', () => {


### PR DESCRIPTION
## Summary
- prevent salary aggregation and overages for second apron teams
- disallow cash when above the second apron
- block trading draft picks more than seven years out
- update tests for new restriction messages

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e9adb48c8326ad5f8ac14355db16