### PR TITLE
feat: refine salary matching utils

### DIFF
--- a/src/features/architect/tradeMachine/TradeSalaryCalculator.jsx
+++ b/src/features/architect/tradeMachine/TradeSalaryCalculator.jsx
@@ -1,29 +1,47 @@
 import React, { useState, useEffect } from 'react';
-import { formatCurrency } from '@/utils/architect/tradeHelpers';
+import {
+  formatCurrency,
+  calculateAllowableIncoming,
+  getSalaryForYear,
+  MIN_SALARY,
+} from '@/utils/architect/tradeHelpers';
 
-const TradeSalaryCalculator = ({ teamSalary, outgoingSalary, capSettings }) => {
+const TradeSalaryCalculator = ({
+  teamSalary,
+  outgoingSalary,
+  incomingPlayers = [],
+  tpes = [],
+  capSettings,
+  yearKey,
+}) => {
   const [incomingSalary, setIncomingSalary] = useState(0);
   const [allowableIncoming, setAllowableIncoming] = useState(0);
+  const [breakdown, setBreakdown] = useState({
+    base: 0,
+    min: 0,
+    tpe: 0,
+  });
 
   useEffect(() => {
     if (!teamSalary || !capSettings) return;
 
-    const { cap } = capSettings;
-    const overCap = teamSalary > cap;
-    let allowable = 0;
-
-    if (!overCap) {
-      allowable = outgoingSalary + 250000 + Math.max(0, cap - teamSalary);
-    } else if (outgoingSalary < 6530000) {
-      allowable = outgoingSalary * 1.75 + 100000;
-    } else if (outgoingSalary < 19600000) {
-      allowable = outgoingSalary * 1.25 + 100000;
-    } else {
-      allowable = outgoingSalary * 1.25;
-    }
-
-    setAllowableIncoming(allowable);
-  }, [teamSalary, outgoingSalary, capSettings]);
+    const base = calculateAllowableIncoming(teamSalary, outgoingSalary, [], [], {
+      ...capSettings,
+      yearKey,
+    });
+    const min = teamSalary > capSettings.cap
+      ? incomingPlayers.reduce((sum, p) => {
+          const s = getSalaryForYear([p], yearKey);
+          return s <= MIN_SALARY ? sum + s : sum;
+        }, 0)
+      : 0;
+    const tpe = tpes.reduce(
+      (sum, t) => sum + (t.remaining ?? t.amount ?? 0),
+      0
+    );
+    setBreakdown({ base, min, tpe });
+    setAllowableIncoming(base + min + tpe);
+  }, [teamSalary, outgoingSalary, incomingPlayers, tpes, capSettings, yearKey]);
 
   const isValid = incomingSalary <= allowableIncoming;
 
