### PR TITLE
feat: implement 2023 matching bands

### DIFF
--- a/src/utils/architect/cbaConstants.js
+++ b/src/utils/architect/cbaConstants.js
@@ -32,6 +32,20 @@ export const CBA_BY_YEAR = {
 export const getMatchingTiers = (year = 2025) =>
   CBA_BY_YEAR[year]?.matchingTiers || CBA_BY_YEAR[2025].matchingTiers;
 
+// Outgoing thresholds for band selection (symbolic; configured elsewhere)
+export const OUTGOING_BAND1_MAX = 'BAND1'; // placeholder token
+export const OUTGOING_BAND2_MAX = 'BAND2'; // placeholder token
+
+// Matching bands for teams below first apron (2023+):
+// A) S_out ≤ BAND1  ⇒ allowed = 200% * S_out + 250k
+// B) BAND1 < S_out ≤ BAND2 ⇒ allowed = S_out + 7.5M
+// C) S_out > BAND2  ⇒ allowed = 125% * S_out + 250k
+export const MATCHING_BANDS_2023 = [
+  { upTo: OUTGOING_BAND1_MAX, allowed: (out) => 2.0 * out + 250_000 },
+  { upTo: OUTGOING_BAND2_MAX, allowed: (out) => out + 7_500_000 },
+  { upTo: Infinity, allowed: (out) => 1.25 * out + 250_000 },
+];
+
 /* --------------------------------------------------------------------------
      Misc “structural” constants (unchanged)
   -------------------------------------------------------------------------- */

--- a/src/utils/architect/tradeHelpers.js
+++ b/src/utils/architect/tradeHelpers.js
@@ -4,10 +4,7 @@
  * areSamePick  (numeric leniency)
  * ▸ Keeps: MIN_SALARY, getApronStatus, pick utils, TPE utils, format helpers
  * -------------------------------------------------------------------------------*/
-import {
-  getMatchingTiers,
-  CBA_BY_YEAR,
-} from '@/utils/architect/cbaConstants.js';
+import { CBA_BY_YEAR, MATCHING_BANDS_2023 } from '@/utils/architect/cbaConstants.js';
 export { wouldExceedHardCap } from '@/utils/architect/hardCapUtils.js';
 
 export const getTierThresholds = (yearKey) => {
@@ -54,6 +51,17 @@ export const getSalaryForYear = (input, year) => {
 /*─────────────────────  Incoming-Salary (CBA rules)  ─────────────────────*/
 
 // ────────────────── Incoming-Salary Ceiling (CBA tiers) ──────────────────
+const allowedIncomingBelowFirstApron = (out, yearKey) => {
+  const [band1, band2] = getTierThresholds(yearKey);
+  const limits = [band1, band2, Infinity];
+  for (let i = 0; i < MATCHING_BANDS_2023.length; i++) {
+    const limit = limits[i];
+    if (out <= limit || limit === Infinity) {
+      return MATCHING_BANDS_2023[i].allowed(out);
+    }
+  }
+  return out;
+};
 export const getIncomingCeiling = (
   teamTotalSalary,
   salaryOut,
@@ -66,10 +74,8 @@ export const getIncomingCeiling = (
     return capSettings.salaryCap;
   }
 
-  // 2️⃣ Tiered matching rules pulled from constants
-  const tiers = getMatchingTiers(yearKey);
-  const tier = tiers.find((t) => salaryOut <= t.maxOutgoing) || tiers.at(-1);
-  let ceiling = tier.incoming(salaryOut);
+  // 2️⃣ Over-cap matching bands (below first apron)
+  let ceiling = allowedIncomingBelowFirstApron(salaryOut, yearKey);
 
   // 3️⃣ Apron limiters – 100 % of outgoing
   if (teamTotalSalary >= capSettings.secondApron) {
@@ -122,7 +128,6 @@ function _calculateAllowableIncomingObj({
   const year = String(yearKey);
   const capData = CBA_BY_YEAR[year] || {};
   const salaryCap = capData.salaryCap || 0;
-  const tiers = getMatchingTiers(year);
 
   if (currentTeamSalary < salaryCap) {
     const capSpace = salaryCap - currentTeamSalary;
@@ -130,12 +135,11 @@ function _calculateAllowableIncomingObj({
     return { ceiling: margin, margin };
   }
 
-  const tier = tiers.find((t) => salaryOut <= t.maxOutgoing) || tiers.at(-1);
   let ceiling;
   if (secondApronStatus || firstApronStatus) {
     ceiling = salaryOut;
   } else {
-    ceiling = tier.incoming(salaryOut);
+    ceiling = allowedIncomingBelowFirstApron(salaryOut, yearKey);
   }
   if (salaryOut === 0) ceiling = 0;
 

--- a/tests/trade/matchingBands_2023.test.js
+++ b/tests/trade/matchingBands_2023.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateAllowableIncoming,
+  getTierThresholds,
+} from '@/utils/architect/tradeHelpers.js';
+
+const [BAND1, BAND2] = getTierThresholds(2025);
+
+describe('2023 matching bands below first apron', () => {
+  const base = {
+    currentTeamSalary: 150_000_000,
+    secondApronStatus: false,
+    firstApronStatus: false,
+    yearKey: 2025,
+    tpeAmount: 0,
+  };
+
+  it('Band A up to BAND1: 200% + 250k', () => {
+    const { ceiling } = calculateAllowableIncoming({
+      ...base,
+      salaryOut: 5_000_000,
+    });
+    expect(ceiling).toBe(10_250_000);
+
+    const { ceiling: edge } = calculateAllowableIncoming({
+      ...base,
+      salaryOut: BAND1,
+    });
+    expect(edge).toBe(BAND1 * 2 + 250_000);
+  });
+
+  it('Band B between BAND1 and BAND2: +7.5M', () => {
+    const { ceiling } = calculateAllowableIncoming({
+      ...base,
+      salaryOut: 10_000_000,
+    });
+    expect(ceiling).toBe(17_500_000);
+
+    const { ceiling: edge } = calculateAllowableIncoming({
+      ...base,
+      salaryOut: BAND2,
+    });
+    expect(edge).toBe(BAND2 + 7_500_000);
+  });
+
+  it('Band C above BAND2: 125% + 250k', () => {
+    const { ceiling } = calculateAllowableIncoming({
+      ...base,
+      salaryOut: 25_000_000,
+    });
+    expect(ceiling).toBe(31_500_000);
+  });
+});
+

--- a/tests/tradeSalaryMatching.test.js
+++ b/tests/tradeSalaryMatching.test.js
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest';
 import {
   calculateAllowableIncoming,
   getIncomingCeiling,
-} from '@/utils/architect/tradeHelpers';
+} from '@/utils/architect/tradeHelpers.js';
 
 const capSettings = {
   salaryCap: 141_000_000,
@@ -14,22 +14,22 @@ const capSettings = {
 };
 
 describe('CBA salary-matching tiers (2025)', () => {
-  it('Tier 1 – ≤ $7.5 M uses 200 %', () => {
-    expect(getIncomingCeiling(150_000_000, 7_000_000, [], capSettings)).toBe(
-      14_000_000
-    ); // 7 M × 2.0
+  it('Band 1 – ≤ BAND1 uses 200% + $250k', () => {
+    expect(getIncomingCeiling(150_000_000, 6_000_000, [], capSettings)).toBe(
+      12_250_000
+    ); // 6 M × 2.0 + 0.25 M
   });
 
-  it('Tier 2 – 175 % + $100 k for $8-14.6 M', () => {
+  it('Band 2 – between thresholds adds $7.5 M', () => {
     expect(getIncomingCeiling(150_000_000, 10_000_000, [], capSettings)).toBe(
-      17_600_000
-    ); // 10 M × 1.75 + 0.1 M
+      17_500_000
+    ); // 10 M + 7.5 M
   });
 
-  it('Tier 3 – ≥ $14.62 M adds flat $5 M', () => {
+  it('Band 3 – above upper threshold uses 125% + $250k', () => {
     expect(getIncomingCeiling(150_000_000, 20_000_000, [], capSettings)).toBe(
-      25_000_000
-    ); // 20 M + 5 M
+      25_250_000
+    ); // 20 M × 1.25 + 0.25 M
   });
 
   it('Second-apron teams capped at 100 %', () => {
@@ -59,7 +59,7 @@ describe('calculateAllowableIncoming returns *margin*', () => {
       [],
       capSettings
     );
-    expect(margin).toBe(7_000_000); // 14 M ceiling – 7 M outgoing
+    expect(margin).toBe(7_500_000); // 14.5 M ceiling – 7 M outgoing
   });
 });
 /**************** END SCSP™ BLOCK: tradeSalaryMatching.test.js  *************/


### PR DESCRIPTION
## Summary
- add symbolic band thresholds and 2023 matching formulas
- compute allowed incoming using band table for below-first-apron teams
- cover new matching bands and boundaries in tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6892021168bc8326b5d550280ffa34a0