### PR TITLE
feat: handle poison pill average for incoming

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -490,12 +490,20 @@ function outgoingValueBYC({ newSalary, priorSalary }) {
  * -----------------------------------------------------------------------*/
 const getMatchingValue = (player, yearKey, isOutgoing = false) => {
   const base = getSalaryForYear(player, yearKey);
+  if (isOutgoing) {
+    if (player.isBYC)
+      return outgoingValueBYC({ newSalary: base, priorSalary: player.previousSalary });
+    if (player.isPoisonPill) return player.currentSalary || base; // PPP
+    return base;
+  }
 
-  if (!isOutgoing) return base; // incoming side – full value
-
-  if (player.isBYC)
-    return outgoingValueBYC({ newSalary: base, priorSalary: player.previousSalary });
-  if (player.isPoisonPill) return player.currentSalary || base; // PPP
+  if (player.isPoisonPill) {
+    const total =
+      (player.currentSalary ?? base) +
+      (player.extensionYears?.reduce((sum, y) => sum + (y.salary || 0), 0) || 0);
+    const years = 1 + (player.extensionYears?.length || 0);
+    return total / years;
+  }
 
   return base;
 };
@@ -514,11 +522,17 @@ export function computeMatchingValues({ teams = [], yearKey }) {
       } else if (player.isPoisonPill && player.currentSalary) {
         outgoing = player.currentSalary;
       }
-      // TODO: trade kicker proration
       player.matchOutgoing = outgoing;
 
       let incoming = newSalary;
-      // TODO: poison-pill average, trade-kicker proration
+      if (player.isPoisonPill) {
+        const total =
+          (player.currentSalary ?? newSalary) +
+          (player.extensionYears?.reduce((sum, y) => sum + (y.salary || 0), 0) || 0);
+        const years = 1 + (player.extensionYears?.length || 0);
+        incoming = total / years;
+      }
+      // TODO: trade kicker proration
       player.matchIncoming = incoming;
     });
   });

--- a/tests/trade/poisonPill_average.test.js
+++ b/tests/trade/poisonPill_average.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computeMatchingValues } from '@/utils/architect/tradeMachine/tradeValidator.js';
+
+const yearKey = 2025;
+
+const makePlayer = ({ currentSalary, extensionYears = [], isBYC = false, previousSalary, newSalary }) => ({
+  name: 'PP Player',
+  isPoisonPill: true,
+  currentSalary,
+  extensionYears,
+  isBYC,
+  previousSalary,
+  contract_clean: {
+    salaries_by_year: {
+      [yearKey]: { salary: newSalary ?? (extensionYears[0]?.salary ?? currentSalary) },
+    },
+  },
+});
+
+describe('Poison Pill matching values', () => {
+  it('uses average of current plus extension for incoming', () => {
+    const player = makePlayer({
+      currentSalary: 4_000_000,
+      extensionYears: [
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+      ],
+    });
+    computeMatchingValues({ teams: [{ sends: [player] }], yearKey });
+    expect(player.matchOutgoing).toBe(4_000_000);
+    expect(player.matchIncoming).toBe(8_500_000);
+  });
+
+  it('defaults to current salary when no extension years', () => {
+    const player = makePlayer({ currentSalary: 4_000_000 });
+    computeMatchingValues({ teams: [{ sends: [player] }], yearKey });
+    expect(player.matchOutgoing).toBe(4_000_000);
+    expect(player.matchIncoming).toBe(4_000_000);
+  });
+
+  it('coexists with BYC for outgoing', () => {
+    const player = makePlayer({
+      currentSalary: 4_000_000,
+      extensionYears: [
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+      ],
+      isBYC: true,
+      previousSalary: 4_000_000,
+      newSalary: 10_000_000,
+    });
+    computeMatchingValues({ teams: [{ sends: [player] }], yearKey });
+    expect(player.matchOutgoing).toBe(5_000_000); // BYC max(prior, 50% new)
+    expect(player.matchIncoming).toBe(8_500_000);
+  });
+});
+


### PR DESCRIPTION
## Summary
- factor poison-pill contracts into matching values, averaging current salary with extension years for recipients
- ensure poison-pill sends count current-year salary while BYC still applies to outgoing
- test poison-pill scenarios including BYC coexistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689221772d488326a482d780149a1821