### PR TITLE
feat: align consent and second apron trade rules

### DIFF
--- a/src/utils/architect/consentUtils.js
+++ b/src/utils/architect/consentUtils.js
@@ -2,37 +2,86 @@ export function requiresConsent(player, destTeamId) {
   if (!player) return false;
   return (
     player.hasFullNTC === true ||
-    (Array.isArray(player.limitedNTCTeamIds) &&
-      player.limitedNTCTeamIds.includes(destTeamId))
+    player.contract?.fullNTC === true ||
+    (Array.isArray(
+      player.limitedNTCTeamIds ||
+        player.limitedNTCTeams ||
+        player.contract?.limitedNTCList
+    ) &&
+      (player.limitedNTCTeamIds ||
+        player.limitedNTCTeams ||
+        player.contract?.limitedNTCList
+      ).includes(destTeamId))
   );
 }
 
 export function hasConsent(player) {
-  return !!player?.consentGranted;
+  return (
+    player?.consentGranted === true ||
+    player?.consent === true ||
+    player?.consents?.full === true ||
+    player?.consents?.limited === true ||
+    player?.consents?.birdOneYear === true
+  );
 }
 
 export function birdRightsVetoApplies(player, destTeamId) {
   return (
-    player?.onOneYearBirdDeal === true &&
+    (player?.onOneYearBirdDeal === true || player?.oneYearBirdVeto === true) &&
     player?.currentTeamId !== destTeamId
   );
 }
 
 // Simple consent gates for tradeValidator
 export function hasFullNTC(player) {
-  return !!player?.contract?.fullNTC;
+  return player?.hasFullNTC === true || player?.contract?.fullNTC === true;
 }
 
 export function destinationRequiresLimitedNTCConsent(player, destTeamId) {
-  const lst = player?.contract?.limitedNTCList;
+  if (Array.isArray(player?.limitedNTCTeamIds) && player.limitedNTCTeamIds.length) {
+    return player.limitedNTCTeamIds.includes(destTeamId);
+  }
+  const lst = player?.limitedNTCTeams || player?.contract?.limitedNTCList;
   if (!Array.isArray(lst) || lst.length === 0) return false;
   return !lst.includes(destTeamId);
 }
 
 export function requiresBirdOneYearConsent(player) {
+  if (player?.onOneYearBirdDeal || player?.oneYearBirdVeto) return true;
   const isOneYear = player?.contract?.yearsRemaining === 1;
   const hasBird = !!player?.rights?.bird;
   return isOneYear && hasBird;
+}
+
+export function collectConsentViolations(
+  player,
+  destTeamId,
+  consentInfo = {},
+  notifier = {}
+) {
+  const messages = [];
+  const reject = notifier.reject || (() => {});
+  const hasConsentFlag =
+    consentInfo.full === true ||
+    consentInfo.limited === true ||
+    consentInfo.bird === true ||
+    hasConsent(player);
+
+  if (
+    (hasFullNTC(player) ||
+      destinationRequiresLimitedNTCConsent(player, destTeamId)) &&
+    !hasConsentFlag
+  ) {
+    const msg = 'Player NTC — consent required';
+    reject(msg);
+    messages.push(msg);
+  }
+  if (requiresBirdOneYearConsent(player) && consentInfo.bird !== true && !hasConsent(player)) {
+    const msg = '1-yr Bird veto — consent required';
+    reject(msg);
+    messages.push(msg);
+  }
+  return messages;
 }
 
 // Backwards compatibility exports

