### PR TITLE
feat: add bulk add option to player drawer

### DIFF
--- a/src/features/ranker/RankingBuilder.jsx
+++ b/src/features/ranker/RankingBuilder.jsx
@@ -136,6 +136,7 @@ const RankingBuilder = () => {
           onSelect={(player) => {
             addPlayerToPool(player);
           }}
+          onAddAll={addPlayersToPool}
         />
       </DrawerShell>
 

--- a/src/features/roster/AddPlayerDrawer/addPlayer/PlayerSearchBar.jsx
+++ b/src/features/roster/AddPlayerDrawer/addPlayer/PlayerSearchBar.jsx
@@ -6,6 +6,8 @@ const PlayerSearchBar = ({
   onSearchChange,
   showFilters,
   onToggleFilters,
+  onAddAll,
+  addAllDisabled,
 }) => (
   <div className="flex-shrink-0 px-3 py-2 border-b border-white/10">
     <div className="flex items-center gap-2">
@@ -16,6 +18,15 @@ const PlayerSearchBar = ({
         onChange={(e) => onSearchChange(e.target.value)}
         className="flex-1 bg-[#111] text-white px-2 py-1 rounded text-sm placeholder-white/30 border border-white/10"
       />
+      {onAddAll && (
+        <button
+          onClick={onAddAll}
+          disabled={addAllDisabled}
+          className="px-2 py-1 text-xs rounded bg-white/10 hover:bg-white/20 text-white disabled:opacity-50"
+        >
+          Add All
+        </button>
+      )}
       <button
         onClick={onToggleFilters}
         className={`p-1.5 rounded ${showFilters ? 'bg-[#222] text-white' : 'text-white/50 hover:text-white'}`}

--- a/src/features/roster/AddPlayerDrawer/index.jsx
+++ b/src/features/roster/AddPlayerDrawer/index.jsx
@@ -7,7 +7,7 @@ import DrawerHeader from './addPlayer/DrawerHeader';
 import PlayerSearchBar from './addPlayer/PlayerSearchBar';
 import FilterTabs from './addPlayer/FilterTabs';
 
-const AddPlayerDrawer = ({ onClose, allPlayers, onSelect }) => {
+const AddPlayerDrawer = ({ onClose, allPlayers, onSelect, onAddAll }) => {
   const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
   const [filters, setFilters] = useState(getDefaultAddPlayerFilters());
@@ -124,6 +124,10 @@ const AddPlayerDrawer = ({ onClose, allPlayers, onSelect }) => {
         onSearchChange={setSearch}
         showFilters={showFilters}
         onToggleFilters={() => setShowFilters(!showFilters)}
+        onAddAll={
+          onAddAll ? () => onAddAll(filteredPlayers) : undefined
+        }
+        addAllDisabled={filteredPlayers.length === 0}
       />
 
       {/* Main content area with proper flex behavior */}

--- a/src/features/tierMaker/TierMakerBoard.jsx
+++ b/src/features/tierMaker/TierMakerBoard.jsx
@@ -288,6 +288,7 @@ const TierMakerBoard = ({ players = [], initialTierListId = '' }) => {
           onSelect={(player) => {
             addPlayerToPool(player);
           }}
+          onAddAll={addPlayersToPool}
         />
       </DrawerShell>
 


### PR DESCRIPTION
## Summary
- allow AddPlayerDrawer to bulk add filtered players
- expose Add All control in PlayerRanker and TierMaker

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689afdc166d08326a74a90513535885d