### PR TITLE
fix: align trade summary with validator

### DIFF
--- a/src/features/architect/tradeMachine/TradeSummaryPanel.jsx
+++ b/src/features/architect/tradeMachine/TradeSummaryPanel.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { formatCurrency } from '@/utils/architect/tradeHelpers';
-import { HelpCircle } from 'lucide-react';
 import { getTeamColors } from '@/utils/formatting';
 import TeamLogo from '@/components/shared/TeamLogo';
 
@@ -25,6 +24,9 @@ function TradeSummaryPanel({
   showRuleExplanations = true,
 }) {
   if (!result) return null;
+
+  const failureMessages =
+    result.teamResults?.flatMap((tr) => tr.violations || []) || [];
 
   // Top status banner text
   const topStatus = forceTrade
@@ -47,11 +49,11 @@ function TradeSummaryPanel({
       </div>
 
       {/* Rule Explanations (surface-level) */}
-      {showRuleExplanations && result?.failures?.length > 0 && (
+      {showRuleExplanations && failureMessages.length > 0 && (
         <div className="bg-[#121212] border border-red-500/30 rounded p-3">
           <div className="font-semibold mb-2">Why it fails</div>
           <ul className="list-disc list-inside space-y-1">
-            {result.failures.map((f, idx) => (
+            {failureMessages.map((f, idx) => (
               <li key={idx} className="text-red-300">
                 {f.message || f.reason || String(f)}
               </li>

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -4,7 +4,6 @@ import capProjections from '@/utils/architect/capProjections';
 import {
   getSalaryForYear,
   formatPick,
-  calculateAllowableIncoming,
   getIncomingCeiling,
 } from '@/utils/architect/tradeHelpers';
 import { formatSalary } from '@/utils/formatting';
@@ -115,33 +114,25 @@ const TradeTeamCard = ({
     [team]
   );
 
-  const allowableIncoming = useMemo(
-    () =>
-      team
-        ? calculateAllowableIncoming(
-            teamTotalSalary,
-            outgoingSalary,
-            incomingPlayers,
-            team.tradeExceptions || [],
-            { ...capSettings, yearKey }
-          )
-        : 0,
-    [teamTotalSalary, outgoingSalary, incomingPlayers, capSettings, yearKey]
-  );
-
-  // Allowable Incoming for display (excluding TPEs)
-  const allowableIncomingNoTPE = useMemo(
+  // Allowable incoming ceiling including any TPEs (for display)
+  const allowableIncomingCeiling = useMemo(
     () =>
       team
         ? getIncomingCeiling(
             teamTotalSalary,
             outgoingSalary,
-            [], // Exclude TPEs from calculation
+            team.tradeExceptions || [],
             capSettings,
             yearKey
           )
         : 0,
-    [teamTotalSalary, outgoingSalary, capSettings, yearKey]
+    [
+      teamTotalSalary,
+      outgoingSalary,
+      team?.tradeExceptions,
+      capSettings,
+      yearKey,
+    ]
   );
 
   const tpeEligiblePlayers = useMemo(() => {
@@ -306,7 +297,7 @@ const TradeTeamCard = ({
             <div>
               Allowable Incoming:{' '}
               <span className="font-semibold text-white/80">
-                {formatSalary(allowableIncomingNoTPE)}
+                {formatSalary(allowableIncomingCeiling)}
               </span>
             </div>
             {team?.tradeExceptions?.length > 0 && (

--- a/src/hooks/tradeMachine/useTradeMachine.js
+++ b/src/hooks/tradeMachine/useTradeMachine.js
@@ -301,7 +301,7 @@ export const useTradeMachine = (
 
     setResult({
       ...validation,
-      legal: forceTrade ? true : validation.overallLegal,
+      legal: forceTrade ? true : validation.legal,
     });
     setPreviewOpen(true);
   }, [teams, capProjections, currentYear, forceTrade]);


### PR DESCRIPTION
## Summary
- show validator violations in trade summary
- sync team card allowable salary with summary
- use validator legal flag when validating trades

## Testing
- `npx vitest run tests/tradeValidator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68970e2a8f7c83268a072317a73e88ef