### PR TITLE
feat: add timing gate soft enforcement

### DIFF
--- a/src/config/validationFlags.js
+++ b/src/config/validationFlags.js
@@ -1,3 +1,5 @@
 export const validationFlags = {
-  rosterEnforcement: 'warn', // 'off' | 'warn' | 'error'
+  rosterEnforcement: 'warn',
+  timingEnforcement: 'warn',
+  moratorium: { startMonth: 7, startDay: 1, endMonth: 7, endDay: 6 },
 };

--- a/src/utils/architect/timingUtils.js
+++ b/src/utils/architect/timingUtils.js
@@ -1,0 +1,16 @@
+export function isWithinMoratorium(date, { startMonth, startDay, endMonth, endDay }) {
+  const d = new Date(date);
+  const y = d.getUTCFullYear();
+  const start = Date.UTC(y, startMonth - 1, startDay);
+  const end = Date.UTC(y, endMonth - 1, endDay, 23, 59, 59);
+  return d.getTime() >= start && d.getTime() <= end;
+}
+export function daysSince(a, b) {
+  return Math.floor((new Date(b).getTime() - new Date(a).getTime()) / 86400000);
+}
+export function violates30Day(p, d) {
+  return p?.signedDate && daysSince(p.signedDate, d) < 30;
+}
+export function violates2MonthAggregation(p, d) {
+  return p?.signedDate && daysSince(p.signedDate, d) < 60;
+}

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -16,6 +16,11 @@ import { BYC_PERCENT } from '@/utils/architect/cbaConstants.js';
 import { passesRosterWindow } from '@/utils/architect/rosterUtils.js';
 import { validationFlags } from '@/config/validationFlags.js';
 import { hasPriorYearTPE } from '@/utils/architect/tradeMachine/tpeUtils.js';
+import {
+  isWithinMoratorium,
+  violates30Day,
+  violates2MonthAggregation,
+} from '@/utils/architect/timingUtils.js';
 
 // ===== DEBUGGER =====
 const debug = {
@@ -261,6 +266,57 @@ export function enforceRosterWindow(
     if (validationFlags.rosterEnforcement === 'error') reject(msg);
     if (validationFlags.rosterEnforcement === 'warn') warn(msg);
   }
+}
+
+export function enforceTiming(
+  teamCtx,
+  tradeCtx = {},
+  { warn = () => {}, reject = () => {} } = {},
+) {
+  const enforcement = validationFlags.timingEnforcement;
+  const tradeDate = new Date(tradeCtx.tradeDate || Date.now());
+
+  if (isWithinMoratorium(tradeDate, validationFlags.moratorium)) {
+    const msg = 'Trade moratorium in effect';
+    if (enforcement === 'error') reject(msg);
+    if (enforcement === 'warn') warn(msg);
+  }
+
+  const outgoing = teamCtx.outgoingPlayers || [];
+  const aggregated = outgoing.length > 1;
+  outgoing.forEach((p) => {
+    const name = p.name || 'Player';
+
+    if (p.eligibleTradeDate && tradeDate < new Date(p.eligibleTradeDate)) {
+      const msg = `${name} not trade-eligible until ${p.eligibleTradeDate}`;
+      if (enforcement === 'error') reject(msg);
+      if (enforcement === 'warn') warn(msg);
+    } else if (p.jan15Eligible === false) {
+      const jan15 = new Date(Date.UTC(tradeDate.getUTCFullYear(), 0, 15));
+      if (tradeDate < jan15) {
+        const msg = `${name} not trade-eligible until Jan 15`;
+        if (enforcement === 'error') reject(msg);
+        if (enforcement === 'warn') warn(msg);
+      }
+    }
+
+    if (violates30Day(p, tradeDate)) {
+      const msg = `${name} signed within last 30 days`;
+      if (enforcement === 'error') reject(msg);
+      if (enforcement === 'warn') warn(msg);
+    }
+
+    if (aggregated) {
+      const violates = p.eligibleAggregationDate
+        ? tradeDate < new Date(p.eligibleAggregationDate)
+        : violates2MonthAggregation(p, tradeDate);
+      if (violates) {
+        const msg = `${name} cannot be aggregated in trade yet`;
+        if (enforcement === 'error') reject(msg);
+        if (enforcement === 'warn') warn(msg);
+      }
+    }
+  });
 }
 
 // ===== TRADE EXCEPTION VALIDATION =====

