### PR TITLE
feat: add pre-ranking anchor comparison phase

### DIFF
--- a/src/features/ranker/AnchorComparison.jsx
+++ b/src/features/ranker/AnchorComparison.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+
+const PlayerButton = ({ player, selected, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`px-2 py-1 rounded border text-sm text-white ${
+      selected ? 'bg-blue-600 border-blue-400' : 'bg-white/10 border-white/20'
+    }`}
+  >
+    {player.display_name || player.name}
+  </button>
+);
+
+export const AnchorComparison = ({ anchor, players = [], onComplete }) => {
+  const [better, setBetter] = useState([]);
+
+  const toggle = (id) => {
+    setBetter((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+    );
+  };
+
+  const handleConfirm = () => {
+    onComplete(better);
+  };
+
+  return (
+    <div className="text-white p-4 max-w-[700px] mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Anchor Comparison</h2>
+      <h3 className="font-semibold mb-2">
+        Select all players better than {anchor.display_name || anchor.name}
+      </h3>
+      <div className="flex flex-wrap gap-2 mb-4">
+        {players.map((p) => (
+          <PlayerButton
+            key={p.id}
+            player={p}
+            selected={better.includes(p.id)}
+            onClick={() => toggle(p.id)}
+          />
+        ))}
+      </div>
+      <button
+        onClick={handleConfirm}
+        className="px-4 py-2 rounded bg-green-600 hover:bg-green-700"
+      >
+        Confirm
+      </button>
+    </div>
+  );
+};
+
+export default AnchorComparison;

--- a/src/features/ranker/RankingSession.jsx
+++ b/src/features/ranker/RankingSession.jsx
@@ -3,10 +3,12 @@ import PlayerCompareCard from './PlayerCompareCard';
 import RankingResults from './RankingResults';
 import ComparisonMatrix from './ComparisonMatrix';
 import { RankingSetup } from './RankingSetup';
+import { AnchorComparison } from './AnchorComparison';
 import {
   generateRankingFromComparisons,
   suggestNextPair,
   estimateRemainingComparisons,
+  buildAnchorComparisons,
 } from '@/utils/ranker/rankingEngine';
 
 const RankingSession = ({ playerPool = [] }) => {
@@ -18,6 +20,7 @@ const RankingSession = ({ playerPool = [] }) => {
   const [results, setResults] = useState([]);
   const [isFinished, setIsFinished] = useState(false);
   const [setupData, setSetupData] = useState(null);
+  const [anchorDone, setAnchorDone] = useState(false);
 
   const remaining = useMemo(
     () => estimateRemainingComparisons(results, players),
@@ -32,6 +35,7 @@ const RankingSession = ({ playerPool = [] }) => {
   // Evaluate next pair every time results change
   useEffect(() => {
     if (!setupData) return;
+    if (setupData.anchor && !anchorDone) return;
     if (players.length < 2) return;
 
     const next = suggestNextPair(results, players);
@@ -41,7 +45,7 @@ const RankingSession = ({ playerPool = [] }) => {
     } else {
       setCurrentPair(next);
     }
-  }, [results, players, setupData]);
+  }, [results, players, setupData, anchorDone]);
 
   const handleSelect = (winner, loser) => {
     setResults((prev) => [...prev, { winner: winner.id, loser: loser.id }]);
@@ -75,6 +79,7 @@ const RankingSession = ({ playerPool = [] }) => {
   if (!setupData) {
     const handleComplete = (data) => {
       setSetupData(data);
+      setAnchorDone(!data.anchor);
 
       const initial = [];
       if (data.firstPlace) {
@@ -93,6 +98,35 @@ const RankingSession = ({ playerPool = [] }) => {
     };
 
     return <RankingSetup playerPool={players} onComplete={handleComplete} />;
+  }
+
+  if (setupData?.anchor && !anchorDone) {
+    const anchorPlayer = players.find((p) => p.id === setupData.anchor);
+    const tagged = new Set([
+      ...setupData.topTier,
+      ...setupData.bottomTier,
+      setupData.firstPlace,
+      setupData.lastPlace,
+    ].filter(Boolean));
+    const untagged = players.filter(
+      (p) => p.id !== setupData.anchor && !tagged.has(p.id)
+    );
+    const handleAnchorComplete = (betterIds) => {
+      const newResults = buildAnchorComparisons(
+        setupData.anchor,
+        untagged,
+        betterIds
+      );
+      if (newResults.length) setResults((prev) => [...prev, ...newResults]);
+      setAnchorDone(true);
+    };
+    return (
+      <AnchorComparison
+        anchor={anchorPlayer}
+        players={untagged}
+        onComplete={handleAnchorComplete}
+      />
+    );
   }
 
   if (!currentPair.length) {

--- a/src/utils/ranker/rankingEngine.js
+++ b/src/utils/ranker/rankingEngine.js
@@ -174,6 +174,16 @@ export function estimateRemainingComparisons(comparisons, players) {
   return count;
 }
 
+// Build direct comparisons against an anchor player
+export function buildAnchorComparisons(anchorId, players, betterIds = []) {
+  const betterSet = new Set(betterIds);
+  return players.map((p) =>
+    betterSet.has(p.id)
+      ? { winner: p.id, loser: anchorId }
+      : { winner: anchorId, loser: p.id }
+  );
+}
+
 // ========== 🏁 FINAL RANKING LOGIC ==========
 
 // Topological sort using DFS

--- a/tests/AnchorComparison.test.jsx
+++ b/tests/AnchorComparison.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AnchorComparison } from '@/features/ranker/AnchorComparison.jsx';
+
+const players = [
+  { id: '1', display_name: 'Alpha' },
+  { id: '2', display_name: 'Beta' },
+];
+const anchor = { id: '3', display_name: 'Gamma' };
+
+describe('AnchorComparison', () => {
+  it('submits better player selections', () => {
+    const handle = vi.fn();
+    render(<AnchorComparison anchor={anchor} players={players} onComplete={handle} />);
+    fireEvent.click(screen.getByText('Alpha'));
+    fireEvent.click(screen.getByText('Confirm'));
+    expect(handle).toHaveBeenCalledWith(['1']);
+  });
+});

--- a/tests/buildAnchorComparisons.test.js
+++ b/tests/buildAnchorComparisons.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { buildAnchorComparisons } from '@/utils/ranker/rankingEngine.js';
+
+describe('buildAnchorComparisons', () => {
+  it('creates directional relationships against anchor', () => {
+    const players = [
+      { id: '1' },
+      { id: '2' },
+    ];
+    const comps = buildAnchorComparisons('A', players, ['1']);
+    expect(comps).toEqual([
+      { winner: '1', loser: 'A' },
+      { winner: 'A', loser: '2' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce AnchorComparison batch selector to compare players against chosen anchor before ranking
- incorporate anchor comparison phase and result handling in ranking session
- expose buildAnchorComparisons utility and accompanying tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891c038c8748326bfc76d6d842208ab