### PR TITLE
feat: improve PlayerRanker ordering and matrix drawer

### DIFF
--- a/src/features/ranker/ComparisonMatrix.jsx
+++ b/src/features/ranker/ComparisonMatrix.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ComparisonMatrix = ({ players, comparisons }) => {
+const ComparisonMatrix = ({ players, comparisons, className = '' }) => {
   const playerIds = players.map((p) => p.id);
   const comparisonMap = {};
 
@@ -15,7 +15,7 @@ const ComparisonMatrix = ({ players, comparisons }) => {
   });
 
   return (
-    <div className="overflow-x-auto mt-8 border border-white/10 rounded text-sm">
+    <div className={`overflow-x-auto mt-8 border border-white/10 rounded text-sm ${className}`}>
       <table className="border-collapse text-white">
         <thead>
           <tr>

--- a/src/features/ranker/ComparisonMatrixDrawer.jsx
+++ b/src/features/ranker/ComparisonMatrixDrawer.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import ComparisonMatrix from './ComparisonMatrix';
+
+const ComparisonMatrixDrawer = ({ players, comparisons }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          className="fixed bottom-2 right-2 z-30 p-1.5 rounded-full bg-black/30 hover:bg-black/50 text-white"
+          title="Show comparison matrix"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <rect x="3" y="3" width="7" height="7" />
+            <rect x="14" y="3" width="7" height="7" />
+            <rect x="14" y="14" width="7" height="7" />
+            <rect x="3" y="14" width="7" height="7" />
+          </svg>
+        </button>
+      )}
+      <div
+        className={`fixed inset-x-0 bottom-0 z-40 transition-transform duration-200 ${
+          open ? 'translate-y-0' : 'translate-y-full'
+        }`}
+      >
+        <div className="relative bg-[#1a1a1a] border-t border-white/10 max-h-[50vh] overflow-auto">
+          <button
+            onClick={() => setOpen(false)}
+            className="absolute top-2 right-2 p-1 text-white/60 hover:text-white"
+            title="Hide comparison matrix"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+          <ComparisonMatrix
+            players={players}
+            comparisons={comparisons}
+            className="mt-0"
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ComparisonMatrixDrawer;

--- a/src/features/ranker/RankingResults.jsx
+++ b/src/features/ranker/RankingResults.jsx
@@ -45,7 +45,7 @@ const RankingResults = ({ ranking = [] }) => {
           </button>
         </div>
       </div>
-      <ol className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+      <ol className="list-none columns-1 sm:columns-2 md:columns-3 lg:columns-4 gap-4">
         {ranking.map((p, idx) => {
           const headshot =
             p.headshot ||
@@ -54,7 +54,7 @@ const RankingResults = ({ ranking = [] }) => {
           return (
             <li
               key={p.id}
-              className="flex items-center h-10 px-2 bg-white/5 rounded text-white gap-2"
+              className="flex items-center h-10 px-2 mb-2 bg-white/5 rounded text-white gap-2 break-inside-avoid"
             >
               <span className="font-bold">#{idx + 1}</span>
               <img

--- a/src/features/ranker/RankingSession.jsx
+++ b/src/features/ranker/RankingSession.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import PlayerCompareCard from './PlayerCompareCard';
 import RankingResults from './RankingResults';
-import ComparisonMatrix from './ComparisonMatrix';
+import ComparisonMatrixDrawer from './ComparisonMatrixDrawer';
 import { RankingSetup } from './RankingSetup';
 import { AnchorComparison } from './AnchorComparison';
 import {
@@ -107,7 +107,7 @@ const RankingSession = ({ playerPool = [] }) => {
         <div className="text-green-400 mt-4 text-center">
           ✅ All comparisons complete!
         </div>
-        <ComparisonMatrix players={groupedPlayers} comparisons={results} />
+        <ComparisonMatrixDrawer players={groupedPlayers} comparisons={results} />
       </>
     );
   }
@@ -170,27 +170,29 @@ const RankingSession = ({ playerPool = [] }) => {
   }
 
   return (
-    <div className="flex flex-col items-center">
-      <PlayerCompareCard
-        left={currentPair[0]}
-        right={currentPair[1]}
-        onSelect={handleSelect}
-        onSkip={handleSkip}
-        onUndo={handleUndo}
-      />
-      <div className="w-full max-w-xs mt-4">
-        <div className="w-full bg-white/20 h-2 rounded-full">
-          <div
-            className="bg-green-500 h-2 rounded-full"
-            style={{ width: `${progressPercent}%` }}
-          />
+    <>
+      <div className="flex flex-col items-center pt-8">
+        <PlayerCompareCard
+          left={currentPair[0]}
+          right={currentPair[1]}
+          onSelect={handleSelect}
+          onSkip={handleSkip}
+          onUndo={handleUndo}
+        />
+        <div className="w-full max-w-xs mt-4">
+          <div className="w-full bg-white/20 h-2 rounded-full">
+            <div
+              className="bg-green-500 h-2 rounded-full"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        </div>
+        <div className="mt-2 text-white/60 text-sm">
+          {comparisonsDone} / {comparisonTotal} comparisons
         </div>
       </div>
-      <div className="mt-2 text-white/60 text-sm">
-        {comparisonsDone} / {comparisonTotal} comparisons
-      </div>
-      <ComparisonMatrix players={groupedPlayers} comparisons={results} />
-    </div>
+      <ComparisonMatrixDrawer players={groupedPlayers} comparisons={results} />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- order rankings vertically on desktop
- tuck comparison matrix into bottom drawer with toggle button
- add top padding before matchups for better vertical centering

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: player prop-types and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891f3eb1ff0832691fc261fcff3e4d6