--- a/tests/trade/timingGates_softEnforcement.test.js
+++ b/tests/trade/timingGates_softEnforcement.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { enforceTiming } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import { validationFlags } from '@/config/validationFlags.js';
+
+const run = (team, tradeCtx) => {
+  const warns = [];
+  const rejects = [];
+  enforceTiming(team, tradeCtx, {
+    warn: (m) => warns.push(m),
+    reject: (m) => rejects.push(m),
+  });
+  return { warns, rejects };
+};
+
+describe('timing gates soft enforcement', () => {
+  afterEach(() => {
+    validationFlags.timingEnforcement = 'warn';
+  });
+
+  it('moratorium rule respects flag', () => {
+    const team = { outgoingPlayers: [{ name: 'P1' }] };
+    const tradeCtx = { tradeDate: '2024-07-03' };
+    validationFlags.timingEnforcement = 'error';
+    let r = run(team, tradeCtx);
+    expect(r.rejects).toHaveLength(1);
+    expect(r.rejects[0]).toMatch(/moratorium/i);
+    validationFlags.timingEnforcement = 'warn';
+    r = run(team, tradeCtx);
+    expect(r.warns).toHaveLength(1);
+    expect(r.warns[0]).toMatch(/moratorium/i);
+  });
+
+  it('dec 15 / jan 15 eligibility respects flag', () => {
+    const team = {
+      outgoingPlayers: [{ name: 'P1', eligibleTradeDate: '2024-12-15' }],
+    };
+    const tradeCtx = { tradeDate: '2024-12-01' };
+    validationFlags.timingEnforcement = 'error';
+    let r = run(team, tradeCtx);
+    expect(r.rejects).toHaveLength(1);
+    expect(r.rejects[0]).toMatch(/eligible/i);
+    validationFlags.timingEnforcement = 'warn';
+    r = run(team, tradeCtx);
+    expect(r.warns).toHaveLength(1);
+  });
+
+  it('30-day rule respects flag', () => {
+    const team = { outgoingPlayers: [{ name: 'P1', signedDate: '2024-01-15' }] };
+    const tradeCtx = { tradeDate: '2024-02-01' };
+    validationFlags.timingEnforcement = 'error';
+    let r = run(team, tradeCtx);
+    expect(r.rejects).toHaveLength(1);
+    expect(r.rejects[0]).toMatch(/30/);
+    validationFlags.timingEnforcement = 'warn';
+    r = run(team, tradeCtx);
+    expect(r.warns).toHaveLength(1);
+  });
+
+  it('2-month aggregation rule respects flag', () => {
+    const team = {
+      outgoingPlayers: [
+        { name: 'P1', signedDate: '2023-12-25' },
+        { name: 'P2', signedDate: '2023-10-01' },
+      ],
+    };
+    const tradeCtx = { tradeDate: '2024-02-01' };
+    validationFlags.timingEnforcement = 'error';
+    let r = run(team, tradeCtx);
+    expect(r.rejects).toHaveLength(1);
+    expect(r.rejects[0]).toMatch(/aggregate/i);
+    validationFlags.timingEnforcement = 'warn';
+    r = run(team, tradeCtx);
+    expect(r.warns).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add timing enforcement flag and moratorium window
- introduce timing utilities and enforcement logic for trades
- cover timing gates with soft-enforcement tests

## Testing
- `npm test tests/trade/timingGates_softEnforcement.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892b6990134832697e563bc7410ca53