### PR TITLE
feat: add trade validation panel

### DIFF
--- a/src/features/architect/tradeMachine/TradeEditor.jsx
+++ b/src/features/architect/tradeMachine/TradeEditor.jsx
@@ -3,6 +3,7 @@ import { RotateCcw } from 'lucide-react';
 import { useTradeMachine } from '@/hooks/tradeMachine/useTradeMachine';
 import TradeTeamCard from './TradeTeamCard';
 import TradeSummaryPanel from './TradeSummaryPanel';
+import TradeValidationPanel from './TradeValidationPanel';
 import TradePreviewModal from './TradePreviewModal';
 import '../../../utils/architect/tradeMachine/tradeValidator.debug'; // Add near other imports
 
@@ -163,6 +164,7 @@ const TradeEditor = ({
         teams={teams}
         forceTrade={forceTrade}
       />
+      <TradeValidationPanel result={result} />
       <TradePreviewModal
         open={previewOpen && !!result}
         onClose={() => setPreviewOpen(false)}

--- a/src/features/architect/tradeMachine/TradeSummaryPanel.jsx
+++ b/src/features/architect/tradeMachine/TradeSummaryPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { formatCurrency } from '@/utils/architect/tradeHelpers';
+import { HelpCircle } from 'lucide-react';
 
 const getPickLabel = (p) => {
   let label = `${p.year} ${p.round} Round`;
@@ -7,12 +8,27 @@ const getPickLabel = (p) => {
   if (p.protection) label += ` 🛡 ${p.protection}`;
   if (p.isSwap) label += ' 🔁 Swap';
   if (p.note) label += ` 📝 ${p.note}`;
-  return label;
+  const color = p.protection ? 'text-yellow-300' : 'text-red-300';
+  return <span className={color}>{label}</span>;
 };
 
-const RuleExplanation = ({ rule, description }) => (
+const RuleExplanation = ({ rule, description, link }) => (
   <div className="mt-2 p-2 bg-[#222] rounded border border-white/10">
-    <strong className="text-sm">{rule}:</strong>
+    <strong className="text-sm flex items-center">
+      {rule}
+      {link && (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-1 text-white/70 hover:text-white"
+          title="View full CBA rule"
+        >
+          <HelpCircle size={14} />
+        </a>
+      )}
+      :
+    </strong>
     <p className="text-xs text-white/80 mt-1">{description}</p>
   </div>
 );
@@ -129,6 +145,16 @@ const TradeSummaryPanel = ({ result, teams, forceTrade }) => {
                     Projected Total:{' '}
                     {formatCurrency(teamResult.projectedSalary)}
                   </div>
+                  {teamResult.secondApronViolations?.length > 0 && (
+                    <div className="text-red-400 mt-1">
+                      {teamResult.secondApronViolations.join('; ')}
+                    </div>
+                  )}
+                  {teamResult.violations?.some((v) => /sign-and-trade/i.test(v)) && (
+                    <div className="text-red-400 mt-1">
+                      Sign-and-trade requirements not met
+                    </div>
+                  )}
                 </div>
               )}
             </div>
@@ -143,7 +169,18 @@ const TradeSummaryPanel = ({ result, teams, forceTrade }) => {
             {violatedRules.map((rule, i) => (
               <li key={i} className="flex items-start">
                 <span className="text-red-400 mr-2">•</span>
-                <span className="text-red-300 text-sm">{rule}</span>
+                <span className="text-red-300 text-sm flex items-center">
+                  {rule}
+                  <a
+                    href="https://nba.com/cba"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-1 text-white/70 hover:text-white"
+                    title="View full CBA rule"
+                  >
+                    <HelpCircle size={14} />
+                  </a>
+                </span>
               </li>
             ))}
           </ul>
@@ -156,18 +193,22 @@ const TradeSummaryPanel = ({ result, teams, forceTrade }) => {
           <RuleExplanation
             rule="Salary Matching (Over Cap)"
             description="Teams over the cap can take back 125% of outgoing salary + $100k (up to $6.5M outgoing), 175% + $100k (under $6.5M), or just 125% (over $19.6M)"
+            link="https://nba.com/cba/salary-matching"
           />
           <RuleExplanation
             rule="Second Apron Restrictions"
             description="Teams above the second apron cannot aggregate salaries in trades, take back more salary than they send, or include cash in trades"
+            link="https://nba.com/cba/second-apron"
           />
           <RuleExplanation
             rule="Sign-and-Trade"
             description="Sign-and-trade players must be traded alone, and receiving team cannot be above the first apron"
+            link="https://nba.com/cba/sign-and-trade"
           />
           <RuleExplanation
             rule="Stepien Rule"
             description="Teams cannot trade consecutive future first-round picks unless protected"
+            link="https://nba.com/cba/stepien-rule"
           />
         </div>
       </div>

--- a/src/features/architect/tradeMachine/TradeValidationPanel.jsx
+++ b/src/features/architect/tradeMachine/TradeValidationPanel.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { HelpCircle } from 'lucide-react';
+
+const RULE_INFO = [
+  {
+    pattern: /salary/i,
+    tip: 'Teams must match incoming and outgoing salary based on cap status.',
+    link: 'https://nba.com/cba/salary-matching',
+  },
+  {
+    pattern: /sign-and-trade/i,
+    tip: 'Sign-and-trade players must be traded alone and cannot push a team above the first apron.',
+    link: 'https://nba.com/cba/sign-and-trade',
+  },
+  {
+    pattern: /second apron/i,
+    tip: 'Second apron teams cannot aggregate salaries, take back more money, or include cash.',
+    link: 'https://nba.com/cba/second-apron',
+  },
+  {
+    pattern: /stepien/i,
+    tip: 'Teams may not trade consecutive future first-round picks unless protected.',
+    link: 'https://nba.com/cba/stepien-rule',
+  },
+];
+
+const getRuleInfo = (msg) => {
+  return RULE_INFO.find((r) => r.pattern.test(msg)) || {
+    tip: 'See full CBA documentation',
+    link: 'https://nba.com/cba',
+  };
+};
+
+const TradeValidationPanel = ({ result }) => {
+  if (!result) return null;
+  const { teamResults = [] } = result;
+
+  return (
+    <div className="mt-6 p-4 bg-[#111] border border-white/10 rounded space-y-4">
+      <h3 className="font-semibold text-base">Validation Results</h3>
+      {teamResults.map((team, idx) => (
+        <div key={idx}>
+          <h4 className="font-medium text-sm mb-1">{team.teamName}</h4>
+          <ul className="list-disc ml-5 space-y-1">
+            {team.violations.map((v, i) => {
+              const info = getRuleInfo(v);
+              return (
+                <li key={i} className="text-red-400 flex items-start">
+                  <span>{v}</span>
+                  <a
+                    href={info.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={info.tip}
+                    className="ml-1 text-white/70 hover:text-white"
+                  >
+                    <HelpCircle size={14} />
+                  </a>
+                </li>
+              );
+            })}
+            {team.apronStatus?.includes('⚠️') && (
+              <li className="text-yellow-400 flex items-start">
+                <span>{team.apronStatus}</span>
+                <HelpCircle
+                  size={14}
+                  className="ml-1"
+                  title="Team is near an apron threshold which may limit future moves"
+                />
+              </li>
+            )}
+          </ul>
+        </div>
+      ))}
+      <div className="text-xs text-white/60">
+        <p className="text-red-400">Red items are rule violations.</p>
+        <p className="text-yellow-400">Yellow items are warnings.</p>
+      </div>
+      <div className="border-t border-white/10 pt-3">
+        <h4 className="font-semibold text-sm mb-1">CBA References</h4>
+        <ul className="list-disc ml-5 text-blue-300 space-y-1 text-xs">
+          {RULE_INFO.map((r) => (
+            <li key={r.link}>
+              <a href={r.link} target="_blank" rel="noopener noreferrer">
+                {r.link.split('/cba/')[1].replace(/-/g, ' ')}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default TradeValidationPanel;


### PR DESCRIPTION
## Summary
- show CBA violations in new `TradeValidationPanel`
- highlight second apron and sign-and-trade issues in `TradeSummaryPanel`
- add help links and tooltips for CBA rules
- wire validation panel into `TradeEditor`

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'forEach'))*

------
https://chatgpt.com/codex/tasks/task_e_68871485f0bc8326833838ba01cdd173