### PR TITLE
feat: implement trade exception creation and restrictions

### DIFF
--- a/src/utils/architect/tradeMachine/tpeUtils.js
+++ b/src/utils/architect/tradeMachine/tpeUtils.js
@@ -4,3 +4,29 @@ export function hasPriorYearTPE(appliedTPEs, currentSeason) {
     (tpe) => (tpe?.createdSeason ?? currentSeason) < currentSeason
   );
 }
+
+export function createTPE({ teamCtx, outgoing, incoming, tradeDate }) {
+  if (!teamCtx.isOverCap) return null;
+  const amt = Math.max(0, outgoing - incoming);
+  if (amt <= 0) return null;
+  const baseDate = tradeDate ? new Date(tradeDate) : new Date();
+  const expiry = new Date(baseDate);
+  expiry.setUTCFullYear(expiry.getUTCFullYear() + 1);
+  return {
+    amount: Math.round(amt),
+    createdSeason: baseDate.getUTCFullYear(),
+    expiryISO: expiry.toISOString(),
+  };
+}
+
+export function isExpiredTPE(tpe, onDate) {
+  const expiry = tpe?.expiryISO || tpe?.expiryDate;
+  if (!expiry) return false;
+  return new Date(onDate).getTime() > new Date(expiry).getTime();
+}
+
+export function canUseTPE(teamCtx, tpe, { currentSeason, onDate }) {
+  if (!tpe || isExpiredTPE(tpe, onDate)) return false;
+  if (teamCtx.postTradeStatus?.isAtOrAboveSecondApron) return false;
+  return true;
+}

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -15,7 +15,12 @@ import {
 import { BYC_PERCENT } from '@/utils/architect/cbaConstants.js';
 import { passesRosterWindow } from '@/utils/architect/rosterUtils.js';
 import { validationFlags } from '@/config/validationFlags.js';
-import { hasPriorYearTPE } from '@/utils/architect/tradeMachine/tpeUtils.js';
+import {
+  hasPriorYearTPE,
+  createTPE,
+  isExpiredTPE,
+  canUseTPE,
+} from '@/utils/architect/tradeMachine/tpeUtils.js';
 import {
   isWithinMoratorium,
   violates30Day,
@@ -322,7 +327,6 @@ export function enforceTiming(
 // ===== TRADE EXCEPTION VALIDATION =====
 export function validateTradeExceptions(team) {
   const violations = [];
-  // Prevent TPEs already flagged as “in use” elsewhere (concurrent usage)
   if (team.tradeExceptions?.some((e) => e.isBeingUsed)) {
     team.tradeExceptions
       .filter((e) => e.isBeingUsed)
@@ -332,9 +336,9 @@ export function validateTradeExceptions(team) {
         )
       );
   }
-  const usedTPEs = new Map(); // Track usage during this validation
-
+  const usedTPEs = new Set();
   const yearKey = team?.context?.yearKey ?? new Date().getFullYear();
+  const onDate = team.context?.tradeDate || new Date().toISOString();
 
   team.incomingPlayers.forEach((player) => {
     if (!player.acquiredViaTPE) return;
@@ -344,36 +348,35 @@ export function validateTradeExceptions(team) {
       violations.push(`No valid TPE found for ${player.name}`);
       return;
     }
-
-    // Check for concurrent usage in THIS validation pass
     if (usedTPEs.has(tpe.id)) {
-      violations.push(
-        `TPE ${tpe.id} is being used multiple times in this trade`
-      );
+      violations.push(`TPE ${tpe.id} is being used multiple times in this trade`);
+      return;
+    }
+    if (
+      team.outgoingPlayers?.some((p) => p.toTeamId === player.fromTeamId)
+    ) {
+      violations.push('Cannot aggregate trade exception with outgoing salary');
+      return;
+    }
+    if (!canUseTPE(team, tpe, { currentSeason: yearKey, onDate })) {
+      if (isExpiredTPE(tpe, onDate)) {
+        violations.push(`Trade exception ${tpe.id} is expired`);
+      } else if (team.postTradeStatus?.isAtOrAboveSecondApron) {
+        violations.push('Second apron team cannot use trade exceptions');
+      } else {
+        violations.push(`Cannot use trade exception ${tpe.id}`);
+      }
       return;
     }
     const incoming = getSalaryForYear(player, yearKey);
-    // === INSERT inside validateTradeExceptions ===
-    if (new Date(tpe.expiryDate) < new Date()) {
-      violations.push(`Trade exception ${tpe.id} is expired`);
-      return;
-    }
     if (incoming > tpe.amount) {
       violations.push(`Trade exception ${tpe.id} is too small`);
       return;
     }
+    usedTPEs.add(tpe.id);
     tpe.remaining = tpe.amount - incoming;
     tpe.isUsed = tpe.remaining === 0;
   });
-
-  // Apply changes if no violations
-  if (violations.length === 0) {
-    usedTPEs.forEach((value, tpeId) => {
-      const tpeIndex = team.tradeExceptions.findIndex((e) => e.id === tpeId);
-      team.tradeExceptions[tpeIndex].remaining = value.newRemaining;
-      team.tradeExceptions[tpeIndex].isUsed = value.newRemaining <= 0;
-    });
-  }
 
   return violations;
 }
@@ -1089,44 +1092,6 @@ export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {
     };
   };
 
-  const validateTradeExceptions = (team) => {
-    const violations = [];
-    const usedTPEs = new Set();
-
-    team.incomingPlayers.forEach((p) => {
-      if (!p.acquiredViaTPE) return;
-      const tpe = team.tradeExceptions?.find((e) => e.id === p.tpeId);
-      const incoming = getSalaryForYear(p, yearKey);
-
-      if (!tpe) {
-        violations.push(`No TPE found for ${p.name}`);
-        return;
-      }
-      if (new Date(tpe.expiryDate) < new Date()) {
-        violations.push(`Trade exception ${tpe.id} is expired`);
-        return;
-      }
-      if (incoming > tpe.amount) {
-        violations.push(`Trade exception ${tpe.id} is too small`);
-        return;
-      }
-      tpe.remaining = tpe.amount - incoming;
-      tpe.isUsed = tpe.remaining === 0;
-
-      if (usedTPEs.has(tpe.id)) {
-        violations.push(`TPE ${tpe.id} used multiple times`);
-        return;
-      }
-    });
-
-    return {
-      passed: violations.length === 0,
-      violations,
-      message: violations.length ? 'TPE violation' : 'TPE usage valid',
-      details: violations.join('; '),
-    };
-  };
-
   // ======================
   // MAIN VALIDATION FLOW
   // ======================
@@ -1195,6 +1160,7 @@ export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {
           ? projectedSalary >= capSettings.firstApron
           : false,
     };
+    const isOverCap = teamTotalSalary > (capSettings.cap || 0);
 
     const baseTeam = {
       teamId: team.team?.id,
@@ -1214,6 +1180,7 @@ export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {
       projectedApronStatus: projectedStatus,
       postTradeStatus,
       capSpace: (capSettings.cap || 0) - projectedSalary,
+      isOverCap,
       totalSalary: teamTotalSalary,
       capRoom: (capSettings.cap || 0) - projectedSalary,
       hardCapped: team.hardCapped || false,
@@ -1221,13 +1188,20 @@ export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {
       cashReceived: cashReceived,
       tradeExceptions: team.team?.tradeExceptions || [],
       appliedTPEs: team.appliedTPEs || [],
-      context: { capSettings, yearKey },
+      context: { capSettings, yearKey, tradeDate: tradeCtx.tradeDate },
     };
 
     const allowableIncoming = getIncomingCeilingForTeam(baseTeam);
+    const createdTPE = createTPE({
+      teamCtx: baseTeam,
+      outgoing: salaryOut,
+      incoming: salaryIn,
+      tradeDate: tradeCtx.tradeDate,
+    });
 
     return {
       ...baseTeam,
+      createdTPE,
       calculations: {
         salaryMatching: {
           allowableIncoming,
@@ -1398,7 +1372,15 @@ export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {
       },
       // Keep other rule checks if needed
       signAndTrade: validateSignAndTrade(team),
-      tradeExceptions: validateTradeExceptions(team),
+      tradeExceptions: (() => {
+        const tpeViolations = validateTradeExceptions(team);
+        return {
+          passed: tpeViolations.length === 0,
+          violations: tpeViolations,
+          message: tpeViolations.length ? 'TPE violation' : 'TPE usage valid',
+          details: tpeViolations.join('; '),
+        };
+      })(),
     };
 
     const violations = [

--- a/tests/trade/tpe_creation_expiry_usage.test.js
+++ b/tests/trade/tpe_creation_expiry_usage.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { validateTrade } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import capProjections from '@/utils/architect/capProjections.js';
+
+const currentYear = 2025;
+const tradeDate = '2025-07-01T00:00:00.000Z';
+
+const makePlayer = (name, salary) => ({
+  name,
+  contract_clean: { salaries_by_year: { [currentYear]: { salary } } },
+});
+
+const makeTeam = (name, totalSalary, rosterSize = 14) => ({
+  id: name,
+  teamName: name,
+  totalSalary,
+  players: Array.from({ length: rosterSize }, (_, i) =>
+    makePlayer(`${name}${i}`, 1_000_000)
+  ),
+  picks: [],
+});
+
+describe('TPE creation and usage', () => {
+  it('creates a TPE when sending out more salary than received', () => {
+    const teamA = makeTeam('A', 150_000_000);
+    const teamB = makeTeam('B', 120_000_000);
+    const outgoing = { ...makePlayer('Out', 18_000_000), toTeamId: 'B' };
+    const incoming = { ...makePlayer('In', 10_000_000), fromTeamId: 'B' };
+    teamA.players.push(outgoing);
+    teamB.players.push(incoming);
+
+    const res = validateTrade({
+      teams: [
+        { team: teamA, sends: [outgoing], picksOut: [] },
+        { team: teamB, sends: [incoming], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { tradeDate },
+    });
+
+    const tpe = res.teamResults[0].createdTPE;
+    expect(tpe.amount).toBe(8_000_000);
+    const expiry = new Date(tpe.expiryISO);
+    const expected = new Date(tradeDate);
+    expected.setUTCFullYear(expected.getUTCFullYear() + 1);
+    expect(expiry.getUTCFullYear()).toBe(expected.getUTCFullYear());
+  });
+
+  it('rejects usage of an expired TPE', () => {
+    const teamA = makeTeam('A', 150_000_000);
+    const teamB = makeTeam('B', 120_000_000);
+    const tpe = {
+      id: 't1',
+      amount: 5_000_000,
+      expiryISO: '2024-07-01T00:00:00.000Z',
+      createdSeason: 2024,
+    };
+    teamA.tradeExceptions = [tpe];
+    const incoming = {
+      ...makePlayer('In', 4_000_000),
+      acquiredViaTPE: true,
+      tpeId: 't1',
+      fromTeamId: 'B',
+    };
+    teamB.players.push(incoming);
+
+    const res = validateTrade({
+      teams: [
+        { team: teamA, sends: [], picksOut: [], appliedTPEs: [tpe] },
+        { team: teamB, sends: [incoming], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { tradeDate },
+    });
+
+    expect(res.teamResults[0].legal).toBe(false);
+    expect(res.teamResults[0].violations).toContain(
+      'Trade exception t1 is expired'
+    );
+  });
+
+  it('rejects combining a TPE with outgoing salary', () => {
+    const teamA = makeTeam('A', 150_000_000);
+    const teamB = makeTeam('B', 120_000_000);
+    const tpe = {
+      id: 't2',
+      amount: 5_000_000,
+      expiryISO: '2026-07-01T00:00:00.000Z',
+      createdSeason: 2025,
+    };
+    teamA.tradeExceptions = [tpe];
+    const outgoing = { ...makePlayer('Out', 5_000_000), toTeamId: 'B' };
+    const incoming = {
+      ...makePlayer('In', 5_000_000),
+      acquiredViaTPE: true,
+      tpeId: 't2',
+      fromTeamId: 'B',
+    };
+    teamA.players.push(outgoing);
+    teamB.players.push(incoming);
+
+    const res = validateTrade({
+      teams: [
+        { team: teamA, sends: [outgoing], picksOut: [], appliedTPEs: [tpe] },
+        { team: teamB, sends: [incoming], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { tradeDate },
+    });
+
+    expect(res.teamResults[0].legal).toBe(false);
+    expect(res.teamResults[0].violations).toContain(
+      'Cannot aggregate trade exception with outgoing salary'
+    );
+  });
+
+  it('rejects TPE usage for second-apron teams', () => {
+    const teamA = makeTeam('A', 195_000_000);
+    const teamB = makeTeam('B', 120_000_000);
+    const tpe = {
+      id: 't3',
+      amount: 5_000_000,
+      expiryISO: '2026-07-01T00:00:00.000Z',
+      createdSeason: 2025,
+    };
+    teamA.tradeExceptions = [tpe];
+    const incoming = {
+      ...makePlayer('In', 4_000_000),
+      acquiredViaTPE: true,
+      tpeId: 't3',
+      fromTeamId: 'B',
+    };
+    teamB.players.push(incoming);
+
+    const res = validateTrade({
+      teams: [
+        { team: teamA, sends: [], picksOut: [], appliedTPEs: [tpe] },
+        { team: teamB, sends: [incoming], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: { tradeDate },
+    });
+
+    expect(res.teamResults[0].legal).toBe(false);
+    expect(res.teamResults[0].violations).toContain(
+      'Second apron team cannot use trade exceptions'
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add helpers for trade exception creation, expiry, and usage limits
- integrate TPE creation and usage rules in trade validator
- cover TPE creation, expiry, aggregation and second-apron bans with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892beef02348326815aa7b6c074be6b