### PR TITLE
feat: enhance Stepien rule logic

### DIFF
--- a/src/utils/architect/tradeMachine/pickOptions.js
+++ b/src/utils/architect/tradeMachine/pickOptions.js
@@ -5,6 +5,7 @@ export const getPickOptions = () => [
   { label: 'Protected Top 8', value: 'Top 8' },
   { label: 'Protected Top 10', value: 'Top 10' },
   { label: 'Lottery Protected', value: 'Lottery' },
+  { label: 'Protected Top 20', value: 'Top 20' },
   { label: 'Swap (+)', value: 'Swap (+)' },
   { label: 'Swap (-)', value: 'Swap (-)' },
 ];

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -2,7 +2,7 @@
 
 // ===== DEBUGGER =====
 const debug = {
-  enabled: true,
+  enabled: false,
   logs: [],
 
   /**
@@ -29,14 +29,14 @@ const debug = {
 
   logSalaries(team) {
     this.write('Outgoing:');
-    team.sends.forEach((p) => {
+    (team.sends || []).forEach((p) => {
       const salary =
         p.contract_clean?.salaries_by_year?.[team.context.yearKey]?.salary || 0;
       this.write(`  - ${p.name}: ${formatSalary(salary)}`);
     });
 
     this.write('Incoming:');
-    team.incomingPlayers.forEach((p) => {
+    (team.incomingPlayers || []).forEach((p) => {
       const salary =
         p.contract_clean?.salaries_by_year?.[team.context.yearKey]?.salary || 0;
       this.write(`  - ${p.name}: ${formatSalary(salary)}`);
@@ -103,6 +103,15 @@ const formatDate = (dateStr) => {
 };
 
 const formatSalary = (amount) => `$${(amount || 0).toLocaleString()}`;
+
+const isMeaningfulProtection = (protection) => {
+  if (!protection) return false;
+  return (
+    /top\s*[1-9]\d*/i.test(protection) ||
+    /lottery/i.test(protection) ||
+    /1-14/i.test(protection)
+  );
+};
 
 const getApronStatus = (salary, { firstApron, secondApron } = {}) => {
   if (secondApron && salary > secondApron) return 'ABOVE 2nd APRON 🔴';
@@ -176,22 +185,27 @@ export function validateDraftPicks(team, allTeams) {
   const violations = [];
   const currentYear = new Date().getFullYear();
 
-  // Stepien Rule (no consecutive 1sts)
-  const tradedFirsts = team.tradedPicks
-    .filter((p) => p.round === 1 && !p.isProtected)
-    .map((p) => p.year)
-    .sort();
+  const unprotectedYears = (team.tradedPicks || [])
+    .filter(
+      (p) =>
+        (p.round === 1 || p.round === '1st') &&
+        !p.isSwap &&
+        !isMeaningfulProtection(p.protection) &&
+        !p.via
+    )
+    .map((p) => parseInt(p.year, 10))
+    .sort((a, b) => a - b);
 
-  for (let i = 0; i < tradedFirsts.length - 1; i++) {
-    if (tradedFirsts[i + 1] === tradedFirsts[i] + 1) {
+  for (let i = 1; i < unprotectedYears.length; i++) {
+    if (unprotectedYears[i] === unprotectedYears[i - 1] + 1) {
       violations.push(
-        `Cannot trade ${tradedFirsts[i]} and ${tradedFirsts[i + 1]} 1st-round picks`
+        `Cannot trade ${unprotectedYears[i - 1]} and ${unprotectedYears[i]} 1st-round picks`
       );
     }
   }
 
   const limit = currentYear + CBA_THRESHOLDS.STEPIEN_YEARS;
-  const distantPicks = team.tradedPicks.filter((p) => p.year > limit);
+  const distantPicks = (team.tradedPicks || []).filter((p) => p.year > limit);
   if (distantPicks.length > 0) {
     violations.push(`Cannot trade picks beyond ${limit} (7 years out)`);
   }
@@ -477,6 +491,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       salaryOut,
       salaryIn,
       picksOut: team.picksOut || [],
+      tradedPicks: team.picksOut || [],
       cashSent: team.cashSent || 0,
       projectedSalary: team.team.totalSalary - salaryOut + salaryIn,
       context: { capSettings, yearKey },
@@ -494,6 +509,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       willBeOverSecond: projectedStatus.includes('2nd APRON'),
       context: { ...team.context, teams: initialTeams },
       picksOut: team.picksOut,
+      tradedPicks: team.tradedPicks,
       cashSent: team.cashSent,
     };
   });
@@ -527,6 +543,24 @@ export function validateTrade({ teams, capProjections, currentYear }) {
     reason:
       validatedTeams.flatMap((t) => t.violations).join('; ') || 'Valid trade',
   };
+}
+
+export function hasStepienViolation(picks = []) {
+  const years = picks
+    .filter(
+      (p) =>
+        (p.round === 1 || p.round === '1st') &&
+        !p.isSwap &&
+        !isMeaningfulProtection(p.protection) &&
+        !p.via
+    )
+    .map((p) => parseInt(p.year, 10))
+    .sort((a, b) => a - b);
+
+  for (let i = 1; i < years.length; i++) {
+    if (years[i] === years[i - 1] + 1) return true;
+  }
+  return false;
 }
 
 export { debug as tradeDebug };

--- a/tests/hasStepienViolation.test.js
+++ b/tests/hasStepienViolation.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { hasStepienViolation } from '../src/utils/architect/tradeMachine/tradeValidator.js';
 
 describe('hasStepienViolation', () => {
-  it('detects consecutive unprotected first round picks', () => {
+  it('fails on consecutive unprotected own picks', () => {
     const picks = [
       { year: 2026, round: '1st' },
       { year: 2027, round: '1st' },
@@ -10,26 +10,27 @@ describe('hasStepienViolation', () => {
     expect(hasStepienViolation(picks)).toBe(true);
   });
 
-  it('allows alternating unprotected firsts', () => {
+  it('passes when picks are protected', () => {
     const picks = [
-      { year: 2026, round: '1st' },
-      { year: 2028, round: '1st' },
+      { year: 2026, round: '1st', protection: 'Top 5' },
+      { year: 2027, round: '1st', protection: 'Lottery' },
     ];
     expect(hasStepienViolation(picks)).toBe(false);
   });
 
-  it('ignores protected picks when checking', () => {
-    const picks = [
-      { year: 2026, round: '1st', protection: 'Top 10' },
-      { year: 2027, round: '1st' },
-    ];
-    expect(hasStepienViolation(picks)).toBe(false);
-  });
-
-  it('ignores swapped picks when checking', () => {
+  it('ignores swap years', () => {
     const picks = [
       { year: 2026, round: '1st', isSwap: true },
-      { year: 2027, round: '1st' },
+      { year: 2027, round: '1st', isSwap: true },
+    ];
+    expect(hasStepienViolation(picks)).toBe(false);
+  });
+
+  it('handles mixed protected and unprotected picks', () => {
+    const picks = [
+      { year: 2026, round: '1st' },
+      { year: 2027, round: '1st', protection: 'Top 10' },
+      { year: 2028, round: '1st' },
     ];
     expect(hasStepienViolation(picks)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- expand pick protection options
- refine Stepien rule validation to ignore protected picks and swaps
- add targeted unit tests

## Testing
- `npx vitest tests/hasStepienViolation.test.js --run`

------
https://chatgpt.com/codex/tasks/task_e_6887077689288326937b291a62f2316e