### PR TITLE
fix: reset ranker progress

### DIFF
--- a/src/features/ranker/RankingSession.jsx
+++ b/src/features/ranker/RankingSession.jsx
@@ -47,9 +47,21 @@ const RankingSession = ({ playerPool = [] }) => {
     [results, groupedPlayers]
   );
 
-  const estimatedTotal = results.length + remaining;
-  const progressPercent = estimatedTotal
-    ? (results.length / estimatedTotal) * 100
+  const [comparisonTotal, setComparisonTotal] = useState(0);
+
+  useEffect(() => {
+    if (
+      comparisonTotal === 0 &&
+      setupData &&
+      (!setupData.anchor || anchorDone)
+    ) {
+      setComparisonTotal(remaining);
+    }
+  }, [comparisonTotal, setupData, anchorDone, remaining]);
+
+  const comparisonsDone = comparisonTotal ? comparisonTotal - remaining : 0;
+  const progressPercent = comparisonTotal
+    ? (comparisonsDone / comparisonTotal) * 100
     : 0;
 
   // Evaluate next pair every time results change
@@ -175,7 +187,7 @@ const RankingSession = ({ playerPool = [] }) => {
         </div>
       </div>
       <div className="mt-2 text-white/60 text-sm">
-        {results.length} / {estimatedTotal} comparisons
+        {comparisonsDone} / {comparisonTotal} comparisons
       </div>
       <ComparisonMatrix players={groupedPlayers} comparisons={results} />
     </div>


### PR DESCRIPTION
## Summary
- reset Player Ranker progress bar after setup so comparisons start from 0%
- track total comparisons remaining and display progress based only on user matchups

## Testing
- `npm run lint` *(fails: 'React' must be in scope when using JSX)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d7d28130832680b737f2e7f346f8