### PR TITLE
feat: validate trade exceptions

### DIFF
--- a/src/features/architect/tradeMachine/TradeExceptionModal.jsx
+++ b/src/features/architect/tradeMachine/TradeExceptionModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { formatCurrency } from '@/utils/architect/tradeHelpers';
+import { AlertTriangle } from 'lucide-react';
 
 const TradeExceptionModal = ({
   player,
@@ -13,9 +14,13 @@ const TradeExceptionModal = ({
   const playerSalary =
     player.contract_clean?.salaries_by_year?.[yearKey]?.salary || 0;
 
-  const availableTPEs = tradeExceptions.filter(
-    (tpe) => !tpe.isUsed && playerSalary <= tpe.amount
-  );
+  const enriched = tradeExceptions.map((tpe) => {
+    const remaining = typeof tpe.remaining === 'number' ? tpe.remaining : tpe.amount;
+    const expiry = tpe.expirationDate || tpe.expiry || tpe.expires;
+    const expired = expiry ? new Date(expiry) <= new Date() : false;
+    const tooSmall = remaining < playerSalary;
+    return { ...tpe, remaining, expired, tooSmall };
+  });
 
   return (
     <div className={`fixed inset-0 z-50 ${isOpen ? 'block' : 'hidden'}`}>
@@ -35,31 +40,39 @@ const TradeExceptionModal = ({
               </p>
 
               <div className="mt-4 space-y-2">
-                {availableTPEs.length > 0 ? (
-                  availableTPEs.map((tpe) => (
-                    <div
-                      key={tpe.id}
-                      className={`p-3 border rounded cursor-pointer ${
-                        selectedTPE?.id === tpe.id
-                          ? 'border-blue-500 bg-blue-500/10'
-                          : 'border-white/10 hover:border-white/30'
-                      }`}
-                      onClick={() => setSelectedTPE(tpe)}
-                    >
-                      <div className="flex justify-between">
-                        <span className="font-medium">
-                          {tpe.name || 'Trade Exception'}
-                        </span>
-                        <span>{formatCurrency(tpe.amount)}</span>
+                {enriched.length > 0 ? (
+                  enriched.map((tpe) => {
+                    const disabled = tpe.isUsed || tpe.tooSmall || tpe.expired;
+                    return (
+                      <div
+                        key={tpe.id}
+                        className={`p-3 border rounded relative cursor-pointer ${
+                          selectedTPE?.id === tpe.id
+                            ? 'border-blue-500 bg-blue-500/10'
+                            : tpe.tooSmall
+                              ? 'border-red-500 bg-red-500/10'
+                              : 'border-white/10 hover:border-white/30'
+                        } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                        onClick={() => !disabled && setSelectedTPE(tpe)}
+                      >
+                        <div className="flex justify-between items-center">
+                          <span className="font-medium">
+                            {tpe.name || 'Trade Exception'}
+                          </span>
+                          <span>{formatCurrency(tpe.remaining)}</span>
+                          {tpe.expired && (
+                            <AlertTriangle className="w-4 h-4 text-yellow-400 ml-2" />
+                          )}
+                        </div>
+                        <div className="text-xs text-white/60 mt-1">
+                          Expires: {tpe.expirationDate || tpe.expiry || tpe.expires || 'Unknown'}
+                        </div>
                       </div>
-                      <div className="text-xs text-white/60 mt-1">
-                        Expires: {tpe.expirationDate || 'Unknown'}
-                      </div>
-                    </div>
-                  ))
+                    );
+                  })
                 ) : (
                   <p className="text-sm text-white/60">
-                    No valid trade exceptions available
+                    No trade exceptions available
                   </p>
                 )}
               </div>
@@ -70,17 +83,27 @@ const TradeExceptionModal = ({
             <button
               type="button"
               className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white sm:ml-3 sm:w-auto sm:text-sm ${
-                selectedTPE
+                selectedTPE && !selectedTPE.tooSmall && !selectedTPE.expired && !selectedTPE.isUsed
                   ? 'bg-blue-600 hover:bg-blue-700'
                   : 'bg-gray-600 cursor-not-allowed'
               }`}
               onClick={() => {
-                if (selectedTPE) {
+                if (
+                  selectedTPE &&
+                  !selectedTPE.tooSmall &&
+                  !selectedTPE.expired &&
+                  !selectedTPE.isUsed
+                ) {
                   onApply(player, selectedTPE);
                   onClose();
                 }
               }}
-              disabled={!selectedTPE}
+              disabled={
+                !selectedTPE ||
+                selectedTPE.tooSmall ||
+                selectedTPE.expired ||
+                selectedTPE.isUsed
+              }
             >
               Apply Exception
             </button>

--- a/src/utils/architect/tradeMachine/tradeValidatorNewRules.js
+++ b/src/utils/architect/tradeMachine/tradeValidatorNewRules.js
@@ -18,15 +18,29 @@ export function validateTradeExceptions(team) {
 
   team.incomingPlayers.forEach((player) => {
     if (player.acquiredViaTPE) {
-      const tpe = team.tradeExceptions.find((e) => e.id === player.tpeId);
+      const index = team.tradeExceptions.findIndex((e) => e.id === player.tpeId);
+      const tpe = team.tradeExceptions[index];
       if (!tpe) {
         violations.push(`No valid TPE found for ${player.name}`);
-      } else if (tpe.remaining < player.salary) {
-        violations.push(
-          `TPE too small for ${player.name} ($${player.salary} > $${tpe.remaining})`
-        );
-      } else if (new Date() > tpe.expiry) {
-        violations.push(`TPE expired on ${tpe.expiry.toLocaleDateString()}`);
+      } else {
+        const remaining =
+          typeof tpe.remaining === 'number' ? tpe.remaining : tpe.amount;
+        const expiry = tpe.expiry || tpe.expirationDate;
+        const expired = expiry ? new Date(expiry) < new Date() : false;
+        if (remaining < player.salary) {
+          violations.push(
+            `TPE too small for ${player.name} ($${player.salary} > $${remaining})`
+          );
+        } else if (expired) {
+          const date = new Date(expiry);
+          violations.push(`TPE expired on ${date.toLocaleDateString()}`);
+        } else {
+          team.tradeExceptions[index] = {
+            ...tpe,
+            remaining: remaining - player.salary,
+            isUsed: true,
+          };
+        }
       }
     }
   });

--- a/tests/tradeExceptions.test.js
+++ b/tests/tradeExceptions.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { validateTradeExceptions } from '../src/utils/architect/tradeMachine/tradeValidatorNewRules.js';
+
+const futureDate = () => {
+  const d = new Date();
+  d.setDate(d.getDate() + 10);
+  return d.toISOString();
+};
+
+const pastDate = () => {
+  const d = new Date();
+  d.setDate(d.getDate() - 10);
+  return d.toISOString();
+};
+
+const makePlayer = (salary, tpeId) => ({
+  name: 'Player',
+  salary,
+  acquiredViaTPE: true,
+  tpeId,
+});
+
+const makeTeam = (tpe) => ({
+  incomingPlayers: [makePlayer(4_000_000, tpe.id)],
+  tradeExceptions: [tpe],
+});
+
+describe('validateTradeExceptions', () => {
+  it('allows valid TPE usage and marks it used', () => {
+    const tpe = { id: '1', amount: 5_000_000, remaining: 5_000_000, expiry: futureDate() };
+    const team = makeTeam(tpe);
+    const result = validateTradeExceptions(team);
+    expect(result).toEqual([]);
+    expect(team.tradeExceptions[0].isUsed).toBe(true);
+    expect(team.tradeExceptions[0].remaining).toBe(1_000_000);
+  });
+
+  it('detects expired TPE', () => {
+    const tpe = { id: '1', amount: 5_000_000, remaining: 5_000_000, expiry: pastDate() };
+    const team = makeTeam(tpe);
+    const result = validateTradeExceptions(team);
+    expect(result[0]).toMatch(/expired/);
+    expect(team.tradeExceptions[0].isUsed).toBeUndefined();
+  });
+
+  it('detects insufficient TPE amount', () => {
+    const tpe = { id: '1', amount: 3_000_000, remaining: 3_000_000, expiry: futureDate() };
+    const team = makeTeam(tpe);
+    const result = validateTradeExceptions(team);
+    expect(result[0]).toMatch(/TPE too small/);
+    expect(team.tradeExceptions[0].isUsed).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- expand trade exception logic to mark used TPEs and check size/expiry
- highlight invalid trade exceptions in `TradeExceptionModal`
- add unit tests covering valid, expired and insufficient TPEs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886f5a0282c832690952d345a029633