### PR TITLE
feat: enforce ranker group isolation

### DIFF
--- a/src/features/ranker/RankingSession.jsx
+++ b/src/features/ranker/RankingSession.jsx
@@ -22,9 +22,29 @@ const RankingSession = ({ playerPool = [] }) => {
   const [setupData, setSetupData] = useState(null);
   const [anchorDone, setAnchorDone] = useState(false);
 
+  const groupedPlayers = useMemo(() => {
+    if (!setupData || (setupData.anchor && !anchorDone)) return players;
+    const { topTier = [], bottomTier = [], anchor } = setupData;
+    const better = new Set();
+    if (anchor) {
+      results.forEach(({ winner, loser }) => {
+        if (loser === anchor) better.add(winner);
+      });
+    }
+    return players.map((p) => {
+      let group;
+      if (p.id === anchor) group = 'anchor';
+      else if (topTier.includes(p.id)) group = 'top';
+      else if (bottomTier.includes(p.id)) group = 'bottom';
+      else if (anchor) group = better.has(p.id) ? 'upper' : 'lower';
+      else group = 'upper';
+      return { ...p, group };
+    });
+  }, [players, setupData, results, anchorDone]);
+
   const remaining = useMemo(
-    () => estimateRemainingComparisons(results, players),
-    [results, players]
+    () => estimateRemainingComparisons(results, groupedPlayers),
+    [results, groupedPlayers]
   );
 
   const estimatedTotal = results.length + remaining;
@@ -36,23 +56,23 @@ const RankingSession = ({ playerPool = [] }) => {
   useEffect(() => {
     if (!setupData) return;
     if (setupData.anchor && !anchorDone) return;
-    if (players.length < 2) return;
+    if (groupedPlayers.length < 2) return;
 
-    const next = suggestNextPair(results, players);
+    const next = suggestNextPair(results, groupedPlayers);
     if (next.length === 0) {
       setIsFinished(true);
       setCurrentPair([]);
     } else {
       setCurrentPair(next);
     }
-  }, [results, players, setupData, anchorDone]);
+  }, [results, groupedPlayers, setupData, anchorDone]);
 
   const handleSelect = (winner, loser) => {
     setResults((prev) => [...prev, { winner: winner.id, loser: loser.id }]);
   };
 
   const handleSkip = () => {
-    const next = suggestNextPair(results, players);
+    const next = suggestNextPair(results, groupedPlayers);
     setCurrentPair(next);
   };
 
@@ -64,14 +84,18 @@ const RankingSession = ({ playerPool = [] }) => {
   };
 
   if (isFinished) {
-    const ranking = generateRankingFromComparisons(results, players, setupData);
+    const ranking = generateRankingFromComparisons(
+      results,
+      groupedPlayers,
+      setupData
+    );
     return (
       <>
         <RankingResults ranking={ranking} />
         <div className="text-green-400 mt-4 text-center">
           ✅ All comparisons complete!
         </div>
-        <ComparisonMatrix players={players} comparisons={results} />
+        <ComparisonMatrix players={groupedPlayers} comparisons={results} />
       </>
     );
   }
@@ -153,7 +177,7 @@ const RankingSession = ({ playerPool = [] }) => {
       <div className="mt-2 text-white/60 text-sm">
         {results.length} / {estimatedTotal} comparisons
       </div>
-      <ComparisonMatrix players={players} comparisons={results} />
+      <ComparisonMatrix players={groupedPlayers} comparisons={results} />
     </div>
   );
 };

--- a/src/utils/ranker/rankingEngine.js
+++ b/src/utils/ranker/rankingEngine.js
@@ -79,82 +79,148 @@ const getNextPhasePair = (players, comparisons) => {
   return [];
 };
 
