### PR TITLE
fix: enforce complete sign-and-trade rules

### DIFF
--- a/src/utils/architect/hardCapUtils.js
+++ b/src/utils/architect/hardCapUtils.js
@@ -58,7 +58,7 @@ export const wouldExceedHardCap = (
 
   let hardCapLimit = null;
 
-  if (hardCapTriggered === 'FirstApron') {
+  if (hardCapTriggered === true || hardCapTriggered === 'FirstApron') {
     hardCapLimit = capSettings.firstApron;
   } else if (hardCapTriggered === 'SecondApron') {
     hardCapLimit = capSettings.secondApron;

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -373,34 +373,54 @@ export function validateCash(team) {
 }
 
 // SIGN-AND-TRADE RULES VALIDATION
-export function validateSignAndTrade(team) {
+export function validateSignAndTrade(team, tradeCtx = {}) {
   const violations = [];
-  const sntPlayers = team.incomingPlayers.filter(
+  const sntIn = team.incomingPlayers.filter(
     (p) => p.isSignAndTrade || p.signAndTrade
   );
-  const signAndTradeCount = team.sends.filter((p) => p.signAndTrade).length;
+  const sntOut = team.sends.filter((p) => p.signAndTrade);
+  const anySnt = sntIn.length > 0 || sntOut.length > 0;
 
-  if (sntPlayers.length > 0) {
-    // === INSERT right after sign-and-trade aggregation check ===
-    if (
-      signAndTradeCount > 0 &&
-      (team.sends.length > 1 || team.picksOut.length)
-    ) {
+  if (!anySnt) return violations;
+
+  if (tradeCtx.offseason === false) {
+    violations.push('Sign-and-trade only permitted in offseason');
+  }
+
+  if (sntOut.length > 0) {
+    if (sntOut.length > 0 && (team.sends.length > 1 || team.picksOut.length)) {
       violations.push('Sign-and-trade player must be traded alone');
     }
+    sntOut.forEach((p) => {
+      const teamId = team.team?.id ?? team.teamId;
+      if (p.originTeamId && p.originTeamId !== teamId) {
+        violations.push('Sign-and-trade must be executed by player\'s original team');
+      }
+    });
+  }
 
-    // Hard cap check against dynamic first apron
-    const firstApron =
-      team.context.capSettings?.firstApron ?? CBA_THRESHOLDS.FIRST_APRON;
-    if (team.projectedSalary > firstApron) {
+  if (sntIn.length > 0) {
+    if (team.usedTaxpayerMLEThisSeason || team.team?.usedTaxpayerMLEThisSeason) {
+      violations.push('Teams using taxpayer MLE cannot receive sign-and-trade players');
+    }
+    if (
+      wouldExceedHardCap(
+        { hardCapTriggered: 'FirstApron' },
+        team.projectedSalary,
+        team.context.capSettings
+      )
+    ) {
       violations.push('Sign-and-trade would hard-cap team at 1st apron');
     }
-
-    // Contract length check
-    sntPlayers.forEach((p) => {
+    team.hardCapped = true;
+    if (team.team) team.team.hardCapTriggered = true;
+    sntIn.forEach((p) => {
       const years = p.contractYears ?? p.years ?? 0;
       if (years < 3 || years > 4) {
         violations.push(`S&T contract for ${p.name} must be 3-4 years`);
+      }
+      if (p.firstYearGuaranteed === false) {
+        violations.push(`First year of ${p.name}\'s deal must be guaranteed`);
       }
     });
   }
@@ -483,12 +503,12 @@ function validateSecondApronRules(team) {
 }
 
 // MAIN NEW RULES VALIDATOR
-export function validateAllNewRules(team, allTeams) {
+export function validateAllNewRules(team, allTeams, tradeCtx = {}) {
   return [
     ...validateTradeExceptions(team),
     ...validateDraftPicks(team, allTeams),
     ...validateCash(team),
-    ...validateSignAndTrade(team),
+    ...validateSignAndTrade(team, tradeCtx),
     ...validateBYC(team),
     ...validateSecondApronRules(team),
   ];
@@ -714,7 +734,7 @@ const TRADE_RULES = {
 };
 
 // ===== MAIN VALIDATOR =====
-export function validateTrade({ teams, capProjections, currentYear }) {
+export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {} }) {
   // Helper functions
   const isExpired = (dateStr) => dateStr && new Date(dateStr) < new Date();
   const formatDate = (dateStr) =>
@@ -902,31 +922,70 @@ export function validateTrade({ teams, capProjections, currentYear }) {
 
   const validateSignAndTrade = (team) => {
     const violations = [];
-    const { outgoingPlayers, incomingPlayers, projectedSalary, context } = team;
+    const {
+      outgoingPlayers,
+      incomingPlayers,
+      projectedSalary,
+      context,
+      outgoingPicks = [],
+    } = team;
     const { capSettings } = context;
 
-    // Logic for team SENDING a S&T player
     const sntOutPlayers = outgoingPlayers.filter((p) => p.signAndTrade);
-    if (sntOutPlayers.length > 0) {
-      if (outgoingPlayers.length > 1) {
-        // A team can't send other players with a S&T player
-        violations.push('Sign-and-trade player must be traded alone.');
-      }
+    const sntInPlayers = incomingPlayers.filter((p) => p.signAndTrade);
+    const anySnt = sntOutPlayers.length > 0 || sntInPlayers.length > 0;
+
+    if (!anySnt) {
+      return {
+        passed: true,
+        violations: [],
+        message: 'S&T valid',
+        details: '',
+      };
     }
 
-    // Logic for team RECEIVING a S&T player
-    const sntInPlayers = incomingPlayers.filter((p) => p.signAndTrade);
+    if (tradeCtx.offseason === false) {
+      violations.push('S&T only in offseason.');
+    }
+
+    if (sntOutPlayers.length > 0) {
+      if (outgoingPlayers.length > 1 || outgoingPicks.length) {
+        violations.push('Sign-and-trade player must be traded alone.');
+      }
+      sntOutPlayers.forEach((p) => {
+        const teamId = team.team?.id ?? team.teamId;
+        if (p.originTeamId && p.originTeamId !== teamId) {
+          violations.push("Sign-and-trade must be executed by player's original team.");
+        }
+      });
+    }
+
     if (sntInPlayers.length > 0) {
-      // S&T hard-caps team at first apron.
-      if (projectedSalary > capSettings.firstApron) {
+      if (
+        team.usedTaxpayerMLEThisSeason ||
+        team.team?.usedTaxpayerMLEThisSeason
+      ) {
+        violations.push('Teams using taxpayer MLE cannot receive sign-and-trade players.');
+      }
+      if (
+        wouldExceedHardCap(
+          { hardCapTriggered: 'FirstApron' },
+          projectedSalary,
+          capSettings
+        )
+      ) {
         violations.push('S&T triggers hard-cap breach.');
       }
-
+      team.hardCapped = true;
+      if (team.team) team.team.hardCapTriggered = true;
       sntInPlayers.forEach((player) => {
         const years = player.contractYears || player.contract_clean?.years || 0;
         const correctYears = years >= 3 && years <= 4;
         if (!correctYears) {
           violations.push('S&T contract must be 3-4 years.');
+        }
+        if (player.firstYearGuaranteed === false) {
+          violations.push('S&T first year must be guaranteed.');
         }
       });
     }
@@ -1131,7 +1190,7 @@ export function validateTrade({ teams, capProjections, currentYear }) {
   // Run all validations
   const validatedTeams = teamResults.map((team) => {
     const seasonKey = team.context.yearKey;
-    const handcuffViolations = enforceSecondApronHandcuffs(team, {});
+    const handcuffViolations = enforceSecondApronHandcuffs(team, tradeCtx);
     if (
       team.postTradeStatus.isAtOrAboveSecondApron &&
       hasPriorYearTPE(team.appliedTPEs, seasonKey)

--- a/tests/trade/signAndTrade_completeness.test.js
+++ b/tests/trade/signAndTrade_completeness.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { validateTrade } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import capProjections from '@/utils/architect/capProjections.js';
+
+const currentYear = 2025;
+
+const makePlayer = (
+  name,
+  salary,
+  {
+    signAndTrade = false,
+    contractYears = 4,
+    firstYearGuaranteed = true,
+    originTeamId = 'A',
+  } = {}
+) => ({
+  name,
+  signAndTrade,
+  contractYears,
+  firstYearGuaranteed,
+  originTeamId,
+  contract_clean: { salaries_by_year: { [currentYear]: { salary } } },
+});
+
+const makeTeam = (id, totalSalary, extra = {}) => ({
+  id,
+  teamName: id,
+  totalSalary,
+  picks: [],
+  players: Array.from({ length: 14 }, (_, i) =>
+    makePlayer(`${id}${i}`, 1_000_000, { originTeamId: id })
+  ),
+  ...extra,
+});
+
+describe('sign-and-trade completeness', () => {
+  it('rejects invalid contract years', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const sat = makePlayer('SAT', 10_000_000, { signAndTrade: true, contractYears: 2, originTeamId: 'A' });
+    const b = makePlayer('B1', 5_000_000, { originTeamId: 'B' });
+    teamA.players.push(sat);
+    teamB.players.push(b);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [b], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { offseason: true },
+    });
+
+    expect(result.teamResults[1].rules.signAndTrade.passed).toBe(false);
+  });
+
+  it('rejects non-guaranteed first year', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const sat = makePlayer('SAT', 10_000_000, { signAndTrade: true, firstYearGuaranteed: false, originTeamId: 'A' });
+    const b = makePlayer('B1', 5_000_000, { originTeamId: 'B' });
+    teamA.players.push(sat);
+    teamB.players.push(b);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [b], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { offseason: true },
+    });
+
+    expect(result.teamResults[1].rules.signAndTrade.passed).toBe(false);
+  });
+
+  it('rejects sign-and-trade from non-origin team', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const sat = makePlayer('SAT', 10_000_000, { signAndTrade: true, originTeamId: 'C' });
+    const b = makePlayer('B1', 5_000_000, { originTeamId: 'B' });
+    teamA.players.push(sat);
+    teamB.players.push(b);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [b], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { offseason: true },
+    });
+
+    expect(result.teamResults[0].rules.signAndTrade.passed).toBe(false);
+  });
+
+  it('rejects sign-and-trade outside offseason', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const sat = makePlayer('SAT', 10_000_000, { signAndTrade: true, originTeamId: 'A' });
+    const b = makePlayer('B1', 5_000_000, { originTeamId: 'B' });
+    teamA.players.push(sat);
+    teamB.players.push(b);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [b], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { offseason: false },
+    });
+
+    expect(result.teamResults[0].rules.signAndTrade.passed).toBe(false);
+    expect(result.teamResults[1].rules.signAndTrade.passed).toBe(false);
+  });
+
+  it('rejects teams using taxpayer MLE from receiving S&T players', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000, { usedTaxpayerMLEThisSeason: true });
+    const sat = makePlayer('SAT', 10_000_000, { signAndTrade: true, originTeamId: 'A' });
+    const b = makePlayer('B1', 5_000_000, { originTeamId: 'B' });
+    teamA.players.push(sat);
+    teamB.players.push(b);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [b], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { offseason: true },
+    });
+
+    expect(result.teamResults[1].rules.signAndTrade.passed).toBe(false);
+  });
+
+  it('enforces hard cap after sign-and-trade', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 171_000_000);
+    const sat = makePlayer('SAT', 20_000_000, { signAndTrade: true, originTeamId: 'A' });
+    const b = makePlayer('B1', 1_000_000, { originTeamId: 'B' });
+    teamA.players.push(sat);
+    teamB.players.push(b);
+
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat], picksOut: [] },
+        { team: teamB, sends: [b], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { offseason: true },
+    });
+
+    expect(result.teamResults[1].rules.signAndTrade.passed).toBe(false);
+    expect(result.teamResults[1].hardCapped).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce offseason, origin-team, contract-length and guarantee, taxpayer-MLE ban, and first-apron hard-cap for sign-and-trade deals
- treat boolean hard-cap triggers as first-apron in hard cap utility
- add comprehensive sign-and-trade validation tests

## Testing
- `npm test tests/trade/signAndTrade_completeness.test.js`
- `npm test tests/tradeValidator.test.js tests/tradeValidatorEdgeCases.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892ba74b4f88326a0def24c24bf6f54