### PR TITLE
feat: block frozen picks for second apron teams

### DIFF
--- a/src/utils/architect/draftPickUtils.js
+++ b/src/utils/architect/draftPickUtils.js
@@ -1,0 +1,5 @@
+export function isFrozenPick(pick, { teamId, teamIsAtOrAboveSecondApron, currentSeason }) {
+  if (!teamIsAtOrAboveSecondApron) return false;
+  const frozenYear = currentSeason + 7;
+  return pick?.round === 1 && pick?.teamId === teamId && pick?.year === frozenYear;
+}

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -16,6 +16,7 @@ import { BYC_PERCENT } from '@/utils/architect/cbaConstants.js';
 import { passesRosterWindow } from '@/utils/architect/rosterUtils.js';
 import { validationFlags } from '@/config/validationFlags.js';
 import { hasPriorYearTPE } from '@/utils/architect/tradeMachine/tpeUtils.js';
+import { isFrozenPick } from '@/utils/architect/draftPickUtils.js';
 import {
   isWithinMoratorium,
   violates30Day,
@@ -1259,6 +1260,8 @@ export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {
     const capStatus = {
       isAboveSecond: team.currentApronStatus.includes('2nd Apron'),
     };
+    const teamIsAtOrAboveSecondApron =
+      capStatus.isAboveSecond || team.postTradeStatus.isAtOrAboveSecondApron;
 
     // --- Salary matching (2023 CBA + TPE)
     const allowable = getIncomingCeilingForTeam(team);
@@ -1317,6 +1320,19 @@ export function validateTrade({ teams, capProjections, currentYear, tradeCtx = {
     }
     if (farthestYear - seasonKey > 7) {
       stepienViolations.push('Cannot trade picks beyond 7 years out.');
+    }
+    if (
+      team.outgoingPicks.some((p) =>
+        isFrozenPick(p, {
+          teamId: team.teamId,
+          teamIsAtOrAboveSecondApron,
+          currentSeason: seasonKey,
+        })
+      )
+    ) {
+      stepienViolations.push(
+        'Second apron team cannot trade its own 7-year-out first-round pick.'
+      );
     }
     const stepienPass = stepienViolations.length === 0;
 

--- a/tests/trade/frozenPick_consequences.test.js
+++ b/tests/trade/frozenPick_consequences.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { validateTrade } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import capProjections from '@/utils/architect/capProjections.js';
+
+const makePlayer = (name, salary, year) => ({
+  name,
+  contract_clean: { salaries_by_year: { [year]: { salary } } },
+});
+
+const makeTeam = (id, name, totalSalary, year, rosterSize = 14) => ({
+  id,
+  teamName: name,
+  totalSalary,
+  players: Array.from({ length: rosterSize }, (_, i) =>
+    makePlayer(`${name}${i}`, 1_000_000, year)
+  ),
+  picks: [],
+});
+
+function runPickTrade(pick, currentYear) {
+  const teamA = makeTeam(1, 'A', 190_000_000, currentYear);
+  const teamB = makeTeam(2, 'B', 100_000_000, currentYear);
+  return validateTrade({
+    teams: [
+      { team: teamA, sends: [], picksOut: [pick] },
+      { team: teamB, sends: [], picksOut: [] },
+    ],
+    capProjections,
+    currentYear,
+  });
+}
+
+describe('frozen pick consequences', () => {
+  it('rejects 2032 first for second apron team', () => {
+    const pick = { year: 2032, round: 1, teamId: 1 };
+    const res = runPickTrade(pick, 2025);
+    expect(res.teamResults[0].legal).toBe(false);
+    expect(res.teamResults[0].violations).toContain(
+      'Second apron team cannot trade its own 7-year-out first-round pick.'
+    );
+  });
+
+  it('rejects protected 2032 first for second apron team', () => {
+    const pick = { year: 2032, round: 1, teamId: 1, protection: 'top 10' };
+    const res = runPickTrade(pick, 2025);
+    expect(res.teamResults[0].legal).toBe(false);
+    expect(res.teamResults[0].violations).toContain(
+      'Second apron team cannot trade its own 7-year-out first-round pick.'
+    );
+  });
+
+  it('allows 2031 first for second apron team', () => {
+    const pick = { year: 2031, round: 1, teamId: 1 };
+    const res = runPickTrade(pick, 2025);
+    expect(res.teamResults[0].legal).toBe(true);
+  });
+
+  it('allows 2033 first for second apron team', () => {
+    const pick = { year: 2033, round: 1, teamId: 1 };
+    const res = runPickTrade(pick, 2027);
+    expect(res.teamResults[0].legal).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent second-apron teams from trading their own 7-year-out first-round pick
- add tests covering frozen pick scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892c4a3656883269a13b6dfec4ae4e2