### PR TITLE
feat: add Player Ranker feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import TierListsHome from '@/pages/TierListsHome';
 import RostersHome from '@/pages/RostersHome';
 import GmLeagueView from '@/pages/GmLeagueView';
 import GmDashboardView from '@/pages/GmDashboardView';
+import PlayerRankerPage from '@/pages/PlayerRankerPage';
 import SiteLayout from '@/components/layout/SiteLayout';
 import NotFound from '@/pages/NotFound';
 import ListPresentationView from '@/pages/ListPresentationView';
@@ -27,6 +28,7 @@ const App = () => {
         <Route path="/list-presentation" element={<ListPresentationView />} />
         <Route path="/tier-lists" element={<TierListsHome />} />
         <Route path="/tier-maker/:tierListId?" element={<TierMakerView />} />
+        <Route path="/player-ranker" element={<PlayerRankerPage />} />
         <Route path="/gm" element={<GmLeagueView />} />
         <Route path="/gm/:teamId" element={<GmDashboardView />} />
         <Route path="*" element={<NotFound />} />

--- a/src/features/ranker/PlayerCompareCard.jsx
+++ b/src/features/ranker/PlayerCompareCard.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PlayerHeadshot from '@/components/shared/PlayerHeadshot';
+import PlayerNameMini from '@/features/table/PlayerTable/PlayerRow/PlayerNameMini';
+
+const PlayerCompareCard = ({ left, right, onSelect, onSkip, onUndo }) => {
+  if (!left || !right) return null;
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="flex items-center gap-8">
+        <button
+          className="compare-button flex flex-col items-center"
+          onClick={() => onSelect(left, right)}
+        >
+          <PlayerHeadshot playerId={left.id} />
+          <PlayerNameMini name={left.display_name || left.name} />
+        </button>
+        <span className="text-xl font-bold text-white">vs</span>
+        <button
+          className="compare-button flex flex-col items-center"
+          onClick={() => onSelect(right, left)}
+        >
+          <PlayerHeadshot playerId={right.id} />
+          <PlayerNameMini name={right.display_name || right.name} />
+        </button>
+      </div>
+      <div className="flex gap-4 mt-4 text-sm text-white/70">
+        {onSkip && (
+          <button onClick={onSkip} className="hover:text-white">
+            Skip
+          </button>
+        )}
+        {onUndo && (
+          <button onClick={onUndo} className="hover:text-white">
+            Undo Last
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PlayerCompareCard;

--- a/src/features/ranker/RankingResults.jsx
+++ b/src/features/ranker/RankingResults.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PlayerHeadshot from '@/components/shared/PlayerHeadshot';
+import PlayerNameMini from '@/features/table/PlayerTable/PlayerRow/PlayerNameMini';
+
+const RankingResults = ({ ranking = [] }) => {
+  return (
+    <div className="mt-6 max-w-md mx-auto">
+      <h2 className="text-2xl font-bold mb-4 text-center">Your Rankings</h2>
+      <ol className="space-y-3">
+        {ranking.map((p, idx) => (
+          <li key={p.id} className="flex items-center gap-4 text-white">
+            <span className="w-6 text-right font-bold">{idx + 1}</span>
+            <PlayerHeadshot playerId={p.id} className="w-12 h-12" />
+            <PlayerNameMini name={p.display_name || p.name} width={120} />
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default RankingResults;

--- a/src/features/ranker/RankingSession.jsx
+++ b/src/features/ranker/RankingSession.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import PlayerCompareCard from './PlayerCompareCard';
+import RankingResults from './RankingResults';
+import {
+  generateRankingFromComparisons,
+  suggestNextPair,
+} from '@/utils/ranker/rankingEngine';
+
+const RankingSession = ({ playerPool = [] }) => {
+  const [currentPair, setCurrentPair] = useState([]);
+  const [results, setResults] = useState([]);
+  const [comparisonCount, setComparisonCount] = useState(0);
+  const totalNeeded = Math.max(playerPool.length * 2, 10);
+  const [isFinished, setIsFinished] = useState(false);
+
+  useEffect(() => {
+    if (playerPool.length >= 2) {
+      setCurrentPair(suggestNextPair([], playerPool));
+    }
+  }, [playerPool]);
+
+  const handleSelect = (winner, loser) => {
+    const newResults = [...results, { winner: winner.id, loser: loser.id }];
+    const newCount = comparisonCount + 1;
+    setResults(newResults);
+    setComparisonCount(newCount);
+    if (newCount >= totalNeeded) {
+      setIsFinished(true);
+    } else {
+      setCurrentPair(suggestNextPair(newResults, playerPool));
+    }
+  };
+
+  const handleSkip = () => {
+    setCurrentPair(suggestNextPair(results, playerPool));
+  };
+
+  const handleUndo = () => {
+    if (results.length === 0) return;
+    const newResults = results.slice(0, -1);
+    setResults(newResults);
+    setComparisonCount((c) => c - 1);
+    setIsFinished(false);
+    setCurrentPair(suggestNextPair(newResults, playerPool));
+  };
+
+  if (isFinished) {
+    const ranking = generateRankingFromComparisons(results, playerPool);
+    return <RankingResults ranking={ranking} />;
+  }
+
+  if (!currentPair.length) {
+    return <div className="text-white">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <PlayerCompareCard
+        left={currentPair[0]}
+        right={currentPair[1]}
+        onSelect={handleSelect}
+        onSkip={handleSkip}
+        onUndo={handleUndo}
+      />
+      <div className="mt-2 text-white/60 text-sm">
+        {comparisonCount} / {totalNeeded} comparisons
+      </div>
+    </div>
+  );
+};
+
+export default RankingSession;

--- a/src/features/ranker/ranker.css
+++ b/src/features/ranker/ranker.css
@@ -1,0 +1,3 @@
+.compare-button:active {
+  transform: scale(0.95);
+}

--- a/src/pages/PlayerRankerPage.jsx
+++ b/src/pages/PlayerRankerPage.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import usePlayerData from '@/hooks/usePlayerData.js';
+import RankingSession from '@/features/ranker/RankingSession';
+import '@/features/ranker/ranker.css';
+
+const PlayerRankerPage = () => {
+  const { players, loading } = usePlayerData();
+
+  if (loading) {
+    return <div className="p-4 text-white">Loading players...</div>;
+  }
+
+  return (
+    <div className="bg-neutral-900 min-h-screen text-white p-4">
+      <h1 className="text-3xl font-bold mb-4">Player Ranker</h1>
+      <RankingSession playerPool={players} />
+    </div>
+  );
+};
+
+export default PlayerRankerPage;

--- a/src/utils/ranker/rankingEngine.js
+++ b/src/utils/ranker/rankingEngine.js
@@ -1,0 +1,35 @@
+export function generateRankingFromComparisons(comparisons, players) {
+  const score = {};
+  players.forEach((p) => {
+    score[p.id] = 0;
+  });
+  comparisons.forEach((c) => {
+    score[c.winner] = (score[c.winner] || 0) + 1;
+  });
+  return players.slice().sort((a, b) => {
+    return (score[b.id] || 0) - (score[a.id] || 0);
+  });
+}
+
+export function suggestNextPair(comparisons, players) {
+  if (players.length < 2) return [];
+  const compared = new Set(
+    comparisons.map((c) => `${c.winner}-${c.loser}`)
+  );
+  let attempts = 0;
+  while (attempts < 100) {
+    const a = players[Math.floor(Math.random() * players.length)];
+    let b = players[Math.floor(Math.random() * players.length)];
+    if (b.id === a.id) {
+      attempts++;
+      continue;
+    }
+    const key1 = `${a.id}-${b.id}`;
+    const key2 = `${b.id}-${a.id}`;
+    if (!compared.has(key1) && !compared.has(key2)) {
+      return [a, b];
+    }
+    attempts++;
+  }
+  return [players[0], players[1]];
+}


### PR DESCRIPTION
## Summary
- add Player Ranker page and route
- implement ranking session workflow
- show side-by-side comparison cards
- compute rankings from pairwise selections
- basic styling for compare buttons

## Testing
- `npx vitest run --silent` *(fails: tradeValidator tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b0005e8288326af821194b196a7e5