### PR TITLE
docs: refresh audit certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HoopZero
 
-[![Audit Status](https://img.shields.io/badge/audit-pass-brightgreen)](docs/AUDIT_CERT.md)
+[![NBA Trade Audit: PASS](https://img.shields.io/badge/NBA%20Trade%20Audit-PASS-brightgreen)](docs/AUDIT_CERT.md)
 
 HoopZero is a public-facing NBA scouting platform focused on clear data presentation and role-based player analysis. It mirrors the internal **ScoutZero** grading tool but exposes a read-only interface backed entirely by Firebase. All player evaluations, roles, grades and contract details are fetched from Firestore, allowing fans and analysts to explore a flattened set of scouting data.
 
@@ -97,6 +97,13 @@ This project uses multiple Firestore collections to separate global player data 
 
 - **ScoutZero** – internal evaluation suite used to create player grades and roles. HoopZero presents this data in a read‑only form.
 - **HoopZero Architect** – forthcoming team‑building and GM toolkit that will integrate with the same player database.
+
+## Compliance
+
+- [Audit Certification](docs/AUDIT_CERT.md)
+- [Deep Audit](docs/AUDIT_DEEP.md)
+- [Compliance Matrix](docs/COMPLIANCE_MATRIX.csv)
+- [Order of Operations](docs/ORDER_OF_OPERATIONS.md)
 
 ## Developer Guide
 

--- a/docs/AUDIT_CERT.md
+++ b/docs/AUDIT_CERT.md
@@ -1,6 +1,22 @@
-# Audit Certification
+# NBA Trade Machine — Certification
 
-- Audit: `docs/AUDIT_DEEP.md`
-- Commit: 5181779
-- Tests: 123/123 passed (`npm run test -- --run`)
-- Certified on 2025-08-08T04:13Z
+**Commit:** 1fa30db • **Date:** 2025-08-08T05:11:02+00:00 • **Suite:** 123/123 PASS
+
+**Verdict:** CBA 2023+ compliance (year-2 rules active) — **PASS**
+
+**Hard-enforced invariants (bullet list):**
+- Salary matching bands; 1st-apron 100%
+- 2nd-apron: **no aggregation, no cash, no TPE, no FA exceptions, ≤100% take-back**
+- BYC = max(prior, 50%); poison-pill average; trade-kicker proration
+- S\&T: receiver ≤ 1st apron + hard-capped; 3–4 yrs; Y1 guaranteed; offseason; origin team; not taxpayer MLE
+- Stepien/7-year/frozen pick; re-acq bar; consent (full/limited NTC + 1-yr Bird)
+- TPE lifecycle (creation/expiry) and 2nd-apron ban; cash ledger seasonal caps
+
+**Soft/toggled rules:** moratorium & roster window (warn → optional error)
+
+**Known limits:** protections/encumbrances parser expects well-formed text; UI admin steps noted
+
+**Links:**
+- [Deep audit](AUDIT_DEEP.md)
+- [Compliance matrix](COMPLIANCE_MATRIX.csv)
+- [Order of operations](ORDER_OF_OPERATIONS.md)


### PR DESCRIPTION
## Summary
- publish up-to-date NBA Trade Machine certification with current commit, timestamp, and invariant list
- show NBA Trade Audit badge and link to compliance docs in README

## Testing
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68958689430083268d859dc3323b5c3d