--- a/src/utils/architect/reacqUtils.js
+++ b/src/utils/architect/reacqUtils.js
@@ -7,13 +7,40 @@ export function violatesReacquisitionBar(
 }
 
 export function getReacqBlock(player, destTeamId, nowDate = new Date()) {
-  const lastSeparatedISO =
-    player?.history?.lastSeparatedFromTeam?.[destTeamId];
-  if (!lastSeparatedISO) return { blocked: false };
-  const last = new Date(lastSeparatedISO).getTime();
-  const yr = new Date(last);
-  yr.setFullYear(yr.getFullYear() + 1);
-  const blocked = nowDate.getTime() < yr.getTime();
-  return blocked ? { blocked: true, until: new Date(yr) } : { blocked: false };
+  // Handle trades/separations
+  const separatedISO =
+    player?.history?.lastSeparatedFromTeam?.[destTeamId] ||
+    (player?.lastTradedFromTeamId === destTeamId ? player.lastTradeDate : null);
+  if (separatedISO) {
+    const base = new Date(separatedISO);
+    const until = player.eligibleReacqDate
+      ? new Date(player.eligibleReacqDate)
+      : new Date(base.setFullYear(base.getFullYear() + 1));
+    if (nowDate.getTime() < until.getTime()) {
+      return { blocked: true, until };
+    }
+  }
+
+  // Handle waived players
+  const waivedISO =
+    player?.history?.waivedByTeam?.[destTeamId]?.finalSeasonEndISO ||
+    (player?.wasWaivedByTeamId === destTeamId ? player.contractEndDate : null);
+  if (waivedISO) {
+    const base = new Date(waivedISO);
+    const until = player.eligibleReacqDate
+      ? new Date(player.eligibleReacqDate)
+      : new Date(
+          Date.UTC(
+            base.getUTCFullYear() + (base.getUTCMonth() >= 6 ? 1 : 0),
+            6,
+            1
+          )
+        );
+    if (nowDate.getTime() < until.getTime()) {
+      return { blocked: true, until };
+    }
+  }
+
+  return { blocked: false };
 }
 

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -16,7 +16,6 @@ import { BYC_PERCENT } from '@/utils/architect/cbaConstants.js';
 import { passesRosterWindow } from '@/utils/architect/rosterUtils.js';
 import { validationFlags } from '@/config/validationFlags.js';
 import {
-  hasPriorYearTPE,
   createTPE,
   isExpiredTPE,
   canUseTPE,
@@ -38,9 +37,7 @@ import {
   violates2MonthAggregation,
 } from '@/utils/architect/timingUtils.js';
 import {
-  hasFullNTC,
-  destinationRequiresLimitedNTCConsent,
-  requiresBirdOneYearConsent,
+  collectConsentViolations,
 } from '@/utils/architect/consentUtils.js';
 import { getReacqBlock } from '@/utils/architect/reacqUtils.js';
 import {
@@ -234,29 +231,45 @@ export function enforceSecondApronHandcuffs(teamCtx, tradeCtx = {}) {
 
   const outgoing = teamCtx.outgoingPlayers || [];
   const incoming = teamCtx.incomingPlayers || [];
+
+  const season = teamCtx.context?.yearKey;
+  const usedTPEIds = new Set(
+    incoming.filter((p) => p.acquiredViaTPE && p.tpeId).map((p) => p.tpeId)
+  );
+  if (season != null) {
+    let addedGeneric = false;
+    let priorAdded = false;
+    const addPrior = () => {
+      if (!priorAdded) {
+        violations.push('Second apron: prior-year TPEs cannot be used.');
+        priorAdded = true;
+      }
+      if (!addedGeneric) {
+        violations.push(SECOND_APRON_TPE_BLOCK);
+        addedGeneric = true;
+      }
+    };
+    if (usedTPEIds.size) {
+      (teamCtx.tradeExceptions || []).forEach((tpe) => {
+        if (usedTPEIds.has(tpe.id) && isPriorYearTPE(tpe, season)) {
+          addPrior();
+        }
+      });
+    }
+    if (
+      Array.isArray(teamCtx.appliedTPEs) &&
+      teamCtx.appliedTPEs.some((tpe) => isPriorYearTPE(tpe, season))
+    ) {
+      addPrior();
+    }
+  }
+
   if (outgoing.length > 1 && incoming.length <= 1) {
     violations.push('Second apron teams cannot aggregate salaries');
   }
 
   if (teamCtx.cashSent > 0 || teamCtx.cashReceived > 0) {
     violations.push('Second apron team cannot include cash in trades');
-  }
-
-  const season = teamCtx.context?.yearKey;
-  const usedTPEIds = new Set(
-    incoming.filter((p) => p.acquiredViaTPE && p.tpeId).map((p) => p.tpeId)
-  );
-  if (usedTPEIds.size && season != null) {
-    let addedGeneric = false;
-    (teamCtx.tradeExceptions || []).forEach((tpe) => {
-      if (usedTPEIds.has(tpe.id) && isPriorYearTPE(tpe, season)) {
-        if (!addedGeneric) {
-          violations.push(SECOND_APRON_TPE_BLOCK);
-          addedGeneric = true;
-        }
-        violations.push('Second apron: prior-year TPEs cannot be used.');
-      }
-    });
   }
 
   if ((teamCtx.salaryIn || 0) > (teamCtx.salaryOut || 0)) {
@@ -297,33 +310,21 @@ export function enforceConsent(
   const consentMap = tradeCtx.consent || {};
   const seen = new Set();
   (teamCtx.outgoingPlayers || []).forEach((p) => {
-    const destId = p.tradeTo;
-    if (destId == null) return;
+    const destId =
+      p.tradeTo ??
+      p.toTeamId ??
+      Object.keys(tradeCtx.teamNames || {}).find(
+        (id) => id !== teamCtx.teamId
+      );
     const consent = consentMap[p.id] || {};
-
-    if (
-      (hasFullNTC(p) && consent.full !== true) ||
-      (destinationRequiresLimitedNTCConsent(p, destId) &&
-        consent.limited !== true)
-    ) {
-      const msg = 'Player NTC — consent required';
+    const msgs = collectConsentViolations(p, destId, consent, { reject });
+    msgs.forEach((msg) => {
       if (!seen.has(msg)) {
-        violations.push({ message: msg, details: p.name });
+        violations.push(msg);
         seen.add(msg);
-        reject(msg);
         if (enforcement === 'warn') warn(msg);
       }
-    }
-
-    if (requiresBirdOneYearConsent(p) && consent.bird !== true) {
-      const msg = '1-yr Bird veto — consent required';
-      if (!seen.has(msg)) {
-        violations.push({ message: msg, details: p.name });
-        seen.add(msg);
-        reject(msg);
-        if (enforcement === 'warn') warn(msg);
-      }
-    }
+    });
   });
   return violations;
 }
@@ -335,9 +336,22 @@ export function enforceEligibility(
 ) {
   const enforcement = validationFlags.reAcquisition;
   const violations = [];
-  const nowDate = ctx.now ? new Date(ctx.now) : new Date();
+  const nowDate = ctx.now
+    ? new Date(ctx.now)
+    : ctx.asOfDate
+    ? new Date(ctx.asOfDate)
+    : new Date();
   (teamCtx.incomingPlayers || []).forEach((p) => {
-    const block = getReacqBlock(p, teamCtx.teamId, nowDate);
+    let block = getReacqBlock(p, teamCtx.teamId, nowDate);
+    if (
+      !block.blocked &&
+      typeof ctx.wasTradedAwayWithinOneYear === 'function' &&
+      ctx.wasTradedAwayWithinOneYear(p.id, teamCtx.teamId)
+    ) {
+      const until = new Date(nowDate);
+      until.setFullYear(until.getFullYear() + 1);
+      block = { blocked: true, until };
+    }
     if (block.blocked) {
       const dateStr = block.until.toISOString().slice(0, 10);
       const msg = `Re-acquisition bar: ${teamCtx.teamName} cannot reacquire ${p.name} until ${dateStr}`;
@@ -435,22 +449,18 @@ export function validateTradeExceptions(team) {
       violations.push('Cannot aggregate trade exception with outgoing salary');
       return;
     }
-    if (
-      team.postTradeStatus?.isAtOrAboveSecondApron &&
-      isPriorYearTPE(tpe, yearKey)
-    ) {
-      if (!addedGeneric) {
+    if (team.postTradeStatus?.isAtOrAboveSecondApron) {
+      const prior = isPriorYearTPE(tpe, yearKey);
+      if (!prior && !addedGeneric) {
         violations.push(SECOND_APRON_TPE_BLOCK);
         addedGeneric = true;
       }
-      violations.push('Second apron: prior-year TPEs cannot be used.');
+      if (!prior && isExpiredTPE(tpe, onDate)) {
+        violations.push(`Trade exception ${tpe.id} is expired`);
+      }
       return;
     }
     if (!canUseTPE(team, tpe, { currentSeason: yearKey, onDate })) {
-      if (!addedGeneric && team.postTradeStatus?.isAtOrAboveSecondApron) {
-        violations.push(SECOND_APRON_TPE_BLOCK);
-        addedGeneric = true;
-      }
       if (isExpiredTPE(tpe, onDate)) {
         violations.push(`Trade exception ${tpe.id} is expired`);
       } else {
@@ -495,6 +505,19 @@ export function validateFaExceptionUsage(team, flags = validationFlags) {
       (faExceptionAutoSelect && !p.absorptionMode)
   );
 
+  if (
+    faPlayers.length &&
+    ctx.teamTotalSalary >= ctx.context.capSettings?.secondApron
+  ) {
+    violations.push(
+      'Second Apron — trade exceptions are banned for second-apron teams'
+    );
+    if (!addedGeneric) {
+      violations.push(SECOND_APRON_TPE_BLOCK);
+      addedGeneric = true;
+    }
+  }
+
   faPlayers.forEach((player) => {
     let mode = player.absorptionMode;
     let bucketType = player.bucketType;
@@ -525,11 +548,9 @@ export function validateFaExceptionUsage(team, flags = validationFlags) {
     }
 
     if (ctx.teamTotalSalary >= ctx.context.capSettings?.secondApron) {
-      if (!addedGeneric) {
-        violations.push(SECOND_APRON_TPE_BLOCK);
-        addedGeneric = true;
+      if (!violations.includes('FA Exception unavailable above/beyond Second Apron.')) {
+        violations.push('FA Exception unavailable above/beyond Second Apron.');
       }
-      violations.push('FA Exception unavailable above/beyond Second Apron.');
       return;
     }
     if (ctx.teamTotalSalary >= ctx.context.capSettings?.firstApron) {
@@ -1492,13 +1513,6 @@ export function validateTrade({
   const validatedTeams = teamResults.map((team) => {
     const seasonKey = team.context.yearKey;
     const handcuffViolations = enforceSecondApronHandcuffs(team, tradeCtx);
-    if (
-      team.postTradeStatus.isAtOrAboveSecondApron &&
-      hasPriorYearTPE(team.appliedTPEs, seasonKey)
-    ) {
-      handcuffViolations.push(SECOND_APRON_TPE_BLOCK);
-      handcuffViolations.push('Second apron: prior-year TPEs cannot be used.');
-    }
     const handcuffPass = handcuffViolations.length === 0;
     const capStatus = {
       isAboveSecond: team.currentApronStatus.includes('2nd Apron'),
@@ -1513,12 +1527,15 @@ export function validateTrade({
     );
     const consentPass =
       consentArr.length === 0 || validationFlags.consent === 'warn';
-    const consentViolations = consentArr.map((v) => v.message);
-    const consentDetails = consentArr.map((v) => v.details).join('; ');
+    const consentViolations = consentArr;
+    const consentDetails = '';
     const signAndTradePass = signAndTradeResult.passed;
     const reacqViolations = enforceEligibility(
       team,
-      { now: tradeCtx.tradeDate },
+      {
+        now: tradeCtx.tradeDate,
+        wasTradedAwayWithinOneYear: tradeCtx.wasTradedAwayWithinOneYear,
+      },
       { reject: rejectMsg }
     );
     const reacqPass =


### PR DESCRIPTION
## Summary
- unify consent checks and emit explicit notifier messages
- block reacquisition and second-apron trade exception use with precise strings
- add banner warnings for FA exception usage over the Second Apron

## Testing
- `npm test tests/trade/consent_and_birdVeto.test.js tests/trade/consent_and_reacq.test.js tests/trade/reacquisition_bar.test.js tests/trade/tpe_creation_expiry_usage.test.js tests/trade/faExceptions_as_trade_buckets.test.js tests/trade/secondApron_handcuffs.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689316aa31248326bc0ed1209953d1d3