### PR TITLE
feat: add fa exception trade buckets

### DIFF
--- a/src/config/validationFlags.js
+++ b/src/config/validationFlags.js
@@ -6,4 +6,7 @@ export const validationFlags = {
   seasonalCash: 'warn',
   twoWayRoster: 'warn',
   moratorium: { startMonth: 7, startDay: 1, endMonth: 7, endDay: 6 },
+  faExceptionTrade: 'on',
+  faExceptionEligible: undefined,
+  faExceptionAutoSelect: true,
 };

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -14,6 +14,11 @@ import { OutgoingPicksList } from './OutgoingPicksList';
 import TeamSelectDropdown from '@/components/shared/TeamSelectDropdown';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import TradeExceptionManager from './TradeExceptionManager';
+import {
+  getTeamFaExceptionBuckets,
+  isFaExceptionEligibleType,
+} from '@/utils/architect/faExceptionUtils.js';
+import { validationFlags } from '@/config/validationFlags.js';
 
 const TradeTeamCard = ({
   team,
@@ -97,6 +102,11 @@ const TradeTeamCard = ({
     const key = `${yearKey}-${String((yearKey + 1) % 100).padStart(2, '0')}`;
     return capProjections[key] || {};
   }, [yearKey]);
+
+  const faBuckets = useMemo(
+    () => getTeamFaExceptionBuckets(team || {}),
+    [team]
+  );
 
   const allowableIncoming = useMemo(
     () =>
@@ -355,8 +365,47 @@ const TradeTeamCard = ({
           <h4 className="text-white/70 text-sm mb-2">Incoming</h4>
           <div className="text-white/90">
             {incomingPlayers.map((p) => (
-              <div key={p.player_id || p.id} className="mb-1">
-                • {p.name}
+              <div
+                key={p.player_id || p.id}
+                className="mb-1 flex items-center gap-2"
+              >
+                <span>• {p.name}</span>
+                {validationFlags.faExceptionTrade !== 'off' && (
+                  <>
+                    <select
+                      className="bg-[#333] text-xs rounded px-1"
+                      value={p.absorptionMode || 'MATCH'}
+                      onChange={(e) =>
+                        onSetPlayerTrade &&
+                        onSetPlayerTrade(p, 'setAbsorptionMode', e.target.value)
+                      }
+                    >
+                      <option value="MATCH">Matching</option>
+                      <option value="TPE">TPE</option>
+                      <option value="FA_EXCEPTION">FA Exception</option>
+                    </select>
+                    {p.absorptionMode === 'FA_EXCEPTION' && (
+                      <select
+                        className="bg-[#333] text-xs rounded px-1"
+                        value={p.bucketType || ''}
+                        onChange={(e) =>
+                          onSetPlayerTrade &&
+                          onSetPlayerTrade(p, 'setFaBucket', e.target.value)
+                        }
+                      >
+                        {faBuckets
+                          .filter((b) =>
+                            isFaExceptionEligibleType(b.type, validationFlags)
+                          )
+                          .map((b) => (
+                            <option key={b.type} value={b.type}>
+                              {b.type} (${b.remaining})
+                            </option>
+                          ))}
+                      </select>
+                    )}
+                  </>
+                )}
               </div>
             ))}
             {incomingPicks.map((p) => (

--- a/src/features/architect/tradeMachine/TradeValidationPanel.jsx
+++ b/src/features/architect/tradeMachine/TradeValidationPanel.jsx
@@ -19,6 +19,26 @@ const RULE_INFO = [
     link: 'https://nba.com/cba/second-apron',
   },
   {
+    pattern: /FA Exception unavailable/i,
+    tip: 'FA Exceptions only available to teams below the first apron and not in the second apron.',
+    link: 'https://nba.com/cba/fa-exceptions',
+  },
+  {
+    pattern: /Cannot combine FA Exception/i,
+    tip: 'FA Exceptions cannot be combined with outgoing salary or other buckets for the same player.',
+    link: 'https://nba.com/cba/fa-exceptions',
+  },
+  {
+    pattern: /Insufficient FA Exception balance/i,
+    tip: 'Selected FA Exception bucket lacks enough value to absorb the player.',
+    link: 'https://nba.com/cba/fa-exceptions',
+  },
+  {
+    pattern: /hard-caps team at First Apron/i,
+    tip: 'Using a FA Exception imposes a First Apron hard cap for the season.',
+    link: 'https://nba.com/cba/aprons',
+  },
+  {
     pattern: /stepien/i,
     tip: 'Teams may not trade consecutive future first-round picks unless protected.',
     link: 'https://nba.com/cba/stepien-rule',

--- a/src/utils/architect/cbaConstants.js
+++ b/src/utils/architect/cbaConstants.js
@@ -46,6 +46,12 @@ export const MATCHING_BANDS_2023 = [
   { upTo: Infinity, allowed: (out) => 1.25 * out + 250_000 },
 ];
 
+// FA exception trade usage flags
+export const FA_EXCEPTION_TRADE_USAGE = {
+  enabled: true,
+  eligible: ['NTMLE', 'RMLE', 'BAE'],
+};
+
 /* --------------------------------------------------------------------------
      Misc “structural” constants (unchanged)
   -------------------------------------------------------------------------- */

--- a/src/utils/architect/faExceptionUtils.js
+++ b/src/utils/architect/faExceptionUtils.js
@@ -1,0 +1,53 @@
+/**
+ * Free-agency exception trade bucket utilities.
+ * These buckets behave similarly to trade exceptions but are drawn from
+ * specific free-agent exceptions (NTMLE, RMLE, BAE).
+ */
+import { FA_EXCEPTION_TRADE_USAGE } from '@/utils/architect/cbaConstants.js';
+
+export function getTeamFaExceptionBuckets(teamSeasonState = {}) {
+  return teamSeasonState.faExceptionBuckets || [];
+}
+
+export function isFaExceptionEligibleType(type, flags = {}) {
+  const eligible = flags.faExceptionEligible || FA_EXCEPTION_TRADE_USAGE.eligible;
+  return eligible?.includes(type);
+}
+
+export function canUseFaException(teamCtx = {}, bucketType) {
+  const { teamSeasonState = {}, teamTotalSalary = 0, context = {} } = teamCtx;
+  const { capSettings = {} } = context;
+  const bucket = getTeamFaExceptionBuckets(teamSeasonState).find(
+    (b) => b.type === bucketType
+  );
+  if (!bucket || bucket.remaining <= 0) return false;
+  const now = Date.now();
+  if (bucket.expiresAt && Date.parse(bucket.expiresAt) < now) return false;
+  if (capSettings.secondApron && teamTotalSalary >= capSettings.secondApron)
+    return false;
+  if (capSettings.firstApron && teamTotalSalary >= capSettings.firstApron)
+    return false;
+  return true;
+}
+
+export function allocateFaExceptionToIncoming({
+  teamCtx = {},
+  incomingPlayerId,
+  amount = 0,
+  bucketType,
+}) {
+  const { teamSeasonState = {} } = teamCtx;
+  const buckets = getTeamFaExceptionBuckets(teamSeasonState);
+  const bucket = buckets.find((b) => b.type === bucketType);
+  if (bucket) {
+    bucket.remaining = Math.max(0, (bucket.remaining || 0) - amount);
+  }
+  teamCtx.faExceptionUsage = teamCtx.faExceptionUsage || [];
+  teamCtx.faExceptionUsage.push({ playerId: incomingPlayerId, amount, type: bucketType });
+  return bucket;
+}
+
+export function summarizeFaExceptionUsage(teamCtx = {}) {
+  const usage = teamCtx.faExceptionUsage || [];
+  return usage.map((u) => `${u.type}:${u.amount}`).join(', ');
+}

--- a/src/utils/architect/hardCapTriggers.js
+++ b/src/utils/architect/hardCapTriggers.js
@@ -1,0 +1,9 @@
+/**
+ * Helper wrapper for recording First Apron hard-cap triggers.
+ */
+export function markHardCapTriggered(teamSeasonState = {}, { reason, season }) {
+  const current = teamSeasonState.hardCapFirstApron;
+  if (current?.active) return teamSeasonState;
+  teamSeasonState.hardCapFirstApron = { active: true, reason, season };
+  return teamSeasonState;
+}

--- a/src/utils/architect/hardCapUtils.js
+++ b/src/utils/architect/hardCapUtils.js
@@ -53,12 +53,14 @@ export const wouldExceedHardCap = (
   projectedTotalSalary,
   capSettings
 ) => {
-  const { hardCapTriggered } = teamCapSheet || {};
-  if (!hardCapTriggered) return false;
+  const { hardCapTriggered, hardCapFirstApron } = teamCapSheet || {};
+  if (!hardCapTriggered && !hardCapFirstApron?.active) return false;
 
   let hardCapLimit = null;
 
-  if (hardCapTriggered === true || hardCapTriggered === 'FirstApron') {
+  if (hardCapFirstApron?.active) {
+    hardCapLimit = capSettings.firstApron;
+  } else if (hardCapTriggered === true || hardCapTriggered === 'FirstApron') {
     hardCapLimit = capSettings.firstApron;
   } else if (hardCapTriggered === 'SecondApron') {
     hardCapLimit = capSettings.secondApron;
@@ -76,4 +78,10 @@ export const getHardCapLimit = (teamCapSheet, capSettings) => {
   if (hardCapTriggered === 'SecondApron') return capSettings.secondApron;
 
   return null;
+};
+
+export const isHardCappedAtFirstApron = (teamSeasonState = {}, season) => {
+  const hc = teamSeasonState.hardCapFirstApron;
+  if (!hc?.active) return false;
+  return season ? hc.season === season : true;
 };

--- a/src/utils/architect/tradeHelpers.js
+++ b/src/utils/architect/tradeHelpers.js
@@ -6,6 +6,7 @@
  * -------------------------------------------------------------------------------*/
 import { CBA_BY_YEAR, MATCHING_BANDS_2023 } from '@/utils/architect/cbaConstants.js';
 export { wouldExceedHardCap } from '@/utils/architect/hardCapUtils.js';
+import { getTeamFaExceptionBuckets } from '@/utils/architect/faExceptionUtils.js';
 
 export const getTierThresholds = (yearKey) => {
   const key = String(yearKey); // normalise
@@ -253,6 +254,18 @@ export const playerFitsInTPE = (player, yearKey, tpe) => {
   const exp = tpe.expirationDate ? Date.parse(tpe.expirationDate) : Infinity;
 
   return salary <= tpe.amount && now < exp;
+};
+
+export const getIncomingCeilingViaFaException = (teamCtx = {}, bucketType) => {
+  const buckets = getTeamFaExceptionBuckets(
+    teamCtx.teamSeasonState || teamCtx.team || {}
+  );
+  const bucket = buckets.find((b) => b.type === bucketType);
+  if (!bucket) return 0;
+  const firstApron = teamCtx.context?.capSettings?.firstApron || Infinity;
+  const salary = teamCtx.projectedSalary || teamCtx.teamTotalSalary || 0;
+  const apronRoom = firstApron - salary;
+  return Math.floor(Math.min(bucket.remaining || 0, apronRoom));
 };
 
 /*───────────────────────  Formatting & Misc Utilities  ───────────────────*/

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -5,6 +5,7 @@ import {
   getApronStatus,
   formatCurrency,
   wouldExceedHardCap,
+  getIncomingCeilingViaFaException,
 } from '@/utils/architect/tradeHelpers.js'; // 🆕 .js extension kept for Vite
 import { CBA_MECHANICS } from '@/utils/architect/cbaMechanics.js';
 import {
@@ -20,6 +21,14 @@ import {
   isExpiredTPE,
   canUseTPE,
 } from '@/utils/architect/tradeMachine/tpeUtils.js';
+import {
+  getTeamFaExceptionBuckets,
+  canUseFaException,
+  allocateFaExceptionToIncoming,
+  summarizeFaExceptionUsage,
+  isFaExceptionEligibleType,
+} from '@/utils/architect/faExceptionUtils.js';
+import { markHardCapTriggered } from '@/utils/architect/hardCapTriggers.js';
 import { isFrozenPick } from '@/utils/architect/draftPickUtils.js';
 import {
   isWithinMoratorium,
@@ -441,6 +450,117 @@ export function validateTradeExceptions(team) {
   return violations;
 }
 
+export function validateFaExceptionUsage(team, flags = validationFlags) {
+  const violations = [];
+  const { faExceptionTrade = 'on', faExceptionAutoSelect = true } = flags;
+  if (faExceptionTrade === 'off') {
+    if (team.incomingPlayers.some((p) => p.absorptionMode === 'FA_EXCEPTION')) {
+      violations.push('FA Exception usage disabled.');
+    }
+    return violations;
+  }
+
+  const ctx = {
+    teamSeasonState: team.team || {},
+    teamTotalSalary: team.teamTotalSalary || 0,
+    context: team.context || {},
+  };
+  const yearKey = ctx.context.yearKey;
+  const buckets = getTeamFaExceptionBuckets(ctx.teamSeasonState);
+  const faPlayers = (team.incomingPlayers || []).filter(
+    (p) => p.absorptionMode === 'FA_EXCEPTION' || (faExceptionAutoSelect && !p.absorptionMode)
+  );
+
+  faPlayers.forEach((player) => {
+    let mode = player.absorptionMode;
+    let bucketType = player.bucketType;
+    const salary = player.matchIncoming ?? getSalaryForYear(player, yearKey);
+
+    if (!mode && faExceptionAutoSelect) {
+      const bucket = buckets.find(
+        (b) =>
+          isFaExceptionEligibleType(b.type, flags) &&
+          canUseFaException(ctx, b.type) &&
+          b.remaining >= salary
+      );
+      if (bucket) {
+        mode = 'FA_EXCEPTION';
+        bucketType = bucket.type;
+        player.absorptionMode = 'FA_EXCEPTION';
+        player.bucketType = bucketType;
+      }
+    }
+
+    if (mode !== 'FA_EXCEPTION') return;
+
+    if (Array.isArray(bucketType)) {
+      violations.push(
+        'Cannot combine FA Exception with outgoing salary for the same player.'
+      );
+      return;
+    }
+
+    if (ctx.teamTotalSalary >= ctx.context.capSettings?.secondApron) {
+      violations.push('FA Exception unavailable above/beyond Second Apron.');
+      return;
+    }
+    if (ctx.teamTotalSalary >= ctx.context.capSettings?.firstApron) {
+      violations.push('FA Exception unavailable above/beyond First Apron.');
+      return;
+    }
+
+    const bucket = buckets.find((b) => b.type === bucketType);
+    if (!bucket || !isFaExceptionEligibleType(bucketType, flags)) {
+      violations.push(`FA Exception ${bucketType} not available`);
+      return;
+    }
+    if (team.outgoingPlayers?.some((p) => p.toTeamId === player.fromTeamId)) {
+      violations.push(
+        'Cannot combine FA Exception with outgoing salary for the same player.'
+      );
+      return;
+    }
+    if (salary > bucket.remaining) {
+      violations.push(
+        `Insufficient FA Exception balance (need $${salary}, have $${bucket.remaining}).`
+      );
+      return;
+    }
+    allocateFaExceptionToIncoming({
+      teamCtx: ctx,
+      incomingPlayerId: player.player_id || player.id,
+      amount: salary,
+      bucketType,
+    });
+  });
+
+  if (!violations.length && faPlayers.some((p) => p.absorptionMode === 'FA_EXCEPTION')) {
+    if (team.projectedSalary > ctx.context.capSettings?.firstApron) {
+      violations.push('FA Exception usage would exceed First Apron.');
+    } else {
+      markHardCapTriggered(ctx.teamSeasonState, {
+        reason: 'FA_EXCEPTION',
+        season: ctx.context.yearKey,
+      });
+      team.hardCapped = true;
+      team.notes = team.notes || [];
+      faPlayers.forEach((p) => {
+        if (p.absorptionMode === 'FA_EXCEPTION') {
+          const amt = p.matchIncoming ?? getSalaryForYear(p, yearKey);
+          team.notes.push(
+            `Absorbed ${p.name} via ${p.bucketType} bucket for $${amt}; team hard-capped at First Apron.`
+          );
+        }
+      });
+      if (debug.enabled) {
+        debug.faException = summarizeFaExceptionUsage(ctx);
+      }
+    }
+  }
+
+  return violations;
+}
+
 // DRAFT PICKS VALIDATION
 export function validateDraftPicks(team, allTeams) {
   const violations = [];
@@ -749,7 +869,7 @@ const getAllowableIncomingMargin = (team) => {
   const status = team.postTradeStatus || {};
   if (status.isAtOrAboveSecondApron) return 0;
   if (status.isAtOrAboveFirstApron) return 0;
-  return calculateAllowableIncoming(
+  const base = calculateAllowableIncoming(
     team.teamTotalSalary,
     team.salaryOut,
     team.incomingPlayers,
@@ -757,10 +877,18 @@ const getAllowableIncomingMargin = (team) => {
     team.context.capSettings,
     team.context.yearKey
   );
+  const faUsage = (team.incomingPlayers || [])
+    .filter((p) => p.absorptionMode === 'FA_EXCEPTION')
+    .reduce((sum, p) => sum + (p.matchIncoming || 0), 0);
+  return base + faUsage;
 };
 
-export const getIncomingCeilingForTeam = (team) =>
-  team.salaryOut + getAllowableIncomingMargin(team);
+export const getIncomingCeilingForTeam = (team) => {
+  if (team.absorptionMode === 'FA_EXCEPTION' && team.bucketType) {
+    return getIncomingCeilingViaFaException(team, team.bucketType);
+  }
+  return team.salaryOut + getAllowableIncomingMargin(team);
+};
 
 // ===== RULES =====
 const TRADE_RULES = {
@@ -1553,6 +1681,17 @@ export function validateTrade({
           details: tpeViolations.join('; '),
         };
       })(),
+      faException: (() => {
+        const faViolations = validateFaExceptionUsage(team, validationFlags);
+        return {
+          passed: faViolations.length === 0,
+          violations: faViolations,
+          message: faViolations.length
+            ? 'FA Exception violation'
+            : 'FA Exception usage valid',
+          details: faViolations.join('; '),
+        };
+      })(),
     };
 
     const violations = [
@@ -1568,6 +1707,7 @@ export function validateTrade({
       ...rules.reAcquisition.violations,
       ...rules.signAndTrade.violations,
       ...rules.tradeExceptions.violations,
+      ...rules.faException.violations,
     ];
     const teamPass =
       handcuffPass &&
@@ -1579,7 +1719,8 @@ export function validateTrade({
       rosterPass &&
       twoWayRosterPass &&
       consentPass &&
-      reacqPass;
+      reacqPass &&
+      rules.faException.passed;
 
     return {
       ...team,

--- a/tests/trade/faExceptions_as_trade_buckets.test.js
+++ b/tests/trade/faExceptions_as_trade_buckets.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { validateFaExceptionUsage } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import { validationFlags } from '@/config/validationFlags.js';
+
+const baseTeam = {
+  context: {
+    yearKey: 2025,
+    capSettings: { firstApron: 172_000_000, secondApron: 182_000_000 },
+  },
+  team: { faExceptionBuckets: [] },
+  incomingPlayers: [],
+  outgoingPlayers: [],
+  salaryOut: 0,
+  salaryIn: 0,
+  teamTotalSalary: 0,
+  projectedSalary: 0,
+};
+
+const makePlayer = (salary, extra = {}) => ({
+  name: 'Player',
+  matchIncoming: salary,
+  player_id: Math.random(),
+  ...extra,
+});
+
+describe('FA exceptions as trade buckets', () => {
+  it('allows eligible usage and hard-caps team', () => {
+    validationFlags.faExceptionTrade = 'on';
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 150_000_000,
+      projectedSalary: 158_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [
+        makePlayer(8_000_000, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: 'NTMLE',
+          fromTeamId: 2,
+        }),
+      ],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v).toEqual([]);
+    expect(team.team.faExceptionBuckets[0].remaining).toBe(2_000_000);
+    expect(team.team.hardCapFirstApron.active).toBe(true);
+  });
+
+  it('rejects usage at or above first apron', () => {
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 172_000_000,
+      projectedSalary: 180_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [
+        makePlayer(8_000_000, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: 'NTMLE',
+          fromTeamId: 2,
+        }),
+      ],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v[0]).toMatch(/First Apron/);
+  });
+
+  it('rejects when post-trade salary exceeds first apron', () => {
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 170_000_000,
+      projectedSalary: 175_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [
+        makePlayer(5_000_000, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: 'NTMLE',
+          fromTeamId: 2,
+        }),
+      ],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v[0]).toMatch(/exceed First Apron/);
+  });
+
+  it('rejects usage for second apron teams', () => {
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 185_000_000,
+      projectedSalary: 193_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [
+        makePlayer(8_000_000, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: 'NTMLE',
+          fromTeamId: 2,
+        }),
+      ],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v[0]).toMatch(/Second Apron/);
+  });
+
+  it('rejects aggregation with outgoing salary', () => {
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 150_000_000,
+      projectedSalary: 158_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [
+        makePlayer(8_000_000, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: 'NTMLE',
+          fromTeamId: 2,
+        }),
+      ],
+      outgoingPlayers: [{ toTeamId: 2, salary: 0 }],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v[0]).toMatch(/Cannot combine FA Exception/);
+  });
+
+  it('rejects splitting across buckets', () => {
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 150_000_000,
+      projectedSalary: 158_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [
+        makePlayer(8_000_000, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: ['NTMLE', 'BAE'],
+          fromTeamId: 2,
+        }),
+      ],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v[0]).toMatch(/Cannot combine FA Exception/);
+  });
+
+  it('rejects when bucket is too small', () => {
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 150_000_000,
+      projectedSalary: 158_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 5_000_000 }] },
+      incomingPlayers: [
+        makePlayer(8_000_000, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: 'NTMLE',
+          fromTeamId: 2,
+        }),
+      ],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v[0]).toMatch(/Insufficient FA Exception balance/);
+  });
+
+  it('auto-selects bucket when enabled', () => {
+    const team = {
+      ...baseTeam,
+      teamTotalSalary: 150_000_000,
+      projectedSalary: 158_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [makePlayer(8_000_000, { fromTeamId: 2 })],
+    };
+    const v = validateFaExceptionUsage(team);
+    expect(v).toEqual([]);
+    expect(team.incomingPlayers[0].absorptionMode).toBe('FA_EXCEPTION');
+    expect(team.notes[0]).toMatch(/hard-capped/);
+  });
+});

--- a/tests/trade/hardCap_trigger_faException.test.js
+++ b/tests/trade/hardCap_trigger_faException.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { validateFaExceptionUsage } from '@/utils/architect/tradeMachine/tradeValidator.js';
+import { isHardCappedAtFirstApron, wouldExceedHardCap } from '@/utils/architect/hardCapUtils.js';
+
+const teamBase = {
+  context: {
+    yearKey: 2025,
+    capSettings: { firstApron: 172_000_000, secondApron: 182_000_000 },
+  },
+  team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+  incomingPlayers: [
+    {
+      name: 'Player',
+      matchIncoming: 8_000_000,
+      absorptionMode: 'FA_EXCEPTION',
+      bucketType: 'NTMLE',
+      fromTeamId: 2,
+    },
+  ],
+  outgoingPlayers: [],
+  salaryOut: 0,
+  salaryIn: 8_000_000,
+  teamTotalSalary: 150_000_000,
+  projectedSalary: 158_000_000,
+};
+
+describe('hard cap trigger via FA exception', () => {
+  it('marks team hard-capped at first apron', () => {
+    const team = JSON.parse(JSON.stringify(teamBase));
+    const v = validateFaExceptionUsage(team);
+    expect(v).toEqual([]);
+    expect(isHardCappedAtFirstApron(team.team, 2025)).toBe(true);
+    expect(
+      wouldExceedHardCap(team.team, 173_000_000, team.context.capSettings)
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- allow FA exceptions (NTMLE/RMLE/BAE) to absorb trade salary with new config flags
- track FA exception usage and trigger first-apron hard cap
- expose UI controls and messages for FA exception absorption

## Testing
- `npm run lint` *(fails: React must be in scope; __dirname not defined; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6892e43d35b08326b8686f86836925a4