### PR TITLE
feat: add architect trade rule stubs

### DIFF
--- a/src/utils/architect/tradeRules/hardCapRule.js
+++ b/src/utils/architect/tradeRules/hardCapRule.js
@@ -1,0 +1,4 @@
+// hardCapRule.js  – SCSP™ FULL FILE
+export default function hardCapRule(teamCtx, globalCtx) {
+  return { passes: true, violations: [] };
+}

--- a/src/utils/architect/tradeRules/salaryMatchingRule.js
+++ b/src/utils/architect/tradeRules/salaryMatchingRule.js
@@ -1,0 +1,4 @@
+// salaryMatchingRule.js  – SCSP™ FULL FILE
+export default function salaryMatchingRule(teamCtx, globalCtx) {
+  return { passes: true, violations: [] };
+}

--- a/src/utils/architect/tradeRules/secondApronRule.js
+++ b/src/utils/architect/tradeRules/secondApronRule.js
@@ -1,0 +1,4 @@
+// secondApronRule.js  – SCSP™ FULL FILE
+export default function secondApronRule(teamCtx, globalCtx) {
+  return { passes: true, violations: [] };
+}

--- a/src/utils/architect/tradeRules/signAndTradeRule.js
+++ b/src/utils/architect/tradeRules/signAndTradeRule.js
@@ -1,0 +1,4 @@
+// signAndTradeRule.js  – SCSP™ FULL FILE
+export default function signAndTradeRule(teamCtx, globalCtx) {
+  return { passes: true, violations: [] };
+}

--- a/src/utils/architect/tradeRules/stepienRule.js
+++ b/src/utils/architect/tradeRules/stepienRule.js
@@ -1,0 +1,4 @@
+// stepienRule.js  – SCSP™ FULL FILE
+export default function stepienRule(teamCtx, globalCtx) {
+  return { passes: true, violations: [] };
+}


### PR DESCRIPTION
## Summary
- scaffold architect trade rule stubs for salary matching, hard cap, sign-and-trade, second apron, and Stepien checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f41a4c2f0832685814fcc86a654ef