### PR TITLE
fix: enforce 100 percent apron matching

### DIFF
--- a/src/features/architect/tradeMachine/TradeSalaryCalculator.jsx
+++ b/src/features/architect/tradeMachine/TradeSalaryCalculator.jsx
@@ -56,7 +56,7 @@ const TradeSalaryCalculator = ({
     if (teamSalary > capSettings.secondApron) {
       rule = 'Second Apron: Dollar-for-dollar matching';
     } else if (teamSalary > capSettings.firstApron) {
-      rule = 'First Apron: 110% of outgoing salary';
+      rule = 'First Apron: 100% of outgoing salary';
     } else if (teamSalary <= capSettings.cap) {
       rule = 'Under Cap: Outgoing + $100k + cap space';
     } else if (outgoingSalary <= 6_500_000) {

--- a/src/utils/architect/tradeHelpers.js
+++ b/src/utils/architect/tradeHelpers.js
@@ -71,9 +71,11 @@ export const getIncomingCeiling = (
   const tier = tiers.find((t) => salaryOut <= t.maxOutgoing) || tiers.at(-1);
   let ceiling = tier.incoming(salaryOut);
 
-  // 3️⃣ Second-Apron limiter – 110 % of outgoing
+  // 3️⃣ Apron limiters – 100 % of outgoing
   if (teamTotalSalary >= capSettings.secondApron) {
-    ceiling = salaryOut * 1.1;
+    ceiling = salaryOut;
+  } else if (teamTotalSalary >= capSettings.firstApron) {
+    ceiling = salaryOut;
   }
 
   // 4️⃣ Add any valid TPE amounts
@@ -113,6 +115,7 @@ function _calculateAllowableIncomingObj({
   currentTeamSalary,
   salaryOut,
   secondApronStatus,
+  firstApronStatus = false,
   yearKey,
   tpeAmount = 0,
 }) {
@@ -128,7 +131,12 @@ function _calculateAllowableIncomingObj({
   }
 
   const tier = tiers.find((t) => salaryOut <= t.maxOutgoing) || tiers.at(-1);
-  let ceiling = secondApronStatus ? salaryOut * 1.1 : tier.incoming(salaryOut);
+  let ceiling;
+  if (secondApronStatus || firstApronStatus) {
+    ceiling = salaryOut;
+  } else {
+    ceiling = tier.incoming(salaryOut);
+  }
   if (salaryOut === 0) ceiling = 0;
 
   const gross = ceiling + tpeAmount;
@@ -179,11 +187,16 @@ export const calculateAllowableIncoming = (...args) => {
     typeof capSettings.secondApron === 'number'
       ? currentTeamSalary >= capSettings.secondApron
       : false;
+  const firstApronStatus =
+    typeof capSettings.firstApron === 'number'
+      ? currentTeamSalary >= capSettings.firstApron
+      : false;
 
   return _calculateAllowableIncomingObj({
     currentTeamSalary,
     salaryOut,
     secondApronStatus,
+    firstApronStatus,
     yearKey,
     tpeAmount,
   }).margin;

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -453,6 +453,23 @@ const getMatchingValue = (player, yearKey, isOutgoing = false) => {
   return base;
 };
 
+const getAllowableIncomingMargin = (team) => {
+  const status = team.postTradeStatus || {};
+  if (status.isAtOrAboveSecondApron) return 0;
+  if (status.isAtOrAboveFirstApron) return 0;
+  return calculateAllowableIncoming(
+    team.teamTotalSalary,
+    team.salaryOut,
+    team.incomingPlayers,
+    team.tradeExceptions,
+    team.context.capSettings,
+    team.context.yearKey
+  );
+};
+
+export const getIncomingCeilingForTeam = (team) =>
+  team.salaryOut + getAllowableIncomingMargin(team);
+
 // ===== RULES =====
 const TRADE_RULES = {
   salaryMatching: {
@@ -466,14 +483,7 @@ const TRADE_RULES = {
       }
 
       // === INSERT in salary-matching section ===
-      const margin = calculateAllowableIncoming(
-        team.teamTotalSalary,
-        team.salaryOut,
-        team.incomingPlayers,
-        team.tradeExceptions,
-        team.context.capSettings,
-        team.context.yearKey
-      );
+      const margin = getAllowableIncomingMargin(team);
       const diff = team.salaryIn - team.salaryOut; // incoming minus outgoing
       const passes = diff <= margin && diff >= 0;
 
@@ -490,14 +500,7 @@ const TRADE_RULES = {
     },
 
     message: (team) => {
-      const margin = calculateAllowableIncoming(
-        team.teamTotalSalary,
-        team.salaryOut,
-        team.incomingPlayers,
-        team.tradeExceptions,
-        team.context.capSettings,
-        team.context.yearKey
-      );
+      const margin = getAllowableIncomingMargin(team);
       const allowable = team.salaryOut + margin;
       return (
         `Salary mismatch: Incoming ${formatCurrency(team.salaryIn)} ` +
@@ -620,14 +623,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       context,
     } = team;
 
-    const allowable = calculateAllowableIncoming(
-      teamTotalSalary,
-      salaryOut,
-      incomingPlayers,
-      tradeExceptions,
-      context.capSettings,
-      context.yearKey
-    );
+    const allowable = getAllowableIncomingMargin(team);
     const diff = salaryIn - salaryOut; // + if taking more back
 
     // can always send out more than comes back
@@ -680,7 +676,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
         )} > ${formatCurrency(firstApron)})`
       );
       parts.push(
-        `• Can take back 110% of outgoing: ${formatCurrency(salaryOut * 1.1)}`
+        `• Can only take back equal salary: ${formatCurrency(salaryOut)}`
       );
     } else if (teamSalary > cap) {
       parts.push(
@@ -948,8 +944,18 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       capSettings
     );
     const projectedStatus = getApronStatus(projectedSalary, capSettings);
+    const postTradeStatus = {
+      isAtOrAboveSecondApron:
+        typeof capSettings.secondApron === 'number'
+          ? projectedSalary >= capSettings.secondApron
+          : false,
+      isAtOrAboveFirstApron:
+        typeof capSettings.firstApron === 'number'
+          ? projectedSalary >= capSettings.firstApron
+          : false,
+    };
 
-    return {
+    const baseTeam = {
       teamId: team.team?.id,
       teamName: team.team?.teamName || 'Unknown Team',
       team: team.team,
@@ -965,6 +971,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       projectedRosterCount,
       currentApronStatus: currentStatus,
       projectedApronStatus: projectedStatus,
+      postTradeStatus,
       capSpace: (capSettings.cap || 0) - projectedSalary,
       totalSalary: teamTotalSalary,
       capRoom: (capSettings.cap || 0) - projectedSalary,
@@ -973,26 +980,16 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       cashReceived: cashReceived,
       tradeExceptions: team.team?.tradeExceptions || [],
       context: { capSettings, yearKey },
+    };
+
+    const allowableIncoming = getIncomingCeilingForTeam(baseTeam);
+
+    return {
+      ...baseTeam,
       calculations: {
         salaryMatching: {
-          allowableIncoming: calculateAllowableIncoming(
-            team.teamTotalSalary,
-            salaryOut,
-            incomingPlayers,
-            team.team?.tradeExceptions || [],
-            capSettings,
-            yearKey
-          ),
-          difference:
-            salaryIn -
-            calculateAllowableIncoming(
-              team.teamTotalSalary,
-              salaryOut,
-              incomingPlayers,
-              team.team?.tradeExceptions || [],
-              capSettings,
-              yearKey
-            ),
+          allowableIncoming,
+          difference: salaryIn - allowableIncoming,
         },
         apronStatus: {
           current: currentStatus,
@@ -1012,17 +1009,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
     };
 
     // --- Salary matching (2023 CBA + TPE)
-    const totalTPE = (team.tradeExceptions ?? []).reduce(
-      (sum, te) => sum + te.remaining,
-      0
-    );
-    const { ceiling: allowable } = calculateAllowableIncoming({
-      currentTeamSalary: team.teamTotalSalary,
-      salaryOut: team.salaryOut,
-      secondApronStatus: capStatus.isAboveSecond,
-      yearKey: seasonKey,
-      tpeAmount: totalTPE,
-    });
+    const allowable = getIncomingCeilingForTeam(team);
     const salaryPass = team.salaryIn <= allowable;
 
     // --- Cash limitations

--- a/tests/trade/firstApron_100pct.test.js
+++ b/tests/trade/firstApron_100pct.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { getIncomingCeilingForTeam } from '@/utils/architect/tradeMachine/tradeValidator.js';
+
+const capSettings = {
+  salaryCap: 141_000_000,
+  firstApron: 172_346_000,
+  secondApron: 182_794_000,
+};
+
+describe('apron matching ceiling', () => {
+  const base = {
+    salaryOut: 20_000_000,
+    incomingPlayers: [],
+    tradeExceptions: [],
+    context: { capSettings, yearKey: 2025 },
+  };
+
+  it('clamps first-apron teams to outgoing salary', () => {
+    const team = {
+      ...base,
+      teamTotalSalary: capSettings.firstApron,
+      postTradeStatus: {
+        isAtOrAboveFirstApron: true,
+        isAtOrAboveSecondApron: false,
+      },
+    };
+    expect(getIncomingCeilingForTeam(team)).toBe(20_000_000);
+  });
+
+  it('clamps second-apron teams to outgoing salary', () => {
+    const team = {
+      ...base,
+      teamTotalSalary: capSettings.secondApron,
+      postTradeStatus: {
+        isAtOrAboveFirstApron: true,
+        isAtOrAboveSecondApron: true,
+      },
+    };
+    expect(getIncomingCeilingForTeam(team)).toBe(20_000_000);
+  });
+});

--- a/tests/tradeSalaryMatching.test.js
+++ b/tests/tradeSalaryMatching.test.js
@@ -1,5 +1,5 @@
 /****************  SCSP™ BLOCK: tradeSalaryMatching.test.js  ****************
- * Validates 2025 tier math + 110 % apron limiter + margin return value
+ * Validates 2025 tier math + apron limiter + margin return value
  * ----------------------------------------------------------------------- */
 import { describe, it, expect } from 'vitest';
 import {
@@ -32,10 +32,10 @@ describe('CBA salary-matching tiers (2025)', () => {
     ); // 20 M + 5 M
   });
 
-  it('Second-apron teams capped at 110 %', () => {
+  it('Second-apron teams capped at 100 %', () => {
     expect(getIncomingCeiling(183_000_000, 25_000_000, [], capSettings)).toBe(
-      27_500_000
-    ); // 25 M × 1.10
+      25_000_000
+    ); // 25 M × 1.00
   });
 });
 


### PR DESCRIPTION
## Summary
- clamp first- and second-apron teams to equal outgoing salary during salary matching【F:src/utils/architect/tradeMachine/tradeValidator.js†L456-L472】【F:src/utils/architect/tradeMachine/tradeValidator.js†L947-L992】
- update UI label and helper to reflect 100% take-back limit【F:src/features/architect/tradeMachine/TradeSalaryCalculator.jsx†L56-L60】【F:src/utils/architect/tradeHelpers.js†L70-L79】
- add regression tests for first and second apron constraints【F:tests/trade/firstApron_100pct.test.js†L10-L40】【F:tests/tradeSalaryMatching.test.js†L1-L39】

## Testing
- `npm test`【02433a†L1-L18】

------
https://chatgpt.com/codex/tasks/task_e_6891f2466ae0832695e81028c4cde10f