### PR TITLE
feat: block prior-year TPEs for second apron

### DIFF
--- a/src/utils/architect/tradeMachine/tpeUtils.js
+++ b/src/utils/architect/tradeMachine/tpeUtils.js
@@ -1,0 +1,6 @@
+export function hasPriorYearTPE(appliedTPEs, currentSeason) {
+  if (!Array.isArray(appliedTPEs)) return false;
+  return appliedTPEs.some(
+    (tpe) => (tpe?.createdSeason ?? currentSeason) < currentSeason
+  );
+}

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -17,6 +17,7 @@ import {
   rosterSizeAfterTrade,
   passesRosterSizeRule,
 } from '@/utils/architect/rosterUtils.js';
+import { hasPriorYearTPE } from '@/utils/architect/tradeMachine/tpeUtils.js';
 
 // ===== DEBUGGER =====
 const debug = {
@@ -1089,6 +1090,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
       cashSent: team.cashSent || 0,
       cashReceived: cashReceived,
       tradeExceptions: team.team?.tradeExceptions || [],
+      appliedTPEs: team.appliedTPEs || [],
       context: { capSettings, yearKey },
     };
 
@@ -1113,9 +1115,17 @@ export function validateTrade({ teams, capProjections, currentYear }) {
 
   // Run all validations
   const validatedTeams = teamResults.map((team) => {
-    const handcuffViolations = enforceSecondApronHandcuffs(team, {});
-    const handcuffPass = handcuffViolations.length === 0;
     const seasonKey = team.context.yearKey;
+    const handcuffViolations = enforceSecondApronHandcuffs(team, {});
+    if (
+      team.postTradeStatus.isAtOrAboveSecondApron &&
+      hasPriorYearTPE(team.appliedTPEs, seasonKey)
+    ) {
+      handcuffViolations.push(
+        'Second apron: prior-year TPEs cannot be used.'
+      );
+    }
+    const handcuffPass = handcuffViolations.length === 0;
     const capStatus = {
       isAboveSecond: team.currentApronStatus.includes('2nd Apron'),
     };

--- a/tests/trade/secondApron_tpeBan.test.js
+++ b/tests/trade/secondApron_tpeBan.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { validateTrade } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import capProjections from '@/utils/architect/capProjections.js';
+
+const currentYear = 2025;
+
+const makePlayer = (name, salary) => ({
+  name,
+  contract_clean: { salaries_by_year: { [currentYear]: { salary } } },
+});
+
+const makeTeam = (name, totalSalary, rosterSize = 14) => ({
+  teamName: name,
+  totalSalary,
+  players: Array.from({ length: rosterSize }, (_, i) =>
+    makePlayer(`${name}${i}`, 1_000_000)
+  ),
+  picks: [],
+});
+
+function runTrade(appliedTPEs, teamSalary, otherTeamSalary = 100_000_000) {
+  const teamA = makeTeam('A', teamSalary);
+  const teamB = makeTeam('B', otherTeamSalary);
+  const aPlayer = makePlayer('Astar', 5_000_000);
+  const bPlayer = makePlayer('Bstar', 5_000_000);
+  teamA.players.push(aPlayer);
+  teamB.players.push(bPlayer);
+
+  return validateTrade({
+    teams: [
+      { team: teamA, sends: [aPlayer], picksOut: [], appliedTPEs },
+      { team: teamB, sends: [bPlayer], picksOut: [] },
+    ],
+    capProjections,
+    currentYear,
+  });
+}
+
+describe('second apron prior-year TPE usage', () => {
+  it('rejects prior-year TPEs for second-apron teams', () => {
+    const res = runTrade(
+      [{ amount: 5_000_000, createdSeason: currentYear - 1 }],
+      190_000_000
+    );
+    expect(res.teamResults[0].legal).toBe(false);
+    expect(res.teamResults[0].violations).toContain(
+      'Second apron: prior-year TPEs cannot be used.'
+    );
+  });
+
+  it('allows current-year TPEs for second-apron teams', () => {
+    const res = runTrade(
+      [{ amount: 5_000_000, createdSeason: currentYear }],
+      190_000_000
+    );
+    expect(res.teamResults[0].legal).toBe(true);
+  });
+
+  it('allows prior-year TPEs for teams below the apron', () => {
+    const res = runTrade(
+      [{ amount: 5_000_000, createdSeason: currentYear - 1 }],
+      100_000_000
+    );
+    expect(res.teamResults[0].legal).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to detect prior-year TPEs
- forbid second-apron teams from using prior-year trade exceptions
- test second-apron TPE ban scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689287a93534832695c6ab781de83177