### PR TITLE
feat: add consent and cash ledger rules

### DIFF
--- a/src/config/validationFlags.js
+++ b/src/config/validationFlags.js
@@ -1,5 +1,9 @@
 export const validationFlags = {
   rosterEnforcement: 'warn',
   timingEnforcement: 'warn',
+  consent: 'error',
+  reAcquisition: 'error',
+  seasonalCash: 'warn',
+  twoWayRoster: 'warn',
   moratorium: { startMonth: 7, startDay: 1, endMonth: 7, endDay: 6 },
 };

--- a/src/features/architect/tradeMachine/TradeValidationPanel.jsx
+++ b/src/features/architect/tradeMachine/TradeValidationPanel.jsx
@@ -23,6 +23,26 @@ const RULE_INFO = [
     tip: 'Teams may not trade consecutive future first-round picks unless protected.',
     link: 'https://nba.com/cba/stepien-rule',
   },
+  {
+    pattern: /Player NTC — consent required/i,
+    tip: 'Players with no-trade clauses must approve any deal.',
+    link: 'https://nba.com/cba/no-trade-clause',
+  },
+  {
+    pattern: /1-yr Bird veto — consent required/i,
+    tip: 'One-year Bird-rights players can veto trades that would strip their rights.',
+    link: 'https://nba.com/cba/bird-rights',
+  },
+  {
+    pattern: /Re-acquisition bar/i,
+    tip: 'Teams cannot reacquire a player they recently traded or waived until the restriction expires.',
+    link: 'https://nba.com/cba/reacquisition',
+  },
+  {
+    pattern: /Two-way slots exceeded/i,
+    tip: 'Teams may roster at most 3 players on two-way contracts.',
+    link: 'https://nba.com/cba/two-way',
+  },
 ];
 
 const getRuleInfo = (msg) => {

--- a/src/utils/architect/cashUtils.js
+++ b/src/utils/architect/cashUtils.js
@@ -1,0 +1,22 @@
+const CBA_THRESHOLDS = {
+  MAX_CASH_IN: 7_100_000,
+  MAX_CASH_OUT: 7_100_000,
+};
+
+export function getSeasonalCashCaps(season) {
+  return {
+    maxCashIn: CBA_THRESHOLDS.MAX_CASH_IN,
+    maxCashOut: CBA_THRESHOLDS.MAX_CASH_OUT,
+  };
+}
+
+export function computeSeasonCashLedger(teamId, season, tradesHistory = []) {
+  const ledger = { sentToDate: 0, receivedToDate: 0 };
+  tradesHistory
+    .filter((t) => t.season === season)
+    .forEach((t) => {
+      if (t.fromTeamId === teamId) ledger.sentToDate += t.cashSent || 0;
+      if (t.toTeamId === teamId) ledger.receivedToDate += t.cashReceived || 0;
+    });
+  return ledger;
+}

--- a/src/utils/architect/consentUtils.js
+++ b/src/utils/architect/consentUtils.js
@@ -1,0 +1,19 @@
+export function requiresConsent(player, destTeamId) {
+  if (!player) return false;
+  return (
+    player.hasFullNTC === true ||
+    (Array.isArray(player.limitedNTCTeamIds) &&
+      player.limitedNTCTeamIds.includes(destTeamId))
+  );
+}
+
+export function hasConsent(player) {
+  return !!player?.consentGranted;
+}
+
+export function birdRightsVetoApplies(player, destTeamId) {
+  return (
+    player?.onOneYearBirdDeal === true &&
+    player?.currentTeamId !== destTeamId
+  );
+}

--- a/src/utils/architect/rosterUtils.js
+++ b/src/utils/architect/rosterUtils.js
@@ -1,11 +1,30 @@
-export function getActiveCount(team) {
-  return team.players?.length ?? 0;
-}
+import { MAX_TWO_WAY_PLAYERS as TWOWAY_MAX } from './cbaConstants.js';
+
 export function getTwoWayCount(team) {
-  return team.twoWayPlayers?.length ?? 0;
+  if (!team) return 0;
+  const roster = team.twoWayPlayers?.length || 0;
+  const flagged = (team.players || []).filter((p) => p.isTwoWay).length;
+  return roster + flagged;
 }
-export function passesRosterWindow(team, { graceMode = false } = {}) {
-  const act = getActiveCount(team);
-  if (graceMode) return act >= 13 && act <= 17;
-  return act >= 14 && act <= 15;
+
+function countStandardContracts(team) {
+  return team?.players?.filter((p) => !p.isTwoWay).length ?? 0;
+}
+
+const CBA_LIMITS = { TWOWAY_MAX };
+
+export function passesRosterWindow(
+  teamPostTrade,
+  { require14to15 = true, maxTwoWays = CBA_LIMITS.TWOWAY_MAX } = {}
+) {
+  const standard = countStandardContracts(teamPostTrade);
+  const twoWays = getTwoWayCount(teamPostTrade);
+  const reasons = [];
+  if (require14to15 && !(standard >= 14 && standard <= 15)) {
+    reasons.push('Standard roster must be 14–15');
+  }
+  if (twoWays > maxTwoWays) {
+    reasons.push(`Two-way slots exceeded (${twoWays}/${maxTwoWays})`);
+  }
+  return { ok: reasons.length === 0, reasons, standard, twoWays };
 }

--- a/src/utils/architect/timingUtils.js
+++ b/src/utils/architect/timingUtils.js
@@ -14,3 +14,24 @@ export function violates30Day(p, d) {
 export function violates2MonthAggregation(p, d) {
   return p?.signedDate && daysSince(p.signedDate, d) < 60;
 }
+export function violatesReacquisitionBar(player, acquiringTeamId, asOfDate) {
+  if (!player) return false;
+  const now = new Date(asOfDate || Date.now());
+  if (
+    player.lastTradedFromTeamId === acquiringTeamId &&
+    player.lastTradeDate &&
+    now - new Date(player.lastTradeDate) < 365 * 24 * 60 * 60 * 1000
+  ) {
+    return true;
+  }
+  if (player.wasWaivedByTeamId === acquiringTeamId) {
+    if (player.contractEndDate) {
+      const july1 = new Date(player.contractEndDate);
+      july1.setUTCFullYear(july1.getUTCFullYear() + 1, 6, 1);
+      if (now < july1) return true;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -5,7 +5,6 @@ import {
   getApronStatus,
   formatCurrency,
   wouldExceedHardCap,
-  getSeasonalCashLimit,
 } from '@/utils/architect/tradeHelpers.js'; // 🆕 .js extension kept for Vite
 import { CBA_MECHANICS } from '@/utils/architect/cbaMechanics.js';
 import {
@@ -26,7 +25,17 @@ import {
   isWithinMoratorium,
   violates30Day,
   violates2MonthAggregation,
+  violatesReacquisitionBar,
 } from '@/utils/architect/timingUtils.js';
+import {
+  requiresConsent,
+  hasConsent,
+  birdRightsVetoApplies,
+} from '@/utils/architect/consentUtils.js';
+import {
+  getSeasonalCashCaps,
+  computeSeasonCashLedger,
+} from '@/utils/architect/cashUtils.js';
 
 // ===== DEBUGGER =====
 const debug = {
@@ -262,16 +271,66 @@ export function enforceRosterWindow(
   tradeCtx = {},
   { warn = () => {}, reject = () => {} } = {}
 ) {
-  const ok = passesRosterWindow(teamCtx.postTradeTeam, {
-    graceMode: tradeCtx?.graceMode,
+  const check = passesRosterWindow(teamCtx.postTradeTeam, {
+    require14to15: !tradeCtx?.graceMode,
   });
-  if (!ok) {
-    const msg =
-      `Roster window: must finish with 14–15 standard contracts` +
-      (tradeCtx?.graceMode ? ` (grace 13–17)` : ``);
-    if (validationFlags.rosterEnforcement === 'error') reject(msg);
-    if (validationFlags.rosterEnforcement === 'warn') warn(msg);
+  const stdMsg = check.reasons.find((r) => r.startsWith('Standard'));
+  const twoWayMsg = check.reasons.find((r) => r.startsWith('Two-way'));
+  if (stdMsg) {
+    if (validationFlags.rosterEnforcement === 'error') reject(stdMsg);
+    if (validationFlags.rosterEnforcement === 'warn') warn(stdMsg);
   }
+  if (twoWayMsg) {
+    if (validationFlags.twoWayRoster === 'error') reject(twoWayMsg);
+    if (validationFlags.twoWayRoster === 'warn') warn(twoWayMsg);
+  }
+  return check;
+}
+
+export function enforceConsent(
+  teamCtx,
+  tradeCtx = {},
+  { warn = () => {}, reject = () => {} } = {}
+) {
+  const enforcement = validationFlags.consent;
+  const violations = [];
+  (teamCtx.outgoingPlayers || []).forEach((p) => {
+    const destId = p.tradeTo;
+    if (destId == null) return;
+    if (requiresConsent(p, destId) && !hasConsent(p)) {
+      const msg = 'Player NTC — consent required';
+      violations.push({ message: msg, details: p.name });
+      if (enforcement === 'error') reject(msg);
+      if (enforcement === 'warn') warn(msg);
+    }
+    if (birdRightsVetoApplies(p, destId) && !hasConsent(p)) {
+      const msg = '1-yr Bird veto — consent required';
+      violations.push({ message: msg, details: p.name });
+      if (enforcement === 'error') reject(msg);
+      if (enforcement === 'warn') warn(msg);
+    }
+  });
+  return violations;
+}
+
+export function enforceEligibility(
+  teamCtx,
+  ctx = {},
+  { warn = () => {}, reject = () => {} } = {}
+) {
+  const enforcement = validationFlags.reAcquisition;
+  const violations = [];
+  (teamCtx.incomingPlayers || []).forEach((p) => {
+    if (violatesReacquisitionBar(p, teamCtx.teamId, ctx.asOfDate)) {
+      const msg = `Re-acquisition bar: ${teamCtx.teamName} cannot reacquire ${p.name} until ${formatDate(
+        p.eligibleReacqDate
+      )}`;
+      violations.push(msg);
+      if (enforcement === 'error') reject(msg);
+      if (enforcement === 'warn') warn(msg);
+    }
+  });
+  return violations;
 }
 
 export function enforceTiming(
@@ -416,20 +475,38 @@ export function validateDraftPicks(team, allTeams) {
 }
 
 // CASH CONSIDERATIONS VALIDATION
-export function validateCash(team) {
+export function validateCash(team, ctx = {}) {
   const violations = [];
+  const season = ctx.season;
+  const tradesHistory = ctx.tradesHistory || [];
+  const caps = getSeasonalCashCaps(season);
+  const ledger = computeSeasonCashLedger(team.teamId, season, tradesHistory);
+  const projectedSent = (ledger.sentToDate || 0) + (team.cashSent || 0);
+  const projectedReceived = (ledger.receivedToDate || 0) + (team.cashReceived || 0);
 
-  if (team.cashSent > CBA_THRESHOLDS.MAX_CASH) {
-    violations.push(
-      `Cash sent ($${team.cashSent}) exceeds $${CBA_THRESHOLDS.MAX_CASH} limit`
-    );
-  }
-
-  if ((team.overSecondApron || team.willBeOverSecond) && team.cashSent > 0) {
+  if (team.postTradeStatus?.isAtOrAboveSecondApron && (team.cashSent > 0 || team.cashReceived > 0)) {
     violations.push('Second apron team cannot include cash in trades');
   }
 
-  return violations;
+  if (validationFlags.seasonalCash !== 'off') {
+    if (projectedSent > caps.maxCashOut) {
+      violations.push(
+        `Cash sent exceeds seasonal cap (${formatCurrency(projectedSent)}/${formatCurrency(caps.maxCashOut)})`
+      );
+    }
+    if (projectedReceived > caps.maxCashIn) {
+      violations.push(
+        `Cash received exceeds seasonal cap (${formatCurrency(projectedReceived)}/${formatCurrency(caps.maxCashIn)})`
+      );
+    }
+  }
+
+  return {
+    passed: violations.length === 0,
+    violations,
+    message: violations.length ? 'Cash invalid' : 'Cash valid',
+    details: violations.join('; '),
+  };
 }
 
 // SIGN-AND-TRADE RULES VALIDATION
@@ -1256,15 +1333,30 @@ export function validateTrade({
     const teamIsAtOrAboveSecondApron =
       capStatus.isAboveSecond || team.postTradeStatus.isAtOrAboveSecondApron;
 
+    const consentArr = enforceConsent(team, tradeCtx);
+    const consentPass =
+      consentArr.length === 0 || validationFlags.consent === 'warn';
+    const consentViolations = consentArr.map((v) => v.message);
+    const consentDetails = consentArr.map((v) => v.details).join('; ');
+
+    const reacqViolations = enforceEligibility(
+      team,
+      { asOfDate: tradeCtx.tradeDate },
+    );
+    const reacqPass =
+      reacqViolations.length === 0 || validationFlags.reAcquisition === 'warn';
+
     // --- Salary matching (2023 CBA + TPE)
     const allowable = getIncomingCeilingForTeam(team);
     const salaryPass = team.salaryIn <= allowable;
 
     // --- Cash limitations
-    const cashBan =
-      capStatus.isAboveSecond && (team.cashReceived > 0 || team.cashSent > 0);
-    const cashLimitFail = team.cashSent > getSeasonalCashLimit(seasonKey);
-    const cashPass = !cashBan && !cashLimitFail;
+    const cashCheck = validateCash(team, {
+      season: seasonKey,
+      tradesHistory: tradeCtx.tradesHistory || [],
+    });
+    const cashPass =
+      cashCheck.passed || validationFlags.seasonalCash === 'warn';
 
     // --- Second-apron aggregation (max from any single opponent ≤ max salary you send out)
     let aggregationPass = true;
@@ -1329,8 +1421,28 @@ export function validateTrade({
     }
     const stepienPass = stepienViolations.length === 0;
 
-    const rosterCnt = team.projectedRosterCount;
-    const rosterPass = true;
+    const currentTwoWay = team.team?.twoWayPlayers?.length || 0;
+    const outgoingTwoWay = (team.outgoingPlayers || []).filter((p) => p.isTwoWay)
+      .length;
+    const incomingTwoWay = team.incomingPlayers.filter((p) => p.isTwoWay).length;
+    const projectedTwoWay = currentTwoWay - outgoingTwoWay + incomingTwoWay;
+    const rosterCheck = passesRosterWindow(
+      {
+        players: Array(team.projectedRosterCount),
+        twoWayPlayers: Array(projectedTwoWay),
+      },
+      { require14to15: true }
+    );
+    const rosterCnt = rosterCheck.standard;
+    const twoWayCnt = rosterCheck.twoWays;
+    const rosterStandardViolation = rosterCheck.reasons.find((r) =>
+      r.startsWith('Standard')
+    );
+    const twoWayViolation = rosterCheck.reasons.find((r) => r.startsWith('Two-way'));
+    const rosterPass =
+      !rosterStandardViolation || validationFlags.rosterEnforcement === 'warn';
+    const twoWayRosterPass =
+      !twoWayViolation || validationFlags.twoWayRoster === 'warn';
 
     const capSheet = team.hardCapped
       ? { ...team.team, hardCapTriggered: 'FirstApron' }
@@ -1366,17 +1478,11 @@ export function validateTrade({
       },
       cash: {
         passed: cashPass,
-        message: cashPass ? 'Cash valid' : 'Cash invalid',
-        details: cashBan
-          ? 'Second apron team cannot include cash in trades'
-          : 'Cash sent exceeds league limit.',
+        message: cashPass ? 'Cash valid' : cashCheck.violations[0],
+        details: cashCheck.violations.slice(1).join('; '),
         violations: cashPass
           ? []
-          : [
-              cashBan
-                ? 'Second apron team cannot include cash in trades'
-                : 'Cash considerations invalid.',
-            ],
+          : cashCheck.violations,
       },
       aggregation: {
         passed: aggregationPass,
@@ -1392,9 +1498,21 @@ export function validateTrade({
       },
       roster: {
         passed: rosterPass,
-        message: rosterPass ? 'Roster size valid' : 'Roster size out of bounds',
-        details: `Projected size: ${rosterCnt} (must be 13-15)`,
-        violations: rosterPass ? [] : ['Roster size invalid.'],
+        message: rosterPass ? 'Roster size valid' : rosterStandardViolation,
+        details: `Projected size: ${rosterCnt}`,
+        violations:
+          rosterPass || validationFlags.rosterEnforcement === 'warn'
+            ? []
+            : [rosterStandardViolation],
+      },
+      twoWayRoster: {
+        passed: twoWayRosterPass,
+        message: twoWayRosterPass ? 'Two-way slots valid' : twoWayViolation,
+        details: twoWayRosterPass ? '' : `Two-way count: ${twoWayCnt}`,
+        violations:
+          twoWayRosterPass || validationFlags.twoWayRoster === 'warn'
+            ? []
+            : [twoWayViolation],
       },
       hardCap: {
         passed: hardCapPass,
@@ -1403,6 +1521,26 @@ export function validateTrade({
           team.projectedSalary
         )} would exceed hard cap.`,
         violations: hardCapPass ? [] : [hardCapMsg],
+      },
+      consent: {
+        passed: consentPass,
+        message: consentPass ? 'Player consent satisfied' : consentViolations[0],
+        details: consentPass ? '' : consentDetails,
+        violations:
+          consentPass || validationFlags.consent === 'warn'
+            ? []
+            : consentViolations,
+      },
+      reAcquisition: {
+        passed: reacqPass,
+        message: reacqPass
+          ? 'Re-acquisition bar satisfied'
+          : reacqViolations[0],
+        details: reacqViolations.slice(1).join('; '),
+        violations:
+          reacqPass || validationFlags.reAcquisition === 'warn'
+            ? []
+            : reacqViolations,
       },
       // Keep other rule checks if needed
       signAndTrade: validateSignAndTrade(team),
@@ -1425,6 +1563,9 @@ export function validateTrade({
       ...rules.cash.violations,
       ...rules.stepienRule.violations,
       ...rules.roster.violations,
+      ...rules.twoWayRoster.violations,
+      ...rules.consent.violations,
+      ...rules.reAcquisition.violations,
       ...rules.signAndTrade.violations,
       ...rules.tradeExceptions.violations,
     ];
@@ -1435,7 +1576,10 @@ export function validateTrade({
       aggregationPass &&
       stepienPass &&
       hardCapPass &&
-      rosterPass;
+      rosterPass &&
+      twoWayRosterPass &&
+      consentPass &&
+      reacqPass;
 
     return {
       ...team,
@@ -1448,6 +1592,9 @@ export function validateTrade({
         stepienPass,
         hardCapPass,
         rosterPass,
+        twoWayRosterPass,
+        consentPass,
+        reacqPass,
       },
       violations,
       legal: violations.length === 0,

--- a/tests/trade/cashLedger_season_tracking.test.js
+++ b/tests/trade/cashLedger_season_tracking.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { validateCash } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import { validationFlags } from '@/config/validationFlags.js';
+
+describe('seasonal cash ledger tracking', () => {
+  it('flags when cash out exceeds seasonal cap', () => {
+    validationFlags.seasonalCash = 'error';
+    const team = {
+      teamId: 1,
+      cashSent: 500_000,
+      cashReceived: 0,
+      postTradeStatus: {},
+    };
+    const history = [
+      { season: 2025, fromTeamId: 1, cashSent: 7_000_000 },
+    ];
+    const res = validateCash(team, { season: 2025, tradesHistory: history });
+    expect(res.violations[0]).toMatch(/Cash sent exceeds seasonal cap/);
+  });
+});

--- a/tests/trade/consent_and_birdVeto.test.js
+++ b/tests/trade/consent_and_birdVeto.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { enforceConsent } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import { validationFlags } from '@/config/validationFlags.js';
+
+const makeTeam = (player) => ({ outgoingPlayers: [player] });
+
+describe('player consent enforcement', () => {
+  afterEach(() => {
+    validationFlags.consent = 'error';
+  });
+
+  it('rejects full NTC without consent', () => {
+    const rejects = [];
+    enforceConsent(
+      makeTeam({ name: 'Full NTC', hasFullNTC: true, tradeTo: 2 }),
+      {},
+      { reject: (m) => rejects.push(m) }
+    );
+    expect(rejects).toContain('Player NTC — consent required');
+  });
+
+  it('rejects limited NTC without consent', () => {
+    const rejects = [];
+    enforceConsent(
+      makeTeam({
+        name: 'Limited',
+        limitedNTCTeamIds: [2],
+        tradeTo: 2,
+      }),
+      {},
+      { reject: (m) => rejects.push(m) }
+    );
+    expect(rejects).toContain('Player NTC — consent required');
+  });
+
+  it('handles Bird rights veto', () => {
+    const rejects = [];
+    enforceConsent(
+      makeTeam({
+        name: 'Bird',
+        onOneYearBirdDeal: true,
+        currentTeamId: 1,
+        tradeTo: 2,
+      }),
+      {},
+      { reject: (m) => rejects.push(m) }
+    );
+    expect(rejects).toContain('1-yr Bird veto — consent required');
+
+    const none = [];
+    enforceConsent(
+      makeTeam({
+        name: 'Bird',
+        onOneYearBirdDeal: true,
+        currentTeamId: 1,
+        tradeTo: 2,
+        consentGranted: true,
+      }),
+      {},
+      { reject: (m) => none.push(m) }
+    );
+    expect(none.length).toBe(0);
+  });
+});

--- a/tests/trade/reacquisition_bar.test.js
+++ b/tests/trade/reacquisition_bar.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { enforceEligibility } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import { validationFlags } from '@/config/validationFlags.js';
+
+describe('re-acquisition bar', () => {
+  afterEach(() => {
+    validationFlags.reAcquisition = 'error';
+  });
+
+  it('rejects trade-back within one year', () => {
+    const player = {
+      name: 'Traded',
+      lastTradedFromTeamId: 1,
+      lastTradeDate: new Date().toISOString(),
+      eligibleReacqDate: new Date(Date.now() + 365 * 24 * 3600 * 1000).toISOString(),
+    };
+    const rejects = [];
+    enforceEligibility(
+      { teamId: 1, teamName: 'Team', incomingPlayers: [player] },
+      { asOfDate: new Date(Date.now() + 100 * 24 * 3600 * 1000).toISOString() },
+      { reject: (m) => rejects.push(m) }
+    );
+    expect(rejects[0]).toMatch(/Re-acquisition bar/);
+  });
+
+  it('rejects reacquiring waived player before July 1 after contract end', () => {
+    const player = {
+      name: 'Waived',
+      wasWaivedByTeamId: 1,
+      contractEndDate: new Date().toISOString(),
+      eligibleReacqDate: new Date(Date.now() + 365 * 24 * 3600 * 1000).toISOString(),
+    };
+    const rejects = [];
+    enforceEligibility(
+      { teamId: 1, teamName: 'Team', incomingPlayers: [player] },
+      { asOfDate: new Date().toISOString() },
+      { reject: (m) => rejects.push(m) }
+    );
+    expect(rejects[0]).toMatch(/Re-acquisition bar/);
+  });
+});

--- a/tests/trade/roster_twoWay_enforcement.test.js
+++ b/tests/trade/roster_twoWay_enforcement.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { enforceRosterWindow } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import { validationFlags } from '@/config/validationFlags.js';
+
+const makeTeam = (std, tw) => ({
+  postTradeTeam: { players: Array(std), twoWayPlayers: Array(tw) },
+});
+
+describe('two-way roster enforcement', () => {
+  afterEach(() => {
+    validationFlags.twoWayRoster = 'warn';
+    validationFlags.rosterEnforcement = 'warn';
+  });
+
+  it('warns or rejects when two-way slots exceeded', () => {
+    const team = makeTeam(14, 4);
+    const warns = [];
+    const rejects = [];
+    enforceRosterWindow(team, {}, { warn: (m) => warns.push(m) });
+    expect(warns).toContain('Two-way slots exceeded (4/3)');
+    validationFlags.twoWayRoster = 'error';
+    enforceRosterWindow(team, {}, { reject: (m) => rejects.push(m) });
+    expect(rejects).toContain('Two-way slots exceeded (4/3)');
+  });
+
+  it('errors when standard roster outside 14-15', () => {
+    validationFlags.rosterEnforcement = 'error';
+    const rejects = [];
+    enforceRosterWindow(makeTeam(13, 0), {}, { reject: (m) => rejects.push(m) });
+    expect(rejects).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce player consent and Bird-rights veto checks
- block reacquisitions within one year and track seasonal cash ledgers
- validate two-way roster slots and surface new rule messages

## Testing
- `npm run lint` *(fails: React must be in scope, __dirname undefined, etc.)*
- `npx eslint src/utils/architect/consentUtils.js src/utils/architect/cashUtils.js src/utils/architect/timingUtils.js src/utils/architect/rosterUtils.js src/config/validationFlags.js src/utils/architect/tradeMachine/tradeValidator.js src/features/architect/tradeMachine/TradeValidationPanel.jsx tests/trade/consent_and_birdVeto.test.js tests/trade/reacquisition_bar.test.js tests/trade/cashLedger_season_tracking.test.js tests/trade/roster_twoWay_enforcement.test.js` *(fails: no-unused-vars in tradeValidator.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6892d9a874d883269b9e79a80a708cbe