@@ -51,6 +69,18 @@ const TradeSalaryCalculator = ({ teamSalary, outgoingSalary, capSettings }) => {
               {formatCurrency(allowableIncoming)}
             </div>
           </div>
+        </div>
+
+        <div className="text-xs text-white/70 space-y-1">
+          <div>Base: {formatCurrency(breakdown.base)}</div>
+          {breakdown.min > 0 && (
+            <div className="text-yellow-400">
+              Min Exception: +{formatCurrency(breakdown.min)}
+            </div>
+          )}
+          {breakdown.tpe > 0 && (
+            <div>Using TPE: +{formatCurrency(breakdown.tpe)}</div>
+          )}
         </div>
 
         <div>

--- a/src/utils/architect/tradeHelpers.js
+++ b/src/utils/architect/tradeHelpers.js
@@ -3,24 +3,34 @@
 // ======================
 // Salary Calculations
 // ======================
+export const MIN_SALARY = 1_119_563;
+
 export const getSalaryForYear = (players = [], year) =>
   players.reduce((sum, p) => {
-    const salaryFromContract =
-      p.contract_clean?.salaries_by_year?.[year]?.salary;
+    const yearData = p.contract_clean?.salaries_by_year?.[year] || {};
     const salaryFromMap = p.salaryByYear?.[year];
     const salary =
-      typeof salaryFromContract === 'number'
-        ? salaryFromContract
+      typeof yearData.salary === 'number'
+        ? yearData.salary
         : typeof salaryFromMap === 'number'
           ? salaryFromMap
-          : 0;
-    return sum + salary;
+          : typeof p.salary === 'number'
+            ? p.salary
+            : 0;
+    const likelyBonus =
+      yearData.bonuses?.likely ??
+      yearData.likelyIncentives ??
+      p.bonusesByYear?.[year]?.likely ??
+      0;
+    return sum + salary + likelyBonus;
   }, 0);
 
 export const calculateAllowableIncoming = (
   teamSalary,
   salaryOut,
-  { cap, firstApron, secondApron } = {}
+  incomingPlayers = [],
+  tpes = [],
+  { cap, firstApron, secondApron, yearKey } = {}
 ) => {
   firstApron = firstApron || Infinity;
   secondApron = secondApron || Infinity;
@@ -32,10 +42,27 @@ export const calculateAllowableIncoming = (
   if (overSecondApron) return salaryOut;
   if (overFirstApron) return salaryOut * 1.1;
 
-  if (!overCap) return salaryOut + 250000 + Math.max(0, cap - teamSalary);
-  if (salaryOut < 6530000) return salaryOut * 1.75 + 100000;
-  if (salaryOut < 19600000) return salaryOut * 1.25 + 100000;
-  return salaryOut * 1.25;
+  let allowable = 0;
+
+  if (!overCap)
+    allowable = salaryOut + 250000 + Math.max(0, cap - teamSalary);
+  else if (salaryOut < 6530000) allowable = salaryOut * 1.75 + 100000;
+  else if (salaryOut < 19600000) allowable = salaryOut * 1.25 + 100000;
+  else allowable = salaryOut * 1.25;
+
+  const tpeAmount = tpes.reduce(
+    (sum, t) => sum + (t.remaining ?? t.amount ?? 0),
+    0
+  );
+
+  const minException = overCap
+    ? incomingPlayers.reduce((sum, p) => {
+        const salary = getSalaryForYear([p], yearKey);
+        return salary <= MIN_SALARY ? sum + salary : sum;
+      }, 0)
+    : 0;
+
+  return allowable + tpeAmount + minException;
 };
 
 export const getApronStatus = (salary, { firstApron, secondApron } = {}) => {

--- a/tests/tradeHelpers.test.js
+++ b/tests/tradeHelpers.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   getSalaryForYear,
   areSamePick,
+  calculateAllowableIncoming,
+  MIN_SALARY,
 } from '../src/utils/architect/tradeHelpers.js';
 
 describe('getSalaryForYear', () => {
@@ -26,6 +28,17 @@ describe('getSalaryForYear', () => {
     };
     expect(getSalaryForYear([player], 2025)).toBe(6000000);
   });
+
+  it('includes likely bonuses in salary', () => {
+    const player = {
+      contract_clean: {
+        salaries_by_year: {
+          2025: { salary: 5000000, bonuses: { likely: 1000000, unlikely: 2000000 } },
+        },
+      },
+    };
+    expect(getSalaryForYear([player], 2025)).toBe(6000000);
+  });
 });
 
 describe('areSamePick', () => {
@@ -33,5 +46,21 @@ describe('areSamePick', () => {
     const a = { year: 2026, round: 1, via: 'LAL' };
     const b = { year: '2026', round: '1', via: 'LAL' };
     expect(areSamePick(a, b)).toBe(true);
+  });
+});
+
+describe('calculateAllowableIncoming', () => {
+  const settings = { cap: 150000000, firstApron: 190000000, secondApron: 200000000, yearKey: 2025 };
+
+  it('adds minimum salary exception when over cap', () => {
+    const player = { salary: MIN_SALARY };
+    const allowable = calculateAllowableIncoming(160000000, 0, [player], [], settings);
+    expect(allowable).toBeCloseTo(MIN_SALARY + 100000, 0);
+  });
+
+  it('includes TPE amounts', () => {
+    const tpe = { amount: 5000000 };
+    const allowable = calculateAllowableIncoming(160000000, 0, [], [tpe], settings);
+    expect(allowable).toBe(5100000); // 100k buffer + tpe
   });
 });


### PR DESCRIPTION
## Summary
- expand salary calculators with minimum salary rules and TPEs
- show allowance breakdown in `TradeSalaryCalculator`
- test salary helper updates

## Testing
- `npm test -- --run` *(fails: Terminating worker thread)*

------
https://chatgpt.com/codex/tasks/task_e_68870ca30ef48326be63dcb1933b6a6c