### PR TITLE
feat: handle trade kicker proration

### DIFF
--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -508,7 +508,18 @@ const getMatchingValue = (player, yearKey, isOutgoing = false) => {
   return base;
 };
 
-export function computeMatchingValues({ teams = [], yearKey }) {
+export function computeMatchingValues({
+  teams = [],
+  yearKey,
+  daysRemainingInSeason,
+  daysInSeason,
+} = {}) {
+  const proration =
+    Math.min(
+      Math.max((daysRemainingInSeason ?? 0) / (daysInSeason ?? 0), 0),
+      1
+    ) || 1;
+
   teams.forEach((team) => {
     (team.sends || []).forEach((player) => {
       const newSalary = getSalaryForYear(player, yearKey);
@@ -532,7 +543,19 @@ export function computeMatchingValues({ teams = [], yearKey }) {
         const years = 1 + (player.extensionYears?.length || 0);
         incoming = total / years;
       }
-      // TODO: trade kicker proration
+
+      const pct = Math.min(player.tradeKickerPct ?? 0, 0.15);
+      const waived = Math.min(
+        Math.max(player.tradeKickerWaivedPct ?? 0, 0),
+        1
+      );
+      const effPct = pct * (1 - waived);
+      if (effPct > 0 && player.remainingGuaranteedOnCurrentContract > 0) {
+        const gross = effPct * player.remainingGuaranteedOnCurrentContract;
+        const currentYearAdd = gross * proration;
+        incoming = (incoming ?? player.currentYearSalary) + currentYearAdd;
+      }
+
       player.matchIncoming = incoming;
     });
   });

--- a/tests/trade/tradeKicker_proration.test.js
+++ b/tests/trade/tradeKicker_proration.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { computeMatchingValues } from '@/utils/architect/tradeMachine/tradeValidator.js';
+
+const yearKey = 2025;
+
+const makePlayer = (overrides = {}) => ({
+  name: 'Player',
+  contract_clean: {
+    salaries_by_year: {
+      [yearKey]: { salary: overrides.salary ?? 0 },
+    },
+  },
+  ...overrides,
+});
+
+describe('Trade kicker proration', () => {
+  it('adds prorated kicker to incoming only', () => {
+    const player = makePlayer({
+      salary: 10_000_000,
+      tradeKickerPct: 0.15,
+      remainingGuaranteedOnCurrentContract: 20_000_000,
+    });
+    computeMatchingValues({
+      teams: [{ sends: [player] }],
+      yearKey,
+      daysRemainingInSeason: 41,
+      daysInSeason: 82,
+    });
+    expect(player.matchOutgoing).toBe(10_000_000);
+    expect(player.matchIncoming).toBe(11_500_000);
+  });
+
+  it('handles partial waivers', () => {
+    const player = makePlayer({
+      salary: 5_000_000,
+      tradeKickerPct: 0.1,
+      tradeKickerWaivedPct: 0.5,
+      remainingGuaranteedOnCurrentContract: 10_000_000,
+    });
+    computeMatchingValues({
+      teams: [{ sends: [player] }],
+      yearKey,
+      daysRemainingInSeason: 82,
+      daysInSeason: 82,
+    });
+    expect(player.matchOutgoing).toBe(5_000_000);
+    expect(player.matchIncoming).toBe(5_500_000);
+  });
+
+  it('coexists with BYC', () => {
+    const player = makePlayer({
+      salary: 10_000_000,
+      isBYC: true,
+      previousSalary: 4_000_000,
+      tradeKickerPct: 0.15,
+      remainingGuaranteedOnCurrentContract: 20_000_000,
+    });
+    computeMatchingValues({
+      teams: [{ sends: [player] }],
+      yearKey,
+      daysRemainingInSeason: 82,
+      daysInSeason: 82,
+    });
+    expect(player.matchOutgoing).toBe(5_000_000);
+    expect(player.matchIncoming).toBe(13_000_000);
+  });
+
+  it('defaults to full proration when timing missing', () => {
+    const player = makePlayer({
+      salary: 10_000_000,
+      tradeKickerPct: 0.15,
+      remainingGuaranteedOnCurrentContract: 20_000_000,
+    });
+    computeMatchingValues({ teams: [{ sends: [player] }], yearKey });
+    expect(player.matchOutgoing).toBe(10_000_000);
+    expect(player.matchIncoming).toBe(13_000_000);
+  });
+});
+


### PR DESCRIPTION
## Summary
- prorate trade kickers up to 15% and apply to incoming matching only
- add tests for waivers, BYC coexistence, and season proration defaults

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6892281b5bf483269a34417523a2eaed