-// Suggest next strategic pair
+// Suggest next strategic pair while respecting group isolation
 // ✅ SMART MATCHUP GENERATOR
 export function suggestNextPair(comparisons, players) {
   if (players.length < 2) return [];
 
-  // Build comparison lookup
-  const seen = new Set();
-  comparisons.forEach(({ winner, loser }) => {
-    seen.add(`${winner}->${loser}`);
-    seen.add(`${loser}->${winner}`); // Treat as compared, regardless of winner
-  });
+  // Helper to suggest a pair within a single group
+  const suggestInGroup = (groupPlayers) => {
+    if (groupPlayers.length < 2) return [];
+    const idSet = new Set(groupPlayers.map((p) => p.id));
+    const groupComps = comparisons.filter(
+      (c) => idSet.has(c.winner) && idSet.has(c.loser)
+    );
 
-  // Track how many times each player has appeared
-  const usageCount = {};
-  players.forEach((p) => (usageCount[p.id] = 0));
-  comparisons.forEach(({ winner, loser }) => {
-    usageCount[winner]++;
-    usageCount[loser]++;
-  });
+    const seen = new Set();
+    groupComps.forEach(({ winner, loser }) => {
+      seen.add(`${winner}->${loser}`);
+      seen.add(`${loser}->${winner}`);
+    });
 
-  // Build win graph
-  const graph = {};
-  players.forEach((p) => (graph[p.id] = new Set()));
-  comparisons.forEach(({ winner, loser }) => {
-    graph[winner].add(loser);
-  });
+    const usageCount = {};
+    groupPlayers.forEach((p) => (usageCount[p.id] = 0));
+    groupComps.forEach(({ winner, loser }) => {
+      usageCount[winner]++;
+      usageCount[loser]++;
+    });
 
-  // Transitive closure
-  const closure = {};
-  for (const a in graph) {
-    closure[a] = new Set();
-    const stack = [...graph[a]];
-    while (stack.length > 0) {
-      const next = stack.pop();
-      if (!closure[a].has(next)) {
-        closure[a].add(next);
-        graph[next]?.forEach((n) => stack.push(n));
+    const graph = {};
+    groupPlayers.forEach((p) => (graph[p.id] = new Set()));
+    groupComps.forEach(({ winner, loser }) => {
+      graph[winner].add(loser);
+    });
+
+    const closure = {};
+    for (const a in graph) {
+      closure[a] = new Set();
+      const stack = [...graph[a]];
+      while (stack.length > 0) {
+        const next = stack.pop();
+        if (!closure[a].has(next)) {
+          closure[a].add(next);
+          graph[next]?.forEach((n) => stack.push(n));
+        }
       }
+    }
+
+    // Phase 1: New vs New inside the group
+    const unused = groupPlayers.filter((p) => usageCount[p.id] === 0);
+    if (unused.length >= 2) {
+      for (let i = 0; i < unused.length; i++) {
+        for (let j = i + 1; j < unused.length; j++) {
+          const key = `${unused[i].id}->${unused[j].id}`;
+          if (!seen.has(key)) return [unused[i], unused[j]];
+        }
+      }
+    }
+
+    // Phase 2: Usage-balanced unresolved matchups
+    const unresolved = [];
+    for (let i = 0; i < groupPlayers.length; i++) {
+      for (let j = i + 1; j < groupPlayers.length; j++) {
+        const a = groupPlayers[i];
+        const b = groupPlayers[j];
+        const key = `${a.id}->${b.id}`;
+        const aBeatsB = closure[a.id]?.has(b.id);
+        const bBeatsA = closure[b.id]?.has(a.id);
+
+        if (!seen.has(key) && !aBeatsB && !bBeatsA) {
+          const usageGap = Math.abs(usageCount[a.id] - usageCount[b.id]);
+          const totalUsage = usageCount[a.id] + usageCount[b.id];
+          unresolved.push({
+            pair: [a, b],
+            score: totalUsage + usageGap * 2,
+          });
+        }
+      }
+    }
+
+    if (unresolved.length > 0) {
+      unresolved.sort((a, b) => a.score - b.score);
+      return unresolved[0].pair;
+    }
+
+    return [];
+  };
+
+  // Group players by tag (default group if undefined)
+  const groups = {};
+  players.forEach((p) => {
+    const g = p.group || 'default';
+    if (!groups[g]) groups[g] = [];
+    groups[g].push(p);
+  });
+
+  // Try to resolve matchups within each group first
+  for (const g of Object.keys(groups)) {
+    const pair = suggestInGroup(groups[g]);
+    if (pair.length) return pair;
+  }
+
+  // Compute boundary comparisons (top↔upper and lower↔bottom)
+  const rankGroup = (groupName) => {
+    const list = groups[groupName] || [];
+    if (list.length === 0) return [];
+    const idSet = new Set(list.map((p) => p.id));
+    const comps = comparisons.filter(
+      (c) => idSet.has(c.winner) && idSet.has(c.loser)
+    );
+    const graph = buildGraph(comps);
+    const visited = new Set();
+    const stack = [];
+    const dfs = (node) => {
+      if (visited.has(node)) return;
+      visited.add(node);
+      graph[node]?.forEach((n) => dfs(n));
+      stack.push(node);
+    };
+    list.forEach((p) => dfs(p.id));
+    const idMap = Object.fromEntries(list.map((p) => [p.id, p]));
+    return stack.reverse().map((id) => idMap[id]);
+  };
+
+  const topRanked = rankGroup('top');
+  const upperRanked = rankGroup('upper');
+  if (topRanked.length && upperRanked.length) {
+    const worstTop = topRanked[topRanked.length - 1];
+    const bestUpper = upperRanked[0];
+    if (!alreadyCompared(worstTop.id, bestUpper.id, comparisons)) {
+      return [worstTop, bestUpper];
     }
   }
 
-  // PHASE 1: New vs New (anchor building)
-  const unused = players.filter((p) => usageCount[p.id] === 0);
-  if (unused.length >= 2) {
-    for (let i = 0; i < unused.length; i++) {
-      for (let j = i + 1; j < unused.length; j++) {
-        const key = `${unused[i].id}->${unused[j].id}`;
-        if (!seen.has(key)) return [unused[i], unused[j]];
-      }
+  const lowerRanked = rankGroup('lower');
+  const bottomRanked = rankGroup('bottom');
+  if (lowerRanked.length && bottomRanked.length) {
+    const worstLower = lowerRanked[lowerRanked.length - 1];
+    const bestBottom = bottomRanked[0];
+    if (!alreadyCompared(worstLower.id, bestBottom.id, comparisons)) {
+      return [worstLower, bestBottom];
     }
   }
 
-  // PHASE 2: Usage-balanced unresolved matchups
-  const unresolved = [];
-  for (let i = 0; i < players.length; i++) {
-    for (let j = i + 1; j < players.length; j++) {
-      const a = players[i];
-      const b = players[j];
-      const key = `${a.id}->${b.id}`;
-      const aBeatsB = closure[a.id]?.has(b.id);
-      const bBeatsA = closure[b.id]?.has(a.id);
-
-      if (!seen.has(key) && !aBeatsB && !bBeatsA) {
-        const usageGap = Math.abs(usageCount[a.id] - usageCount[b.id]);
-        const totalUsage = usageCount[a.id] + usageCount[b.id];
-        unresolved.push({ pair: [a, b], score: totalUsage + usageGap * 2 });
-      }
-    }
-  }
-
-  if (unresolved.length > 0) {
-    unresolved.sort((a, b) => a.score - b.score);
-    return unresolved[0].pair;
-  }
-
-  // All pairs are resolved or inferred
+  // All groups resolved and boundaries checked
   return [];
 }
 

--- a/tests/rankingEngine.test.js
+++ b/tests/rankingEngine.test.js
@@ -51,4 +51,46 @@ describe('ranking engine', () => {
     });
     expect(ranking.map((p) => p.id)).toEqual(['1', '4', '3', '2', '5']);
   });
+
+  it('enforces group isolation with boundary stitching', () => {
+    const groupPlayers = [
+      { id: '1', name: 'T1', group: 'top' },
+      { id: '2', name: 'T2', group: 'top' },
+      { id: '3', name: 'U1', group: 'upper' },
+      { id: '4', name: 'U2', group: 'upper' },
+      { id: '5', name: 'A', group: 'anchor' },
+      { id: '6', name: 'L1', group: 'lower' },
+      { id: '7', name: 'L2', group: 'lower' },
+      { id: '8', name: 'B1', group: 'bottom' },
+      { id: '9', name: 'B2', group: 'bottom' },
+    ];
+
+    // First suggestion should be within a single group
+    const first = suggestNextPair([], groupPlayers);
+    expect(first[0].group).toBe(first[1].group);
+
+    // Resolve internal group matchups
+    const comps = [
+      { winner: '1', loser: '2' },
+      { winner: '3', loser: '4' },
+      { winner: '6', loser: '7' },
+      { winner: '8', loser: '9' },
+    ];
+
+    const boundary1 = suggestNextPair(comps, groupPlayers);
+    expect(new Set(boundary1.map((p) => p.group))).toEqual(
+      new Set(['top', 'upper'])
+    );
+    expect(boundary1.map((p) => p.id).sort()).toEqual(['2', '3']);
+    comps.push({ winner: boundary1[0].id, loser: boundary1[1].id });
+
+    const boundary2 = suggestNextPair(comps, groupPlayers);
+    expect(new Set(boundary2.map((p) => p.group))).toEqual(
+      new Set(['lower', 'bottom'])
+    );
+    expect(boundary2.map((p) => p.id).sort()).toEqual(['7', '8']);
+    comps.push({ winner: boundary2[0].id, loser: boundary2[1].id });
+
+    expect(suggestNextPair(comps, groupPlayers)).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- enforce group-aware pairing rules in ranking engine and add boundary checks
- tag players by tier during ranking session and feed grouped roster to engine
- test ranker for group isolation and stitching matchups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891ceb409648326920430b009b44421