### PR TITLE
feat: wire trade validator into UI

### DIFF
--- a/src/features/architect/tradeMachine/TradeEditor.jsx
+++ b/src/features/architect/tradeMachine/TradeEditor.jsx
@@ -84,7 +84,6 @@ const TradeEditor = ({
           <button
             onClick={() => {
               handleValidate();
-              setPreviewOpen(true);
             }}
             className="bg-blue-600 hover:bg-blue-700 text-sm font-medium px-3 py-1.5 rounded"
           >
@@ -128,6 +127,7 @@ const TradeEditor = ({
               yearKey={yearKey}
               otherTeams={otherTeams}
               playersMap={playersMap}
+              validation={result?.perTeam?.[t.team?.id]}
               onSetPlayerTrade={(p, action, dest) =>
                 setPlayerTrade(idx, p, action, dest)
               }
@@ -153,7 +153,8 @@ const TradeEditor = ({
               onApplyTrade(tradeData);
             }
           }}
-          className="bg-green-600 hover:bg-green-700 text-sm font-medium px-3 py-1.5 rounded"
+          disabled={result && !result.passed && !forceTrade}
+          className="bg-green-600 hover:bg-green-700 text-sm font-medium px-3 py-1.5 rounded disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Apply Trade
         </button>
@@ -172,6 +173,7 @@ const TradeEditor = ({
         teams={teams}
         result={result}
         yearKey={yearKey}
+        forceTrade={forceTrade}
       />
     </div>
   );

--- a/src/features/architect/tradeMachine/TradePreviewModal.jsx
+++ b/src/features/architect/tradeMachine/TradePreviewModal.jsx
@@ -3,7 +3,7 @@ import { X } from 'lucide-react';
 import useImageDownload from '@/hooks/useImageDownload';
 import TradeExportCapture from './TradeExportCapture';
 
-const TradePreviewModal = ({ open, onClose, teams = [], result, yearKey }) => {
+const TradePreviewModal = ({ open, onClose, teams = [], result, yearKey, forceTrade = false }) => {
   if (!open) return null;
 
   const exportRef = useRef(null);
@@ -74,7 +74,8 @@ const TradePreviewModal = ({ open, onClose, teams = [], result, yearKey }) => {
             <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-30">
               <button
                 onClick={handleDownload}
-                className="bg-neutral-200 text-black text-lg font-semibold px-4 py-1.5 rounded shadow-lg hover:bg-neutral-300 transition"
+                disabled={result && !result.passed && !forceTrade}
+                className="bg-neutral-200 text-black text-lg font-semibold px-4 py-1.5 rounded shadow-lg hover:bg-neutral-300 transition disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Download
               </button>

--- a/src/features/architect/tradeMachine/TradeSummaryPanel.jsx
+++ b/src/features/architect/tradeMachine/TradeSummaryPanel.jsx
@@ -29,10 +29,9 @@ function TradeSummaryPanel({
 }) {
   if (!result) return null;
 
-  // Top status banner text
   const topStatus = forceTrade
     ? '⚠️ Trade Forced – Not CBA Legal'
-    : result.legal
+    : result.passed
       ? '✅ Trade is CBA Legal'
       : '❌ Trade is NOT CBA Legal';
 
@@ -41,7 +40,7 @@ function TradeSummaryPanel({
       {/* Top Status Message */}
       <div>
         <strong className="text-base">{topStatus}</strong>
-        {!result.legal && !forceTrade && (
+        {!result.passed && !forceTrade && (
           <div className="text-xs text-white/60 mt-1">
             Fix the issues below or toggle Force Trade to proceed (for sandbox
             testing).
@@ -50,13 +49,13 @@ function TradeSummaryPanel({
       </div>
 
       {/* Rule Explanations (surface-level) */}
-      {showRuleExplanations && result?.failures?.length > 0 && (
+      {showRuleExplanations && result?.violations?.length > 0 && (
         <div className="bg-[#121212] border border-red-500/30 rounded p-3">
           <div className="font-semibold mb-2">Why it fails</div>
           <ul className="list-disc list-inside space-y-1">
-            {result.failures.map((f, idx) => (
+            {result.violations.map((msg, idx) => (
               <li key={idx} className="text-red-300">
-                {f.message || f.reason || String(f)}
+                {msg}
               </li>
             ))}
           </ul>
@@ -65,10 +64,10 @@ function TradeSummaryPanel({
 
       {/* Team Summaries — revamped to cards with logo/color + rows */}
       <div className="grid md:grid-cols-2 gap-4">
-        {result.summaryByTeamIndex?.map((t, i) => {
+        {result.details?.summaryByTeamIndex?.map((t, i) => {
           if (!t) return null;
 
-          const teamResult = result.teamResults?.[i];
+          const teamResult = result.details?.teamResults?.[i];
           const isIllegal = teamResult ? !teamResult.legal : false;
 
           const teamMeta =

--- a/src/features/architect/tradeMachine/TradeTeamCard.jsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.jsx
@@ -37,6 +37,7 @@ const TradeTeamCard = ({
   onSelectTeam,
   onRemove,
   onApplyTradeException,
+  validation,
 }) => {
   const [activeTab, setActiveTab] = useState('players');
   const [editingTeam, setEditingTeam] = useState(false);
@@ -193,6 +194,24 @@ const TradeTeamCard = ({
             }}
           />
         </div>
+
+        {validation && (
+          <span
+            className={`text-xs mr-6 ${
+              validation.passed
+                ? 'text-green-400'
+                : validation.violations?.length
+                  ? 'text-red-400'
+                  : 'text-yellow-400'
+            }`}
+          >
+            {validation.passed
+              ? '✔'
+              : validation.violations?.length
+                ? '✖'
+                : '!'}
+          </span>
+        )}
 
         {onRemove && (
           <button

--- a/src/features/architect/tradeMachine/TradeValidationPanel.jsx
+++ b/src/features/architect/tradeMachine/TradeValidationPanel.jsx
@@ -78,7 +78,7 @@ const TradeValidationPanel = ({ result }) => {
   const [expanded, setExpanded] = React.useState(false);
   const [detailsOpen, setDetailsOpen] = React.useState({});
   if (!result) return null;
-  const { teamResults = [] } = result;
+  const teamResults = result.details?.teamResults || [];
 
   const handleToggleDetails = (teamIdx, ruleIdx) => {
     setDetailsOpen((prev) => ({

--- a/src/hooks/tradeMachine/useTradeMachine.js
+++ b/src/hooks/tradeMachine/useTradeMachine.js
@@ -1,8 +1,8 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { validateTrade } from '@/utils/architect/tradeMachine/engine/tradeValidator';
 import { loadTeamCapSheet } from '@/utils/architect/firebaseTeamPlanHelpers';
 import { getSalaryForYear, areSamePick } from '@/utils/architect/tradeHelpers';
 import { TeamMap } from '@/constants/teamList';
+import { useTradeValidation } from './useTradeValidation.js';
 
 /* ============================
    Helpers: numeric + payroll + season keys
@@ -141,12 +141,11 @@ export const useTradeMachine = (
 ) => {
   // Main state
   const [teams, setTeams] = useState([]);
-  const [result, setResult] = useState(null);
   const [forceTrade, setForceTrade] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
 
-  // Use the selected season end-year everywhere (no hardcoding)
   const yearKey = currentYear;
+  const { result, revalidate } = useTradeValidation(teams, capProjections, yearKey);
 
   // Memoized calculations
   const incomingAssets = useMemo(() => {
@@ -379,68 +378,9 @@ export const useTradeMachine = (
   // Trade validation and execution
   const handleValidate = useCallback(() => {
     if (teams.filter((t) => t.team).length < 2) return;
-
-    // (Optional) last-second safety net: if any team is missing payroll, patch it
-    const patchedTeams = teams.map((t) => {
-      if (!t.team) return t;
-      if (
-        !Number.isFinite(t.team.teamTotalSalary) ||
-        t.team.teamTotalSalary === 0
-      ) {
-        const baseline = payrollForYearFromCapSheet(t.team, yearKey);
-        const dead = deadMoneyForYear(t.team, yearKey);
-        return {
-          ...t,
-          team: {
-            ...t.team,
-            teamTotalSalary: baseline + dead,
-            projectedSalary: baseline + dead,
-          },
-        };
-      }
-      return t;
-    });
-
-    // LOG C) Right before validateTrade(...) in handleValidate()
-    console.log(
-      '[validate -> teams payroll]',
-      teams.map(
-        (t) =>
-          t.team && {
-            team: t.team.nickname || t.team.name || t.team.id,
-            teamTotalSalary: t.team.teamTotalSalary,
-            projectedSalary: t.team.projectedSalary,
-          }
-      )
-    );
-    const validation = validateTrade({
-      teams: patchedTeams
-        .filter((t) => t.team)
-        .map((t) => ({
-          team: t.team,
-          sends: t.sends,
-          picksOut: t.picksOut,
-          hardCapped: t.team.hardCapped,
-        })),
-      capProjections,
-      currentYear: yearKey,
-    });
-
-    setResult({
-      ...validation,
-      legal: forceTrade ? true : validation.overallLegal,
-    });
+    revalidate();
     setPreviewOpen(true);
-    console.log(
-      '[after validate]',
-      validation.teamResults.map((tr) => ({
-        team: tr.team?.nickname || tr.team?.name || tr.team?.id,
-        pre: tr.preTradeStatus?.projectedSalary,
-        post: tr.postTradeStatus?.projectedSalary,
-        apron: tr.postTradeStatus?.isAtOrAboveSecondApron,
-      }))
-    );
-  }, [teams, capProjections, yearKey, forceTrade]);
+  }, [teams, revalidate]);
 
   const exportCurrentTrade = useCallback(() => {
     return teams
@@ -461,7 +401,6 @@ export const useTradeMachine = (
 
   const resetTrade = useCallback(() => {
     setTeams((prev) => prev.map((t) => ({ ...t, sends: [], picksOut: [] })));
-    setResult(null);
     setForceTrade(false);
   }, []);
 

--- a/src/hooks/tradeMachine/useTradeValidation.js
+++ b/src/hooks/tradeMachine/useTradeValidation.js
@@ -1,0 +1,125 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { validateTrade } from '@/utils/architect/tradeMachine/engine/tradeValidator.js';
+
+// Helper functions duplicated from useTradeMachine for isolated usage
+const num = (v) => {
+  if (v == null) return 0;
+  if (typeof v === 'number') return v;
+  const n = Number(String(v).replace(/[^0-9.-]/g, ''));
+  return Number.isFinite(n) ? n : 0;
+};
+
+const payrollForYearFromCapSheet = (capSheet, endYear) => {
+  if (!capSheet) return 0;
+  const y = String(endYear);
+  const fromActive = (capSheet.activeContracts || []).reduce((sum, c) => {
+    const s = c?.salaryByYear?.[endYear] ?? c?.salaryByYear?.[y] ?? 0;
+    return sum + num(s);
+  }, 0);
+  if (fromActive > 0) return fromActive;
+  const fromPlayers = (capSheet.players || []).reduce((sum, p) => {
+    const s =
+      p?.contract_clean?.salaries_by_year?.[endYear]?.salary ??
+      p?.contract_clean?.salaries_by_year?.[y]?.salary ??
+      0;
+    return sum + num(s);
+  }, 0);
+  return fromPlayers;
+};
+
+const deadMoneyForYear = (capSheet, endYear) => {
+  const y = String(endYear);
+  const arrs = []
+    .concat(capSheet?.waivedContracts || [])
+    .concat(capSheet?.stretchHistory || []);
+  const fromArrays = arrs.reduce((sum, w) => {
+    const amt =
+      w?.deadMoneyByYear?.[endYear] ??
+      w?.deadMoneyByYear?.[y] ??
+      w?.amountByYear?.[endYear] ??
+      w?.amountByYear?.[y] ??
+      0;
+    return sum + num(amt);
+  }, 0);
+  const fromFlat =
+    num(capSheet?.deadMoney?.[endYear]) + num(capSheet?.deadMoney?.[y]);
+  return fromArrays + fromFlat;
+};
+
+export function normalizeValidationResult(validation) {
+  if (!validation) return null;
+  const normalized = {
+    passed: true,
+    warnings: [],
+    violations: [],
+    perTeam: {},
+    details: validation,
+  };
+  if (Array.isArray(validation.teamResults)) {
+    validation.teamResults.forEach((tr) => {
+      const passed = tr.legal !== false && !(tr.violations && tr.violations.length);
+      normalized.perTeam[tr.teamId || tr.teamName] = {
+        passed,
+        warnings: tr.warnings || [],
+        violations: tr.violations || [],
+      };
+      if (!passed) normalized.passed = false;
+      normalized.warnings.push(...(tr.warnings || []));
+      normalized.violations.push(...(tr.violations || []));
+    });
+  } else {
+    normalized.passed = validation.legal !== false;
+    normalized.warnings = validation.warnings || [];
+    normalized.violations = validation.violations || [];
+  }
+  return normalized;
+}
+
+export function useTradeValidation(teams, capProjections, currentYear) {
+  const [result, setResult] = useState(null);
+  const timer = useRef(null);
+
+  const runValidation = useCallback(() => {
+    const active = teams.filter((t) => t.team);
+    if (active.length < 2) {
+      setResult(null);
+      return;
+    }
+    const patched = active.map((t) => {
+      let teamObj = t.team;
+      if (
+        !Number.isFinite(teamObj.teamTotalSalary) ||
+        teamObj.teamTotalSalary === 0
+      ) {
+        const baseline = payrollForYearFromCapSheet(teamObj, currentYear);
+        const dead = deadMoneyForYear(teamObj, currentYear);
+        teamObj = {
+          ...teamObj,
+          teamTotalSalary: baseline + dead,
+          projectedSalary: baseline + dead,
+        };
+      }
+      return {
+        team: teamObj,
+        sends: t.sends,
+        picksOut: t.picksOut,
+        hardCapped: t.team.hardCapped,
+      };
+    });
+    const validation = validateTrade({
+      teams: patched,
+      capProjections,
+      currentYear,
+    });
+    setResult(normalizeValidationResult(validation));
+  }, [teams, capProjections, currentYear]);
+
+  useEffect(() => {
+    clearTimeout(timer.current);
+    timer.current = setTimeout(runValidation, 300);
+    return () => clearTimeout(timer.current);
+  }, [runValidation]);
+
+  return { result, revalidate: runValidation };
+}
+

--- a/tests/useTradeValidation.test.js
+++ b/tests/useTradeValidation.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { validateTrade } from '@/utils/architect/tradeMachine/engine/tradeValidator.js';
+import { normalizeValidationResult } from '@/hooks/tradeMachine/useTradeValidation.js';
+import capProjections from '@/utils/architect/capProjections.js';
+
+const currentYear = 2025;
+
+const makePlayer = (name, salary, signAndTrade = false, contractYears = 4) => ({
+  name,
+  signAndTrade,
+  contractYears,
+  contract_clean: { salaries_by_year: { [currentYear]: { salary } } },
+});
+
+const makeTeam = (name, totalSalary, rosterSize = 14, picks = []) => ({
+  teamName: name,
+  totalSalary,
+  players: Array.from({ length: rosterSize }, (_, i) =>
+    makePlayer(`${name}${i}`, 1_000_000)
+  ),
+  picks,
+});
+
+describe('normalizeValidationResult', () => {
+  it('passes valid trades', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const aPlayer = makePlayer('Astar', 10_000_000);
+    const bPlayer = makePlayer('Bstar', 10_000_000);
+    teamA.players.push(aPlayer);
+    teamB.players.push(bPlayer);
+
+    const raw = validateTrade({
+      teams: [
+        { team: teamA, sends: [aPlayer], picksOut: [] },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    const normalized = normalizeValidationResult(raw);
+    expect(normalized.passed).toBe(true);
+    expect(normalized.perTeam.A.passed).toBe(true);
+    expect(normalized.perTeam.B.passed).toBe(true);
+  });
+
+  it('fails trades with violations', () => {
+    const teamA = makeTeam('A', 100_000_000);
+    const teamB = makeTeam('B', 100_000_000);
+    const sat = makePlayer('Astar', 10_000_000, true);
+    const extra = makePlayer('Aextra', 5_000_000);
+    const bPlayer = makePlayer('Bstar', 15_000_000);
+    teamA.players.push(sat, extra);
+    teamB.players.push(bPlayer);
+
+    const raw = validateTrade({
+      teams: [
+        { team: teamA, sends: [sat, extra], picksOut: [] },
+        { team: teamB, sends: [bPlayer], picksOut: [] },
+      ],
+      capProjections,
+      currentYear,
+    });
+
+    const normalized = normalizeValidationResult(raw);
+    const keys = Object.keys(normalized.perTeam);
+    expect(normalized.passed).toBe(false);
+    expect(normalized.perTeam[keys[0]].passed).toBe(false);
+    expect(normalized.perTeam[keys[1]].passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- integrate centralized trade validation hook with debounced execution
- surface per-team validation and block trade actions when illegal
- cover normalization behaviour with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a712161d108326aad14dd340d8ed58