### PR TITLE
feat: permit current-year TPE use for second-apron teams

### DIFF
--- a/src/utils/architect/tradeMachine/tpeUtils.js
+++ b/src/utils/architect/tradeMachine/tpeUtils.js
@@ -40,6 +40,8 @@ export function isExpiredTPE(tpe, onDate) {
 
 export function canUseTPE(teamCtx, tpe, { currentSeason, onDate }) {
   if (!tpe || isExpiredTPE(tpe, onDate)) return false;
-  // Second-apron logic handled upstream; this helper only checks expiry.
+  if (teamCtx?.postTradeStatus?.isAtOrAboveSecondApron) {
+    return !isPriorYearTPE(tpe, currentSeason);
+  }
   return true;
 }

--- a/src/utils/architect/tradeMachine/tradeValidator.js
+++ b/src/utils/architect/tradeMachine/tradeValidator.js
@@ -250,11 +250,11 @@ export function enforceSecondApronHandcuffs(teamCtx, tradeCtx = {}) {
     let addedGeneric = false;
     (teamCtx.tradeExceptions || []).forEach((tpe) => {
       if (usedTPEIds.has(tpe.id) && isPriorYearTPE(tpe, season)) {
+        violations.push('Second apron: prior-year TPEs cannot be used.');
         if (!addedGeneric) {
           violations.push(SECOND_APRON_TPE_BLOCK);
           addedGeneric = true;
         }
-        violations.push('Second apron: prior-year TPEs cannot be used.');
       }
     });
   }
@@ -435,26 +435,26 @@ export function validateTradeExceptions(team) {
       violations.push('Cannot aggregate trade exception with outgoing salary');
       return;
     }
-    if (
-      team.postTradeStatus?.isAtOrAboveSecondApron &&
-      isPriorYearTPE(tpe, yearKey)
-    ) {
-      if (!addedGeneric) {
-        violations.push(SECOND_APRON_TPE_BLOCK);
-        addedGeneric = true;
-      }
-      violations.push('Second apron: prior-year TPEs cannot be used.');
-      return;
-    }
     if (!canUseTPE(team, tpe, { currentSeason: yearKey, onDate })) {
-      if (!addedGeneric && team.postTradeStatus?.isAtOrAboveSecondApron) {
-        violations.push(SECOND_APRON_TPE_BLOCK);
-        addedGeneric = true;
-      }
-      if (isExpiredTPE(tpe, onDate)) {
-        violations.push(`Trade exception ${tpe.id} is expired`);
+      if (
+        team.postTradeStatus?.isAtOrAboveSecondApron &&
+        isPriorYearTPE(tpe, yearKey)
+      ) {
+        violations.push('Second apron: prior-year TPEs cannot be used.');
+        if (!addedGeneric) {
+          violations.push(SECOND_APRON_TPE_BLOCK);
+          addedGeneric = true;
+        }
       } else {
-        violations.push(`Cannot use trade exception ${tpe.id}`);
+        if (!addedGeneric && team.postTradeStatus?.isAtOrAboveSecondApron) {
+          violations.push(SECOND_APRON_TPE_BLOCK);
+          addedGeneric = true;
+        }
+        if (isExpiredTPE(tpe, onDate)) {
+          violations.push(`Trade exception ${tpe.id} is expired`);
+        } else {
+          violations.push(`Cannot use trade exception ${tpe.id}`);
+        }
       }
       return;
     }
@@ -1494,10 +1494,11 @@ export function validateTrade({
     const handcuffViolations = enforceSecondApronHandcuffs(team, tradeCtx);
     if (
       team.postTradeStatus.isAtOrAboveSecondApron &&
-      hasPriorYearTPE(team.appliedTPEs, seasonKey)
+      hasPriorYearTPE(team.appliedTPEs, seasonKey) &&
+      !handcuffViolations.includes(SECOND_APRON_TPE_BLOCK)
     ) {
-      handcuffViolations.push(SECOND_APRON_TPE_BLOCK);
       handcuffViolations.push('Second apron: prior-year TPEs cannot be used.');
+      handcuffViolations.push(SECOND_APRON_TPE_BLOCK);
     }
     const handcuffPass = handcuffViolations.length === 0;
     const capStatus = {


### PR DESCRIPTION
## Summary
- permit second-apron teams to apply trade exceptions created this season
- return prior-year TPE violation before generic second-apron block
- dedupe handcuff messages when prior-year TPEs are detected

## Testing
- `npm run lint` *(fails: 'React' must be in scope when using JSX, '__dirname' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68931ef96388832697a99bf5234d784d