### PR TITLE
feat: enforce second apron handcuffs

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -196,6 +196,56 @@ const CBA_THRESHOLDS = {
 
 const MAX_FUTURE_PICK_YEARS = 7;
 
+// ===== SECOND APRON HANDCUFFS =====
+export function enforceSecondApronHandcuffs(teamCtx, tradeCtx = {}) {
+  const violations = [];
+  if (!teamCtx?.postTradeStatus?.isAtOrAboveSecondApron) return violations;
+
+  const outgoing = teamCtx.outgoingPlayers || [];
+  const incoming = teamCtx.incomingPlayers || [];
+  if (outgoing.length > 1 && incoming.length <= 1) {
+    violations.push('Second apron teams cannot aggregate salaries');
+  }
+
+  if (
+    teamCtx.cashSent > 0 ||
+    teamCtx.cashReceived > 0 ||
+    teamCtx.cashInvolved ||
+    tradeCtx.cashInvolved
+  ) {
+    violations.push('Second apron team cannot include cash in trades');
+  }
+
+  const season = teamCtx.context?.yearKey;
+  const usedTPEIds = new Set(
+    incoming
+      .filter((p) => p.acquiredViaTPE && p.tpeId)
+      .map((p) => p.tpeId)
+  );
+  if (usedTPEIds.size && season != null) {
+    (teamCtx.tradeExceptions || []).forEach((tpe) => {
+      const createdSeason =
+        tpe.createdSeason ||
+        tpe.createdAtSeason ||
+        tpe.season ||
+        (tpe.createdAt ? new Date(tpe.createdAt).getFullYear() : undefined);
+      if (
+        usedTPEIds.has(tpe.id) &&
+        createdSeason != null &&
+        createdSeason < season
+      ) {
+        violations.push('Second apron team cannot use prior-year trade exceptions');
+      }
+    });
+  }
+
+  if ((teamCtx.salaryIn || 0) > (teamCtx.salaryOut || 0)) {
+    violations.push('Second apron team cannot receive more salary than sent');
+  }
+
+  return violations;
+}
+
 // ===== TRADE EXCEPTION VALIDATION =====
 export function validateTradeExceptions(team) {
   const violations = [];
@@ -1003,6 +1053,8 @@ export function validateTrade({ teams, capProjections, currentYear }) {
 
   // Run all validations
   const validatedTeams = teamResults.map((team) => {
+    const handcuffViolations = enforceSecondApronHandcuffs(team, {});
+    const handcuffPass = handcuffViolations.length === 0;
     const seasonKey = team.context.yearKey;
     const capStatus = {
       isAboveSecond: team.currentApronStatus.includes('2nd Apron'),
@@ -1089,6 +1141,15 @@ export function validateTrade({ teams, capProjections, currentYear }) {
         : 'Hard cap exceeded (1st Apron)';
 
     const rules = {
+      secondApron: {
+        passed: handcuffPass,
+        message: handcuffPass
+          ? 'Second apron handcuffs satisfied'
+          : 'Second apron violation',
+        details:
+          handcuffViolations.join('; ') || 'Second apron restrictions',
+        violations: handcuffViolations,
+      },
       salaryMatching: {
         passed: salaryPass,
         message: salaryPass ? 'Salary match valid' : 'Salary mismatch',
@@ -1145,6 +1206,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
     };
 
     const violations = [
+      ...rules.secondApron.violations,
       ...rules.hardCap.violations,
       ...rules.salaryMatching.violations,
       ...rules.aggregation.violations,
@@ -1155,6 +1217,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       ...rules.tradeExceptions.violations,
     ];
     const teamPass =
+      handcuffPass &&
       salaryPass &&
       cashPass &&
       aggregationPass &&
@@ -1166,6 +1229,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       ...team,
       rules,
       checks: {
+        handcuffPass,
         salaryPass,
         cashPass,
         aggregationPass,

--- a/tests/trade/secondApron_handcuffs.test.js
+++ b/tests/trade/secondApron_handcuffs.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { enforceSecondApronHandcuffs } from '@/utils/architect/tradeMachine/tradeValidator.js';
+
+const baseTeam = {
+  context: { yearKey: 2025 },
+  postTradeStatus: { isAtOrAboveSecondApron: true },
+  tradeExceptions: [],
+  cashSent: 0,
+  cashReceived: 0,
+};
+
+const makePlayer = (salary = 0, extra = {}) => ({ salary, ...extra });
+
+describe('second apron handcuffs', () => {
+  it('rejects aggregation into one slot', () => {
+    const team = {
+      ...baseTeam,
+      outgoingPlayers: [makePlayer(10_000_000), makePlayer(10_000_000)],
+      incomingPlayers: [makePlayer(20_000_000)],
+      salaryOut: 20_000_000,
+      salaryIn: 20_000_000,
+    };
+    const v = enforceSecondApronHandcuffs(team, {});
+    expect(v[0]).toMatch(/aggregate/);
+  });
+
+  it('rejects cash inclusion', () => {
+    const team = {
+      ...baseTeam,
+      outgoingPlayers: [makePlayer(10_000_000)],
+      incomingPlayers: [makePlayer(10_000_000)],
+      salaryOut: 10_000_000,
+      salaryIn: 10_000_000,
+      cashSent: 1,
+    };
+    const v = enforceSecondApronHandcuffs(team, {});
+    expect(v[0]).toMatch(/cash/);
+  });
+
+  it('rejects prior-year TPE usage', () => {
+    const team = {
+      ...baseTeam,
+      outgoingPlayers: [makePlayer(10_000_000), makePlayer(5_000_000)],
+      incomingPlayers: [
+        makePlayer(10_000_000),
+        makePlayer(5_000_000, { acquiredViaTPE: true, tpeId: 'old' }),
+      ],
+      salaryOut: 15_000_000,
+      salaryIn: 15_000_000,
+      tradeExceptions: [{ id: 'old', amount: 5_000_000, createdSeason: 2024 }],
+    };
+    const v = enforceSecondApronHandcuffs(team, {});
+    expect(v[0]).toMatch(/prior-year/);
+  });
+
+  it('enforces 100% salary matching', () => {
+    const failTeam = {
+      ...baseTeam,
+      outgoingPlayers: [makePlayer(10_000_000)],
+      incomingPlayers: [makePlayer(10_000_001)],
+      salaryOut: 10_000_000,
+      salaryIn: 10_000_001,
+    };
+    const okTeam = {
+      ...baseTeam,
+      outgoingPlayers: [makePlayer(10_000_000)],
+      incomingPlayers: [makePlayer(10_000_000)],
+      salaryOut: 10_000_000,
+      salaryIn: 10_000_000,
+    };
+    expect(enforceSecondApronHandcuffs(failTeam, {}).length).toBeGreaterThan(0);
+    expect(enforceSecondApronHandcuffs(okTeam, {})).toEqual([]);
+  });
+});
+

--- a/tests/tradeValidator.test.js
+++ b/tests/tradeValidator.test.js
@@ -65,7 +65,7 @@ describe('tradeValidator', () => {
     expect(result.legal).toBe(false);
     expect(result.teamResults[0].legal).toBe(false);
     expect(result.teamResults[0].violations[0]).toContain(
-      'Hard cap exceeded (1st Apron)'
+      'Second apron team cannot receive more salary than sent'
     );
     expect(result.teamResults[0].rules.hardCap.passed).toBe(false);
   });


### PR DESCRIPTION
## Summary
- add enforceSecondApronHandcuffs helper and rule integration
- block second-apron aggregation, cash, prior-year TPE, and >100% salary
- cover second-apron edge cases with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68920ed8f97883269af17e118205701f