### PR TITLE
feat: apply poison pill incoming average

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -518,7 +518,15 @@ export function computeMatchingValues({ teams = [], yearKey }) {
       player.matchOutgoing = outgoing;
 
       let incoming = newSalary;
-      // TODO: poison-pill average, trade-kicker proration
+      if (player.isPoisonPill) {
+        const ext = player.extensionYears ?? [];
+        const total =
+          (player.currentSalary ?? newSalary) +
+          ext.reduce((sum, y) => sum + (y.salary || 0), 0);
+        const years = 1 + ext.length;
+        incoming = total / years;
+      }
+      // TODO: trade kicker proration
       player.matchIncoming = incoming;
     });
   });

--- a/tests/trade/poisonPill_average.test.js
+++ b/tests/trade/poisonPill_average.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { computeMatchingValues } from '@/utils/architect/tradeMachine/tradeValidator.js';
+
+const yearKey = 2025;
+
+function makePoisonPill({ currentSalary, extensionYears }) {
+  return {
+    name: 'Poison Pill Player',
+    isPoisonPill: true,
+    currentSalary,
+    contract_clean: {
+      salaries_by_year: {
+        [yearKey]: { salary: currentSalary },
+      },
+    },
+    ...(extensionYears ? { extensionYears } : {}),
+  };
+}
+
+describe('Poison Pill matching values', () => {
+  it('averages current and extension years for incoming', () => {
+    const player = makePoisonPill({
+      currentSalary: 4_000_000,
+      extensionYears: [
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+      ],
+    });
+    computeMatchingValues({ teams: [{ sends: [player] }], yearKey });
+    expect(player.matchOutgoing).toBe(4_000_000);
+    expect(player.matchIncoming).toBe(8_500_000);
+  });
+
+  it('falls back to current salary when extension years missing', () => {
+    const player = makePoisonPill({ currentSalary: 5_000_000 });
+    computeMatchingValues({ teams: [{ sends: [player] }], yearKey });
+    expect(player.matchOutgoing).toBe(5_000_000);
+    expect(player.matchIncoming).toBe(5_000_000);
+  });
+
+  it('coexists with BYC on outgoing while using poison pill average for incoming', () => {
+    const player = {
+      name: 'BYC Poison Pill',
+      isBYC: true,
+      previousSalary: 8_000_000,
+      isPoisonPill: true,
+      currentSalary: 4_000_000,
+      extensionYears: [
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+        { salary: 10_000_000 },
+      ],
+      contract_clean: {
+        salaries_by_year: {
+          [yearKey]: { salary: 30_000_000 },
+        },
+      },
+    };
+    computeMatchingValues({ teams: [{ sends: [player] }], yearKey });
+    expect(player.matchOutgoing).toBe(15_000_000);
+    expect(player.matchIncoming).toBe(8_500_000);
+  });
+});


### PR DESCRIPTION
## Summary
- handle poison pill trades by averaging current salary and extension years when computing incoming matching value【F:src/utils/architect/tradeMachine/tradeValidator.js†L506-L530】
- cover poison pill averaging scenarios, including BYC coexistence, with new tests【F:tests/trade/poisonPill_average.test.js†L20-L63】

## Testing
- `npm test`【eb3110†L1-L9】

------
https://chatgpt.com/codex/tasks/task_e_6892241e9f648326bb08057fa1f82bd6