### PR TITLE
feat: enforce trade consent and reacquisition bar

### DIFF
--- a/src/utils/architect/consentUtils.js
+++ b/src/utils/architect/consentUtils.js
@@ -1,0 +1,6 @@
+export function requiresConsent(player, destinationTeamId) {
+  if (player?.hasFullNTC) return true;
+  if (Array.isArray(player?.limitedNTCTeams)) return !player.limitedNTCTeams.includes(destinationTeamId);
+  if (player?.oneYearBirdVeto) return true;
+  return false;
+}

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -27,6 +27,7 @@ import {
   violates30Day,
   violates2MonthAggregation,
 } from '@/utils/architect/timingUtils.js';
+import { requiresConsent } from '@/utils/architect/consentUtils.js';
 
 // ===== DEBUGGER =====
 const debug = {
@@ -1185,6 +1186,7 @@ export function validateTrade({
     const isOverCap = teamTotalSalary > (capSettings.cap || 0);
 
     const baseTeam = {
+      teamIndex: idx,
       teamId: team.team?.id,
       teamName: team.team?.teamName || 'Unknown Team',
       team: team.team,
@@ -1329,6 +1331,27 @@ export function validateTrade({
     }
     const stepienPass = stepienViolations.length === 0;
 
+    const consentViolations = [];
+    const reacqViolations = [];
+    team.outgoingPlayers.forEach((p) => {
+      const destTeamId =
+        p.tradeTo !== undefined
+          ? p.tradeTo
+          : teams[team.teamIndex === 0 ? 1 : 0]?.team?.id;
+      if (requiresConsent(p, destTeamId) && p.consent !== true) {
+        consentViolations.push(`${p.name} requires trade consent`);
+      }
+    });
+    team.incomingPlayers.forEach((p) => {
+      if (tradeCtx.wasTradedAwayWithinOneYear?.(p.id, team.teamId)) {
+        reacqViolations.push(
+          `${p.name} cannot be reacquired by ${team.teamId} within one year`
+        );
+      }
+    });
+    const consentPass = consentViolations.length === 0;
+    const reacqPass = reacqViolations.length === 0;
+
     const rosterCnt = team.projectedRosterCount;
     const rosterPass = true;
 
@@ -1415,6 +1438,20 @@ export function validateTrade({
           details: tpeViolations.join('; '),
         };
       })(),
+      consent: {
+        passed: consentPass,
+        message: consentPass ? 'Consent valid' : 'Consent required',
+        details: consentViolations.join('; '),
+        violations: consentViolations,
+      },
+      reacquisition: {
+        passed: reacqPass,
+        message: reacqPass
+          ? 'Re-acquisition valid'
+          : 'Re-acquisition violation',
+        details: reacqViolations.join('; '),
+        violations: reacqViolations,
+      },
     };
 
     const violations = [
@@ -1427,6 +1464,8 @@ export function validateTrade({
       ...rules.roster.violations,
       ...rules.signAndTrade.violations,
       ...rules.tradeExceptions.violations,
+      ...rules.consent.violations,
+      ...rules.reacquisition.violations,
     ];
     const teamPass =
       handcuffPass &&

--- a/tests/trade/consent_and_reacq.test.js
+++ b/tests/trade/consent_and_reacq.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { validateTrade } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import capProjections from '@/utils/architect/capProjections.js';
+
+const currentYear = 2025;
+const salary = 10_000_000;
+
+const makePlayer = (name, extra = {}) => ({
+  id: name,
+  name,
+  contract_clean: { salaries_by_year: { [currentYear]: { salary } } },
+  ...extra,
+});
+
+const makeTeam = (id, extraPlayers = []) => ({
+  id,
+  teamName: id,
+  totalSalary: 100_000_000,
+  picks: [],
+  players: Array.from({ length: 14 }, (_, i) => makePlayer(`${id}${i}`)).concat(
+    extraPlayers
+  ),
+});
+
+describe('consent and re-acquisition rules', () => {
+  it('blocks full NTC without consent', () => {
+    const ntc = makePlayer('NTC', { hasFullNTC: true });
+    const b1 = makePlayer('B1');
+    const teamA = makeTeam('A', [ntc]);
+    const teamB = makeTeam('B', [b1]);
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [ntc], picksOut: [] },
+        { team: teamB, sends: [b1], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: {},
+    });
+    expect(result.legal).toBe(false);
+  });
+
+  it('allows full NTC with consent', () => {
+    const ntc = makePlayer('NTC', { hasFullNTC: true, consent: true });
+    const b1 = makePlayer('B1');
+    const teamA = makeTeam('A', [ntc]);
+    const teamB = makeTeam('B', [b1]);
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [ntc], picksOut: [] },
+        { team: teamB, sends: [b1], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: {},
+    });
+    expect(result.legal).toBe(true);
+  });
+
+  it('allows limited NTC to approved team', () => {
+    const lntc = makePlayer('LNTC', { limitedNTCTeams: ['B'] });
+    const b1 = makePlayer('B1');
+    const teamA = makeTeam('A', [lntc]);
+    const teamB = makeTeam('B', [b1]);
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [lntc], picksOut: [] },
+        { team: teamB, sends: [b1], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: {},
+    });
+    expect(result.legal).toBe(true);
+  });
+
+  it('blocks limited NTC to non-approved team', () => {
+    const lntc = makePlayer('LNTC', { limitedNTCTeams: ['C'] });
+    const b1 = makePlayer('B1');
+    const teamA = makeTeam('A', [lntc]);
+    const teamB = makeTeam('B', [b1]);
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [lntc], picksOut: [] },
+        { team: teamB, sends: [b1], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: {},
+    });
+    expect(result.legal).toBe(false);
+  });
+
+  it('blocks one-year Bird veto without consent', () => {
+    const bird = makePlayer('BIRD', { oneYearBirdVeto: true });
+    const b1 = makePlayer('B1');
+    const teamA = makeTeam('A', [bird]);
+    const teamB = makeTeam('B', [b1]);
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [bird], picksOut: [] },
+        { team: teamB, sends: [b1], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: {},
+    });
+    expect(result.legal).toBe(false);
+  });
+
+  it('blocks re-acquisition within one year', () => {
+    const reacq = makePlayer('REACQ');
+    const a1 = makePlayer('A1');
+    const teamA = makeTeam('A', [a1]);
+    const teamB = makeTeam('B', [reacq]);
+    const result = validateTrade({
+      teams: [
+        { team: teamA, sends: [a1], picksOut: [] },
+        { team: teamB, sends: [reacq], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+      tradeCtx: {
+        wasTradedAwayWithinOneYear: (playerId, destTeamId) =>
+          playerId === 'REACQ' && destTeamId === 'A',
+      },
+    });
+    expect(result.legal).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `requiresConsent` helper for full/limited NTC and Bird veto
- validate player consent and 1-year reacquisition ban in trade validator
- cover consent and reacquisition scenarios in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892c9b8cf488326bb7ef7b3c048c20e