### PR TITLE
feat: add pre-ranking setup screen

### DIFF
--- a/src/features/ranker/RankingSession.jsx
+++ b/src/features/ranker/RankingSession.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import PlayerCompareCard from './PlayerCompareCard';
 import RankingResults from './RankingResults';
 import ComparisonMatrix from './ComparisonMatrix';
+import { RankingSetup } from './RankingSetup';
 import {
   generateRankingFromComparisons,
   suggestNextPair,
@@ -9,13 +10,18 @@ import {
 } from '@/utils/ranker/rankingEngine';
 
 const RankingSession = ({ playerPool = [] }) => {
+  const players = useMemo(
+    () => playerPool.map((p) => p.original || p),
+    [playerPool]
+  );
   const [currentPair, setCurrentPair] = useState([]);
   const [results, setResults] = useState([]);
   const [isFinished, setIsFinished] = useState(false);
+  const [setupData, setSetupData] = useState(null);
 
   const remaining = useMemo(
-    () => estimateRemainingComparisons(results, playerPool),
-    [results, playerPool]
+    () => estimateRemainingComparisons(results, players),
+    [results, players]
   );
 
   const estimatedTotal = results.length + remaining;
@@ -25,23 +31,24 @@ const RankingSession = ({ playerPool = [] }) => {
 
   // Evaluate next pair every time results change
   useEffect(() => {
-    if (playerPool.length < 2) return;
+    if (!setupData) return;
+    if (players.length < 2) return;
 
-    const next = suggestNextPair(results, playerPool);
+    const next = suggestNextPair(results, players);
     if (next.length === 0) {
       setIsFinished(true);
       setCurrentPair([]);
     } else {
       setCurrentPair(next);
     }
-  }, [results, playerPool]);
+  }, [results, players, setupData]);
 
   const handleSelect = (winner, loser) => {
     setResults((prev) => [...prev, { winner: winner.id, loser: loser.id }]);
   };
 
   const handleSkip = () => {
-    const next = suggestNextPair(results, playerPool);
+    const next = suggestNextPair(results, players);
     setCurrentPair(next);
   };
 
@@ -53,16 +60,39 @@ const RankingSession = ({ playerPool = [] }) => {
   };
 
   if (isFinished) {
-    const ranking = generateRankingFromComparisons(results, playerPool);
+    const ranking = generateRankingFromComparisons(results, players);
     return (
       <>
         <RankingResults ranking={ranking} />
         <div className="text-green-400 mt-4 text-center">
           ✅ All comparisons complete!
         </div>
-        <ComparisonMatrix players={playerPool} comparisons={results} />
+        <ComparisonMatrix players={players} comparisons={results} />
       </>
     );
+  }
+
+  if (!setupData) {
+    const handleComplete = (data) => {
+      setSetupData(data);
+
+      const initial = [];
+      if (data.firstPlace) {
+        players.forEach((p) => {
+          if (p.id !== data.firstPlace)
+            initial.push({ winner: data.firstPlace, loser: p.id });
+        });
+      }
+      if (data.lastPlace) {
+        players.forEach((p) => {
+          if (p.id !== data.lastPlace)
+            initial.push({ winner: p.id, loser: data.lastPlace });
+        });
+      }
+      if (initial.length) setResults(initial);
+    };
+
+    return <RankingSetup playerPool={players} onComplete={handleComplete} />;
   }
 
   if (!currentPair.length) {
@@ -89,7 +119,7 @@ const RankingSession = ({ playerPool = [] }) => {
       <div className="mt-2 text-white/60 text-sm">
         {results.length} / {estimatedTotal} comparisons
       </div>
-      <ComparisonMatrix players={playerPool} comparisons={results} />
+      <ComparisonMatrix players={players} comparisons={results} />
     </div>
   );
 };

--- a/src/features/ranker/RankingSetup.jsx
+++ b/src/features/ranker/RankingSetup.jsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+
+const PlayerButton = ({ player, selected, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`px-2 py-1 rounded border text-sm text-white ${
+      selected ? 'bg-blue-600 border-blue-400' : 'bg-white/10 border-white/20'
+    }`}
+  >
+    {player.display_name || player.name}
+  </button>
+);
+
+export const RankingSetup = ({ playerPool = [], onComplete }) => {
+  const [topTier, setTopTier] = useState([]);
+  const [bottomTier, setBottomTier] = useState([]);
+  const [anchor, setAnchor] = useState(null);
+  const [firstPlace, setFirstPlace] = useState(null);
+  const [lastPlace, setLastPlace] = useState(null);
+
+  const toggleMulti = (id, list, setter) => {
+    setter((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id].slice(0, 4)
+    );
+  };
+
+  const handleReady = () => {
+    onComplete({ topTier, bottomTier, anchor, firstPlace, lastPlace });
+  };
+
+  return (
+    <div className="text-white p-4 max-w-[700px] mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Pre-Ranking Setup</h2>
+
+      <div className="mb-4" data-testid="top-tier">
+        <h3 className="font-semibold mb-2">Top Tier Selector (2–4 players)</h3>
+        <div className="flex flex-wrap gap-2">
+          {playerPool.map((p) => (
+            <PlayerButton
+              key={`top-${p.id}`}
+              player={p}
+              selected={topTier.includes(p.id)}
+              onClick={() => toggleMulti(p.id, topTier, setTopTier)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-4" data-testid="bottom-tier">
+        <h3 className="font-semibold mb-2">Bottom Tier Selector (2–4 players)</h3>
+        <div className="flex flex-wrap gap-2">
+          {playerPool.map((p) => (
+            <PlayerButton
+              key={`bottom-${p.id}`}
+              player={p}
+              selected={bottomTier.includes(p.id)}
+              onClick={() => toggleMulti(p.id, bottomTier, setBottomTier)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-4" data-testid="anchor">
+        <h3 className="font-semibold mb-2">Anchor Selector</h3>
+        <div className="flex flex-wrap gap-2">
+          {playerPool.map((p) => (
+            <PlayerButton
+              key={`anchor-${p.id}`}
+              player={p}
+              selected={anchor === p.id}
+              onClick={() => setAnchor(anchor === p.id ? null : p.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-6 flex gap-8" data-testid="locks">
+        <div>
+          <h3 className="font-semibold mb-2">1st Place Lock-In</h3>
+          <select
+            value={firstPlace || ''}
+            onChange={(e) => setFirstPlace(e.target.value || null)}
+            className="bg-[#1a1a1a] text-white text-sm px-2 py-1 rounded border border-white/10"
+          >
+            <option value="">None</option>
+            {playerPool.map((p) => (
+              <option key={`first-${p.id}`} value={p.id}>
+                {p.display_name || p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2">Last Place Lock-In</h3>
+          <select
+            value={lastPlace || ''}
+            onChange={(e) => setLastPlace(e.target.value || null)}
+            className="bg-[#1a1a1a] text-white text-sm px-2 py-1 rounded border border-white/10"
+          >
+            <option value="">None</option>
+            {playerPool.map((p) => (
+              <option key={`last-${p.id}`} value={p.id}>
+                {p.display_name || p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <button
+        onClick={handleReady}
+        className="px-4 py-2 rounded bg-green-600 hover:bg-green-700"
+      >
+        Ready to Rank
+      </button>
+    </div>
+  );
+};
+
+export default RankingSetup;

--- a/tests/RankingSetup.test.jsx
+++ b/tests/RankingSetup.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { RankingSetup } from '@/features/ranker/RankingSetup.jsx';
+
+const samplePlayers = [
+  { id: '1', display_name: 'Alpha' },
+  { id: '2', display_name: 'Beta' },
+];
+
+describe('RankingSetup', () => {
+  it('captures selections and submits', () => {
+    const handle = vi.fn();
+    render(<RankingSetup playerPool={samplePlayers} onComplete={handle} />);
+    const top = screen.getByTestId('top-tier');
+    fireEvent.click(within(top).getByText('Alpha'));
+    fireEvent.click(screen.getByText('Ready to Rank'));
+    expect(handle).toHaveBeenCalledWith({
+      topTier: ['1'],
+      bottomTier: [],
+      anchor: null,
+      firstPlace: null,
+      lastPlace: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Pre-Ranking Setup for selecting top tier, bottom tier, anchor, and optional first/last place locks
- integrate setup data into ranking session and seed comparisons for locked placements
- test RankingSetup selections

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: POSITION_MAP is defined but never used, React must be in scope, __dirname is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6891b9ca12508326a922ce82703fccca