### PR TITLE
feat: enforce sign-and-trade rules

### DIFF
--- a/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
+++ b/src/features/architect/tradeMachine/OutgoingPlayersList.jsx
@@ -41,6 +41,11 @@ export const OutgoingPlayersList = ({
     [incomingPlayers]
   );
 
+  const signAndTradeActive = useMemo(
+    () => sends.some((p) => p.signAndTrade),
+    [sends]
+  );
+
   // Memoized sorted list
   const sortedAvailable = useMemo(() => {
     return available.slice().sort((a, b) => {
@@ -87,6 +92,7 @@ export const OutgoingPlayersList = ({
             setOpenMenu={setOpenMenu}
             setContractPlayer={setContractPlayer}
             tradeExceptions={tradeExceptions}
+            signAndTradeActive={signAndTradeActive}
           />
         ))}
         {available.length === 0 && (

--- a/src/features/architect/tradeMachine/TradePlayerRow.jsx
+++ b/src/features/architect/tradeMachine/TradePlayerRow.jsx
@@ -19,6 +19,7 @@ const TradePlayerRow = ({
   setOpenMenu,
   setContractPlayer,
   tradeExceptions = [],
+  signAndTradeActive = false,
 }) => {
   const menuRef = useRef(null);
   const buttonRef = useRef(null);
@@ -139,11 +140,17 @@ const TradePlayerRow = ({
         </div>
       </div>
 
-      {/* Traded Icon - unchanged */}
+      {/* Trade Indicator */}
       {incoming && (
-        <div className="ml-10 text-blue-300" title="Traded">
-          <ArrowsRightLeftIcon className="w-6 h-6" />
-        </div>
+        player.signAndTrade ? (
+          <div className="ml-10 text-blue-300 font-semibold text-sm" title="Sign-and-Trade">
+            S&amp;T
+          </div>
+        ) : (
+          <div className="ml-10 text-blue-300" title="Traded">
+            <ArrowsRightLeftIcon className="w-6 h-6" />
+          </div>
+        )
       )}
 
       {/* Contract Info - unchanged */}
@@ -193,7 +200,8 @@ const TradePlayerRow = ({
 
             {/* Sign-and-Trade Option */}
             {!included &&
-              !player.contract_clean?.salaries_by_year?.[yearKey]?.salary && (
+              !player.contract_clean?.salaries_by_year?.[yearKey]?.salary &&
+              (!signAndTradeActive || player.signAndTrade) && (
                 <button
                   onClick={() => {
                     onSetPlayerTrade(player, 'signAndTrade', otherTeams[0]?.id);

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -238,17 +238,27 @@ export function validateCash(team) {
 // SIGN-AND-TRADE RULES VALIDATION
 export function validateSignAndTrade(team) {
   const violations = [];
-  const sntPlayers = team.incomingPlayers.filter((p) => p.isSignAndTrade);
+  const sntPlayers = team.incomingPlayers.filter(
+    (p) => p.isSignAndTrade || p.signAndTrade
+  );
 
   if (sntPlayers.length > 0) {
-    // Hard cap check
-    if (team.projectedSalary > CBA_THRESHOLDS.FIRST_APRON) {
+    // Player must be traded alone
+    if (team.sends.length > 1) {
+      violations.push('Sign-and-trade player must be traded alone.');
+    }
+
+    // Hard cap check against dynamic first apron
+    const firstApron =
+      team.context.capSettings?.firstApron ?? CBA_THRESHOLDS.FIRST_APRON;
+    if (team.projectedSalary > firstApron) {
       violations.push('Sign-and-trade would hard-cap team at 1st apron');
     }
 
     // Contract length check
     sntPlayers.forEach((p) => {
-      if (p.contractYears < 3 || p.contractYears > 4) {
+      const years = p.contractYears ?? p.years ?? 0;
+      if (years < 3 || years > 4) {
         violations.push(`S&T contract for ${p.name} must be 3-4 years`);
       }
     });

--- a/tests/tradeValidator.test.js
+++ b/tests/tradeValidator.test.js
@@ -5,9 +5,15 @@ import capProjections from '../src/utils/architect/capProjections.js';
 
 const currentYear = 2025;
 
-const makePlayer = (name, salary, signAndTrade = false) => ({
+const makePlayer = (
+  name,
+  salary,
+  signAndTrade = false,
+  contractYears = 4
+) => ({
   name,
   signAndTrade,
+  contractYears,
   contract_clean: { salaries_by_year: { [currentYear]: { salary } } },
 });
 
@@ -93,6 +99,68 @@ describe('tradeValidator', () => {
     expect(result.teamResults[0].checks.signAndTrade).toBe(false);
     expect(result.teamResults[1].legal).toBe(true);
     expect(result.teamResults[1].checks.signAndTrade).toBe(true);
+  });
+
+  it('allows valid sign-and-trade deals', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const sat = makePlayer('Astar', 20_000_000, true, 4);
+    const bPlayer = makePlayer('Bstar', 15_000_000);
+    teamA.players.push(sat);
+    teamB.players.push(bPlayer);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    expect(result.overallLegal).toBe(true);
+  });
+
+  it('blocks sign-and-trade hard cap violations', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 195_500_000);
+    const sat = makePlayer('Astar', 20_000_000, true, 4);
+    const bPlayer = makePlayer('Bstar', 15_000_000);
+    teamA.players.push(sat);
+    teamB.players.push(bPlayer);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    expect(result.overallLegal).toBe(false);
+    expect(result.reason).toContain('hard-cap');
+  });
+
+  it('requires sign-and-trade contracts to be 3-4 years', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const sat = makePlayer('Astar', 10_000_000, true, 2);
+    const bPlayer = makePlayer('Bstar', 10_000_000);
+    teamA.players.push(sat);
+    teamB.players.push(bPlayer);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    expect(result.overallLegal).toBe(false);
+    expect(result.reason).toContain('must be 3-4 years');
   });
 
   it('detects Stepien Rule violations', () => {


### PR DESCRIPTION
## Summary
- validate sign-and-trade logic
- show S&T badge on traded players
- disable multi-player S&T selection
- expand sign-and-trade test coverage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887022c71d08326931b3de965fa2c19