### PR TITLE
fix: correctly track ranking progress

### DIFF
--- a/src/features/ranker/RankingSession.jsx
+++ b/src/features/ranker/RankingSession.jsx
@@ -13,17 +13,14 @@ const RankingSession = ({ playerPool = [] }) => {
   const [results, setResults] = useState([]);
   const [isFinished, setIsFinished] = useState(false);
 
-  const totalPairs = useMemo(() => {
-    return (playerPool.length * (playerPool.length - 1)) / 2;
-  }, [playerPool]);
-
   const remaining = useMemo(
     () => estimateRemainingComparisons(results, playerPool),
     [results, playerPool]
   );
 
-  const progressPercent = totalPairs
-    ? ((totalPairs - remaining) / totalPairs) * 100
+  const estimatedTotal = results.length + remaining;
+  const progressPercent = estimatedTotal
+    ? (results.length / estimatedTotal) * 100
     : 0;
 
   // Evaluate next pair every time results change
@@ -90,7 +87,7 @@ const RankingSession = ({ playerPool = [] }) => {
         </div>
       </div>
       <div className="mt-2 text-white/60 text-sm">
-        {results.length} / {totalPairs} comparisons
+        {results.length} / {estimatedTotal} comparisons
       </div>
       <ComparisonMatrix players={playerPool} comparisons={results} />
     </div>


### PR DESCRIPTION
## Summary
- base progress bar on completed vs estimated comparisons so it starts empty
- show dynamic comparison count during ranking

## Testing
- `npm run lint` (fails: Unnecessary escape character, __dirname undefined, etc.)
- `npm test` (fails: trade validator and helper tests)


------
https://chatgpt.com/codex/tasks/task_e_688f16194c4c83269bc7bbdefcd73fdf