### PR TITLE
refactor: align roster and player views with players_v2 schema

### DIFF
--- a/src/constants/collections.ts
+++ b/src/constants/collections.ts
@@ -13,12 +13,6 @@ export const PLAYERS_COLLECTION =
   import.meta.env.VITE_PLAYERS_COLLECTION || 'players_v2';
 
 /**
- * Legacy players collection (deprecated - for reference only)
- * DO NOT USE in new code
- */
-export const PLAYERS_COLLECTION_LEGACY = 'players';
-
-/**
  * Teams collection
  */
 export const TEAMS_COLLECTION = 'teams';

--- a/src/features/architect/FreeAgentRow.jsx
+++ b/src/features/architect/FreeAgentRow.jsx
@@ -36,7 +36,7 @@ const FreeAgentRow = ({
   const firstName = nameParts[0]?.toUpperCase() || '';
   const lastName = nameParts.slice(1).join(' ').toUpperCase() || '';
 
-  const rawPosition = player.bio?.Position || player.formattedPosition || '';
+  const rawPosition = player.bio?.position || player.formattedPosition || '';
   const position = getPlayerPositionLabel(rawPosition) || '—';
 
   const formatHeight = (inches) => {
@@ -54,6 +54,7 @@ const FreeAgentRow = ({
   const faType =
     askInfo.freeAgentType ||
     askInfo.fa_type ||
+    player.bio?.display?.freeAgentType ||
     player.freeAgentType ||
     player.fa_type ||
     'UFA';
@@ -89,7 +90,8 @@ const FreeAgentRow = ({
       <div className="h-[43px] w-[50px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden">
         <img
           src={
-            player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+            player.headshotUrl ||
+            `/assets/headshots/${player.bio?.playerId || player.id || player.player_id}.png`
           }
           onError={(e) => {
             e.target.src = '/assets/headshots/default.png';

--- a/src/features/architect/GMDashboard.jsx
+++ b/src/features/architect/GMDashboard.jsx
@@ -322,7 +322,9 @@ const GMDashboard = () => {
         const position =
           playerData?.position ||
           playerData?.formattedPosition ||
-          getPlayerPositionLabel(playerData?.bio?.Position || p.position || '');
+          getPlayerPositionLabel(
+            playerData?.bio?.position || p.position || ''
+          );
         return {
           ...(playerData || {}),
           name: playerData?.name || p.name,
@@ -376,7 +378,9 @@ const GMDashboard = () => {
       const position =
         base.position ||
         base.formattedPosition ||
-        getPlayerPositionLabel(base.bio?.Position || playerObj.position || '');
+        getPlayerPositionLabel(
+          base.bio?.position || playerObj.position || ''
+        );
 
       const newPlayer = {
         ...(base || {}),

--- a/src/features/architect/RosterVisual.jsx
+++ b/src/features/architect/RosterVisual.jsx
@@ -29,8 +29,8 @@ const RosterVisual = ({
     const filtered = enriched.filter((p) => !isTwoWayContract(p));
     const sorted = filtered.sort(
       (a, b) =>
-        parseFloat(b.system?.stats?.MP || 0) -
-        parseFloat(a.system?.stats?.MP || 0)
+        parseFloat(b.MIN ?? b.latestSeasonStats?.MIN ?? 0) -
+        parseFloat(a.MIN ?? a.latestSeasonStats?.MIN ?? 0)
     );
 
     return buildInitialRoster(sorted);

--- a/src/features/architect/tradeMachine/TradeExportCapture.jsx
+++ b/src/features/architect/tradeMachine/TradeExportCapture.jsx
@@ -175,7 +175,7 @@ const TradeExportCapture = React.forwardRef(
                                       p.teamId ||
                                       p.team ||
                                       p.teamAbbr ||
-                                      p.bio?.Team
+                                      p.bio?.display?.team
                                     }
                                     className="w-8 h-8 ml-2 shrink-0"
                                   />

--- a/src/features/architect/tradeMachine/TradePlayerRow.jsx
+++ b/src/features/architect/tradeMachine/TradePlayerRow.jsx
@@ -28,11 +28,11 @@ const TradePlayerRow = ({
   const details = playersMap[player.name] || {};
   const team =
     player.tradeTo ||
-    player.bio?.Team ||
+    player.bio?.display?.team ||
     player.team ||
     player.teamId ||
     player.teamAbbr ||
-    details.bio?.Team ||
+    details.bio?.display?.team ||
     details.team ||
     details.teamId ||
     details.teamAbbr;
@@ -53,19 +53,35 @@ const TradePlayerRow = ({
   }, [openMenu, player.name, setOpenMenu]);
 
   // Calculate player data (unchanged visual output)
+  const primaryContract =
+    player.primaryContract ||
+    (player.contracts ? Object.values(player.contracts)[0] : null) ||
+    details.primaryContract ||
+    (details.contracts ? Object.values(details.contracts)[0] : null);
+
   const year =
     typeof yearKey === 'number'
       ? yearKey
       : parseInt(yearKey.match(/\d{4}/)?.[0]);
   const salary = getSalaryWithFallback(player, yearKey);
   const faYear =
-    player.contract_clean?.fa_year ?? player.fa_year ?? player.freeAgentYear;
+    primaryContract?.freeAgency?.freeAgentYear ??
+    player.bio?.display?.freeAgentYear ??
+    player.freeAgentYear ??
+    null;
   const yearsLeft = getYearsRemaining(faYear, year);
+  const salaryForYear = Array.isArray(primaryContract?.salariesByYear)
+    ? primaryContract.salariesByYear.find(
+        (s) =>
+          String(s.year) === String(year) ||
+          (typeof s.season === 'string' && s.season.includes(String(year)))
+      )
+    : null;
   const position =
     getPlayerPositionLabel(
-      player.bio?.Position ||
+      player.bio?.position ||
         player.position ||
-        playersMap[player.name]?.bio?.Position
+        playersMap[player.name]?.bio?.position
     ) || '—';
 
   // Enhanced TPE check
@@ -107,7 +123,11 @@ const TradePlayerRow = ({
       {/* Headshot - unchanged */}
       <div className="h-full w-[70px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden">
         <img
-          src={`/assets/headshots/${player.player_id}.png`}
+          src={`/assets/headshots/${
+            player.bio?.playerId ||
+            playersMap[player.name]?.bio?.playerId ||
+            player.player_id
+          }.png`}
           onError={(e) => (e.target.src = '/assets/headshots/default.png')}
           alt={player.bio?.displayName || player.name}
           className="h-full w-full object-cover"
@@ -130,7 +150,9 @@ const TradePlayerRow = ({
             fallbackClassName="bg-neutral-800 rounded-full"
           />
           <div>
-            {player.bio?.height ? `${Math.floor(player.bio.height / 12)}-${player.bio.height % 12}` : (player.height || player.height_ft_in || '—')}
+            {player.bio?.height
+              ? `${Math.floor(player.bio.height / 12)}-${player.bio.height % 12}`
+              : player.height || player.height_ft_in || '—'}
             <span className="text-white/30">|</span>{' '}
             {player.bio?.weight || player.weight || player.weight_lbs || '—'} lbs
           </div>
@@ -199,7 +221,7 @@ const TradePlayerRow = ({
 
             {/* Sign-and-Trade Option */}
             {!included &&
-              !player.contract_clean?.salaries_by_year?.[yearKey]?.salary &&
+              !salaryForYear?.salary &&
               (!signAndTradeActive || player.signAndTrade) && (
                 <button
                   onClick={() => {
@@ -257,7 +279,9 @@ const TradePlayerRow = ({
             {/* View Profile Option */}
             <button
               onClick={() =>
-                (window.location.href = `/profiles?player=${player.player_id}`)
+                (window.location.href = `/profiles?player=${
+                  player.bio?.playerId || player.id || player.player_id
+                }`)
               }
               className="block w-full text-left px-3 py-1 hover:bg-[#333]"
             >

--- a/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportPlayerRowSingle.jsx
+++ b/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportPlayerRowSingle.jsx
@@ -13,7 +13,7 @@ const ListExportPlayerRowSingle = ({ player, rank }) => {
   const firstName = nameParts[0]?.toUpperCase() || '';
   const lastName = nameParts.slice(1).join(' ').toUpperCase() || '';
 
-  const rawPosition = player.bio?.Position || player.formattedPosition || '';
+  const rawPosition = player.bio?.position || player.formattedPosition || '';
   const position = getPlayerPositionLabel(rawPosition) || '—';
 
   return (
@@ -30,7 +30,8 @@ const ListExportPlayerRowSingle = ({ player, rank }) => {
       <div className="h-full w-[70px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden">
         <img
           src={
-            player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+            player.headshotUrl ||
+            `/assets/headshots/${player.bio?.playerId || player.player_id}.png`
           }
           onError={(e) => {
             e.target.src = '/assets/headshots/default.png';
@@ -46,7 +47,7 @@ const ListExportPlayerRowSingle = ({ player, rank }) => {
           <PlayerNameMini name={player.bio?.displayName || player.name} />
         </div>
         <div className="flex items-center mt-[11px] -mb-1 gap-2 text-white/50 text-[13px]">
-          <TeamLogo teamAbbr={player.bio?.Team} className="w-5 h-5" />
+          <TeamLogo teamAbbr={player.bio?.display?.team} className="w-5 h-5" />
           <div>
             {player.bio?.height ? `${Math.floor(player.bio.height / 12)}-${player.bio.height % 12}` : '—'} <span className="text-white/30">|</span>{' '}
             {player.bio?.weight || '—'} lbs

--- a/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportPlayerRowTwoColumn.jsx
+++ b/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportPlayerRowTwoColumn.jsx
@@ -13,7 +13,7 @@ const ListExportPlayerRowTwoColumn = ({ player, rank }) => {
   const firstName = nameParts[0]?.toUpperCase() || '';
   const lastName = nameParts.slice(1).join(' ').toUpperCase() || '';
 
-  const rawPosition = player.bio?.Position || player.formattedPosition || '';
+  const rawPosition = player.bio?.position || player.formattedPosition || '';
   const position = getPlayerPositionLabel(rawPosition) || '—';
 
   return (
@@ -30,7 +30,8 @@ const ListExportPlayerRowTwoColumn = ({ player, rank }) => {
       <div className="h-full w-[70px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden">
         <img
           src={
-            player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+            player.headshotUrl ||
+            `/assets/headshots/${player.bio?.playerId || player.player_id}.png`
           }
           onError={(e) => {
             e.target.src = '/assets/headshots/default.png';
@@ -46,7 +47,7 @@ const ListExportPlayerRowTwoColumn = ({ player, rank }) => {
           <PlayerNameMini name={player.bio?.displayName || player.name} />
         </div>
         <div className="flex items-center mt-[11px] -mb-1 gap-2 text-white/50 text-[13px]">
-          <TeamLogo teamAbbr={player.bio?.Team} className="w-5 h-5" />
+          <TeamLogo teamAbbr={player.bio?.display?.team} className="w-5 h-5" />
           <div>
             {player.bio?.height ? `${Math.floor(player.bio.height / 12)}-${player.bio.height % 12}` : '—'} <span className="text-white/30">|</span>{' '}
             {player.bio?.weight || '—'} lbs

--- a/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportRowCompactSingle.jsx
+++ b/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportRowCompactSingle.jsx
@@ -9,7 +9,7 @@ const ListExportRowCompactSingle = ({ player, rank }) => {
   const firstName = nameParts[0]?.toUpperCase() || '';
   const lastName = nameParts.slice(1).join(' ').toUpperCase() || '';
 
-  const rawPosition = player.bio?.Position || player.formattedPosition || '';
+  const rawPosition = player.bio?.position || player.formattedPosition || '';
   const position = getPlayerPositionLabel(rawPosition) || '—';
 
   const formatHeight = (inches) => {
@@ -34,7 +34,8 @@ const ListExportRowCompactSingle = ({ player, rank }) => {
       <div className="h-[45px] w-[50px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden rounded-sm">
         <img
           src={
-            player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+            player.headshotUrl ||
+            `/assets/headshots/${player.bio?.playerId || player.player_id}.png`
           }
           onError={(e) => {
             e.target.src = '/assets/headshots/default.png';
@@ -57,7 +58,7 @@ const ListExportRowCompactSingle = ({ player, rank }) => {
 
         {/* HT / WT / Team Logo */}
         <div className="flex items-center justify-end text-white/50 text-[13px] w-[130px] gap-2">
-          <TeamLogo teamAbbr={player.bio?.Team} className="w-4 h-4" />
+          <TeamLogo teamAbbr={player.bio?.display?.team} className="w-4 h-4" />
           <div className="whitespace-nowrap tabular-nums flex gap-1 items-center">
             <span className="w-[32px] text-right">{height}</span>
             <span className="text-white/30">|</span>

--- a/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportRowCompactTwoColumn.jsx
+++ b/src/features/lists/ListPreviewModal/ListExportWrapper/ListExportRowCompactTwoColumn.jsx
@@ -9,7 +9,7 @@ const ListExportRowCompactTwoColumn = ({ player, rank }) => {
   const firstName = nameParts[0]?.toUpperCase() || '';
   const lastName = nameParts.slice(1).join(' ').toUpperCase() || '';
 
-  const rawPosition = player.bio?.Position || player.formattedPosition || '';
+  const rawPosition = player.bio?.position || player.formattedPosition || '';
   const position = getPlayerPositionLabel(rawPosition) || '—';
 
   const formatHeight = (inches) => {
@@ -34,7 +34,8 @@ const ListExportRowCompactTwoColumn = ({ player, rank }) => {
       <div className="h-[45px] w-[50px] bg-[#2a2a2a] flex items-center justify-center overflow-hidden rounded-sm">
         <img
           src={
-            player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+            player.headshotUrl ||
+            `/assets/headshots/${player.bio?.playerId || player.player_id}.png`
           }
           onError={(e) => {
             e.target.src = '/assets/headshots/default.png';
@@ -57,7 +58,7 @@ const ListExportRowCompactTwoColumn = ({ player, rank }) => {
 
         {/* HT / WT / Team Logo */}
         <div className="flex items-center justify-end text-white/50 text-[13px] w-[130px] gap-2">
-          <TeamLogo teamAbbr={player.bio?.Team} className="w-4 h-4" />
+          <TeamLogo teamAbbr={player.bio?.display?.team} className="w-4 h-4" />
           <div className="whitespace-nowrap tabular-nums flex gap-1 items-center">
             <span className="w-[32px] text-right">{height}</span>
             <span className="text-white/30">|</span>

--- a/src/features/lists/ListTierHeader/ListPlayerRow.jsx
+++ b/src/features/lists/ListTierHeader/ListPlayerRow.jsx
@@ -20,19 +20,22 @@ const ListPlayerRow = ({
 }) => {
   const processedPlayer = {
     ...player,
-    id: player.player_id,
+    id: player.id,
     formattedPosition:
-      player.formattedPosition || POSITION_MAP[player.bio?.Position] || '—',
+      player.formattedPosition ||
+      POSITION_MAP[player.bio?.position] ||
+      player.bio?.position ||
+      '—',
     headshotUrl:
       player.headshot ||
       player.headshotUrl ||
-      `/assets/headshots/${player.player_id}.png`,
-    offenseRole: player.roles?.offense1 || player.offenseRole || '—',
-    defenseRole: player.roles?.defense1 || player.defenseRole || '—',
+      `/assets/headshots/${player.bio?.playerId || player.id}.png`,
+    offenseRole: player.offenseRole || '—',
+    defenseRole: player.defenseRole || '—',
     shootingProfile: player.shootingProfile || '—',
-    PPG: player.PPG ?? player.system?.stats?.PTS ?? null,
-    RPG: player.RPG ?? player.system?.stats?.TRB ?? null,
-    APG: player.APG ?? player.system?.stats?.AST ?? null,
+    PPG: player.PPG ?? null,
+    RPG: player.RPG ?? null,
+    APG: player.APG ?? null,
   };
 
   return (

--- a/src/features/lists/TierPlayerTile.jsx
+++ b/src/features/lists/TierPlayerTile.jsx
@@ -10,7 +10,7 @@ const TierPlayerTile = ({ player }) => {
   const headshot =
     player.headshotUrl ||
     player.headshot ||
-    `/assets/headshots/${player.player_id}.png`;
+    `/assets/headshots/${player.bio?.playerId || player.id}.png`;
 
   // V2 structure: bio.height is in inches, use formatHeight to display
   const height = player.bio?.height ? formatHeight(player.bio.height) : '—';

--- a/src/features/profile/PlayerDetails/PlayerHeader/index.jsx
+++ b/src/features/profile/PlayerDetails/PlayerHeader/index.jsx
@@ -21,7 +21,8 @@ const PlayerHeader = ({ player, selectedPlayer }) => {
   const thisYear = 2025;
   
   // Get contract data from contracts subcollection (v2 structure only)
-  const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
+  const contractData = player.primaryContract ||
+    (player.contracts ? Object.values(player.contracts)[0] : null);
   const totalYears = contractData?.contractLength;
   const currentYearSalaryObj = contractData?.salariesByYear?.find(
     (s) => s.year === thisYear || s.season?.startsWith(String(thisYear))
@@ -33,8 +34,11 @@ const PlayerHeader = ({ player, selectedPlayer }) => {
       : '—';
 
   // Get free agency info from bio.display or contract subcollection (v2 structure only)
-  const freeAgentType = player.bio?.display?.freeAgentType || contractData?.freeAgency?.freeAgentType;
-  const freeAgentYear = player.bio?.display?.freeAgentYear || contractData?.freeAgency?.freeAgentYear;
+  const freeAgency = contractData?.freeAgency || {};
+  const freeAgentType =
+    player.bio?.display?.freeAgentType ?? freeAgency.freeAgentType;
+  const freeAgentYear =
+    player.bio?.display?.freeAgentYear ?? freeAgency.freeAgentYear;
   const freeAgencyDisplay =
     freeAgentYear && freeAgentType
       ? `${freeAgentYear} (${freeAgentType})`
@@ -46,10 +50,10 @@ const PlayerHeader = ({ player, selectedPlayer }) => {
         <div className="flex flex-col justify-center">
           <PlayerName name={player.bio?.displayName || player.name || 'Unknown'} />
           <div className="flex items-center gap-4 mt-4">
-            <TeamLogo teamAbbr={player.bio?.display?.team || player.bio?.Team} />
+            <TeamLogo teamAbbr={player.bio?.display?.team} />
             <div className="h-[2.5rem] w-[2px] bg-black" />
             <PlayerPosition
-              position={getAbbreviatedPosition(player.bio?.position || player.bio?.Position)}
+              position={getAbbreviatedPosition(player.bio?.position)}
               className="text-5xl"
             />
           </div>
@@ -71,13 +75,13 @@ const PlayerHeader = ({ player, selectedPlayer }) => {
           </p>
           <p>
             <span className="font-bold">YEARS PRO</span>:{' '}
-            {player.bio?.display?.yearsPro || player.bio?.['Years Pro'] || 'N/A'}
+            {player.bio?.display?.yearsPro ?? 'N/A'}
           </p>
         </div>
         <div className="h-6" />
         <div className="space-y-[2px]">
           <p>
-            <span className="font-bold">TEAM</span>: {player.bio?.display?.team || player.bio?.Team || 'N/A'}
+            <span className="font-bold">TEAM</span>: {player.bio?.display?.team || 'N/A'}
           </p>
           <p>
             <span className="font-bold">CONTRACT</span>: {contractSummary}

--- a/src/features/profile/PlayerDetails/PlayerStatsTable.jsx
+++ b/src/features/profile/PlayerDetails/PlayerStatsTable.jsx
@@ -10,8 +10,8 @@ const formatStat = (stat, isInteger = false, multiply = false) => {
 };
 
 const PlayerStatsTable = ({ player }) => {
-  const stats = player.system?.stats || {};
-  const gamesPlayed = stats.G ?? player.bio?.['Games Played'] ?? 'N/A';
+  const stats = player.latestSeasonStats || {};
+  const gamesPlayed = stats.GP ?? 'N/A';
 
   return (
     <div className="w-full max-w-[750px] bg-[#1f1f1f] rounded-2xl shadow-lg px-6 pt-[0.5rem] pb-[0.75rem] text-white text-sm font-medium">
@@ -34,16 +34,16 @@ const PlayerStatsTable = ({ player }) => {
           G: {gamesPlayed}
         </div>
         <div className="h-4 w-[1px] bg-neutral-700" />
-        <div className="w-[50px] text-center">{formatStat(stats.MP)}</div>
+        <div className="w-[50px] text-center">{formatStat(stats.MIN)}</div>
         <div className="w-[50px] text-center">{formatStat(stats.PTS)}</div>
-        <div className="w-[50px] text-center">{formatStat(stats.TRB)}</div>
+        <div className="w-[50px] text-center">{formatStat(stats.REB)}</div>
         <div className="w-[50px] text-center">{formatStat(stats.AST)}</div>
         <div className="h-4 w-[1px] bg-neutral-700" />
         <div className="w-[50px] text-center">
           {formatStat(stats['FG%'], false, true)}
         </div>
         <div className="w-[50px] text-center">
-          {formatStat(stats['3P%'], false, true)}
+          {formatStat(stats['3PT%'], false, true)}
         </div>
         <div className="w-[50px] text-center">
           {formatStat(stats['FT%'], false, true)}

--- a/src/features/ranker/RankingBuilder.jsx
+++ b/src/features/ranker/RankingBuilder.jsx
@@ -15,45 +15,51 @@ const RankingBuilder = () => {
 
   const processedPlayers = useMemo(
     () =>
-      allPlayers.map((player) => ({
-        id: player.id,
-        player_id: player.id,
-        name: (player.bio?.displayName || player.name || '').toLowerCase(),
-        team: (player.bio?.Team || '').toLowerCase(),
-        position:
-          POSITION_MAP[player.bio?.Position] || player.bio?.Position || '',
-        offenseRoles: [
-          player.roles?.offense1?.toLowerCase() || '',
-          player.roles?.offense2?.toLowerCase() || '',
-        ],
-        defenseRoles: [
-          player.roles?.defense1?.toLowerCase() || '',
-          player.roles?.defense2?.toLowerCase() || '',
-        ],
-        offenseSubroles: player.subRoles?.offense || [],
-        defenseSubroles: player.subRoles?.defense || [],
-        shootingProfile: (player.shootingProfile || '').toLowerCase(),
-        badges: player.badges || [],
-        salary: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.salariesByYear?.find((s) => s.year === 2025 || s.season?.startsWith('2025'))?.salary;
-        })(),
-        freeAgentYear: player.freeAgentYear?.toString() || player.bio?.display?.freeAgentYear?.toString(),
-        freeAgentType: (player.freeAgentType || player.bio?.display?.freeAgentType)?.toLowerCase(),
-        contractType: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.contractType?.toLowerCase();
-        })(),
-        extension: (() => {
-          const contracts = player.contracts ? Object.values(player.contracts) : [];
-          return contracts.find(c => c.isExtension);
-        })(),
-        options: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.options || [];
-        })(),
-        original: player,
-      })),
+      allPlayers.map((player) => {
+        const contractData = player.primaryContract ||
+          (player.contracts ? Object.values(player.contracts)[0] : null);
+
+        return {
+          id: player.id,
+          player_id: player.id,
+          name: (player.bio?.displayName || player.name || '').toLowerCase(),
+          team: (player.bio?.display?.team || '').toLowerCase(),
+          position:
+            player.formattedPosition ||
+            POSITION_MAP[player.bio?.position] ||
+            player.bio?.position ||
+            '',
+          offenseRoles: [
+            player.offenseRole?.toLowerCase() || '',
+            player.primaryEvaluation?.roles?.offense2?.toLowerCase() || '',
+          ],
+          defenseRoles: [
+            player.defenseRole?.toLowerCase() || '',
+            player.primaryEvaluation?.roles?.defense2?.toLowerCase() || '',
+          ],
+          offenseSubroles: player.subRoles?.offense || [],
+          defenseSubroles: player.subRoles?.defense || [],
+          shootingProfile: (player.shootingProfile || '').toLowerCase(),
+          badges: player.badges || [],
+          salary: contractData?.salariesByYear?.find(
+            (s) => s.year === 2025 || s.season?.startsWith('2025')
+          )?.salary,
+          freeAgentYear:
+            player.bio?.display?.freeAgentYear?.toString() ||
+            contractData?.freeAgency?.freeAgentYear?.toString() ||
+            null,
+          freeAgentType: (
+            player.bio?.display?.freeAgentType ||
+            contractData?.freeAgency?.freeAgentType ||
+            ''
+          ).toLowerCase(),
+          contractType: (contractData?.contractType || '').toLowerCase(),
+          extension: (player.contracts ? Object.values(player.contracts) : [])
+            .find((c) => c.isExtension),
+          options: contractData?.options || [],
+          original: player,
+        };
+      }),
     [allPlayers]
   );
 
@@ -107,7 +113,7 @@ const RankingBuilder = () => {
   const handleAddTeam = () => {
     if (!selectedTeam) return;
     const teamPlayers = allPlayers.filter(
-      (p) => (p.bio?.Team || '').toLowerCase() === selectedTeam.id
+      (p) => (p.bio?.display?.team || '').toLowerCase() === selectedTeam.id
     );
     addPlayersToPool(teamPlayers);
     setSelectedTeam(null);

--- a/src/features/roster/AddPlayerDrawer/PlayerRowMini.jsx
+++ b/src/features/roster/AddPlayerDrawer/PlayerRowMini.jsx
@@ -11,7 +11,7 @@ const PlayerRowMini = ({ player, onClick }) => {
   const name = player.bio?.displayName || player.name || 'Unknown Player';
   const headshot = player.headshot || `/assets/headshots/${player.id}.png`;
 
-  const rawPosition = player.bio?.Position || '—';
+  const rawPosition = player.bio?.position || player.formattedPosition || '—';
   const position = getPlayerPositionLabel(rawPosition);
 
   const height = player.bio?.height || '—';

--- a/src/features/roster/RosterSection/BenchCard.jsx
+++ b/src/features/roster/RosterSection/BenchCard.jsx
@@ -32,7 +32,7 @@ const BenchCard = ({
           <div
             className={`absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[12px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`}
           >
-            {getPlayerPositionLabel(player.bio?.Position)}
+            {getPlayerPositionLabel(player.bio?.position || player.formattedPosition)}
           </div>
         </div>
         <div className="bg-[#0f0f0f] px-2 pt-1 pb-2 h-[46px] flex flex-col items-center justify-center text-center border-t border-white/10">

--- a/src/features/roster/RosterSection/RotationCard.jsx
+++ b/src/features/roster/RosterSection/RotationCard.jsx
@@ -32,7 +32,7 @@ const RotationCard = ({
           <div
             className={`absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[14px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`}
           >
-            {getPlayerPositionLabel(player.bio?.Position)}
+            {getPlayerPositionLabel(player.bio?.position || player.formattedPosition)}
           </div>
         </div>
         <div className="bg-[#0f0f0f] px-2 pt-1 pb-2 h-[52px] flex flex-col items-center justify-center text-center border-t border-white/10">

--- a/src/features/roster/RosterSection/StarterCard.jsx
+++ b/src/features/roster/RosterSection/StarterCard.jsx
@@ -32,7 +32,7 @@ const StarterCard = ({
           <div
             className={`absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[16px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`}
           >
-            {getPlayerPositionLabel(player.bio?.Position)}
+            {getPlayerPositionLabel(player.bio?.position || player.formattedPosition)}
           </div>
         </div>
         <div className="bg-[#0f0f0f] px-2 pt-1 pb-2 h-[60px] flex flex-col items-center justify-center text-center border-t border-white/10">

--- a/src/features/table/PlayerTable/PlayerRow/index.jsx
+++ b/src/features/table/PlayerTable/PlayerRow/index.jsx
@@ -39,7 +39,8 @@ const PlayerRow = ({ player, ranking = '—' }) => {
         <div className="h-full w-20 bg-[#2a2a2a] overflow-hidden">
           <img
             src={
-              player.headshotUrl || `/assets/headshots/${player.player_id}.png`
+              player.headshotUrl ||
+              `/assets/headshots/${player.bio?.playerId || player.id}.png`
             }
             onError={(e) => {
               e.target.src = '/assets/headshots/default.png';
@@ -55,7 +56,7 @@ const PlayerRow = ({ player, ranking = '—' }) => {
             <PlayerNameMini name={player.bio?.displayName || player.name} />
           </div>
           <div className="flex items-center gap-2">
-            <TeamLogo teamAbbr={player.bio?.display?.team || player.bio?.Team} className="w-6 h-6" />
+            <TeamLogo teamAbbr={player.bio?.display?.team} className="w-6 h-6" />
             <div className="text-[14px] text-white/50 tracking-wide">
               {player.bio?.height ? `${Math.floor(player.bio.height / 12)}-${player.bio.height % 12}` : '—'} <span className="text-white/30">|</span>{' '}
               {player.bio?.weight || '—'} lbs
@@ -83,7 +84,8 @@ const PlayerRow = ({ player, ranking = '—' }) => {
         <div className="ml-0 border-l border-[#333] text-[11px] tracking-wide w-[140px] leading-tight text-center break-words">
           {(() => {
             const CURRENT_YEAR = getCurrentSeasonYear();
-            const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
+            const contractData = player.primaryContract ||
+              (player.contracts ? Object.values(player.contracts)[0] : null);
             const freeAgentYear = player.bio?.display?.freeAgentYear || contractData?.freeAgency?.freeAgentYear;
             const freeAgentType = player.bio?.display?.freeAgentType || contractData?.freeAgency?.freeAgentType;
 

--- a/src/features/table/PlayerTable/index.jsx
+++ b/src/features/table/PlayerTable/index.jsx
@@ -100,8 +100,8 @@ const PlayerTable = () => {
       <div className="w-full max-w-[1100px] mx-auto relative z-10">
         {filteredPlayers.map((player, index) => (
           <PlayerRow
-            key={player.player_id || player.id || `player-${index}`}
-            player={{ id: player.player_id || player.id, ...player }}
+            key={player.id || player.bio?.playerId || `player-${index}`}
+            player={{ id: player.id || player.bio?.playerId, ...player }}
           />
         ))}
       </div>

--- a/src/features/tierMaker/TierMakerBoard.jsx
+++ b/src/features/tierMaker/TierMakerBoard.jsx
@@ -22,45 +22,51 @@ const TierMakerBoard = ({ players = [], initialTierListId = '' }) => {
 
   const processedPlayers = useMemo(
     () =>
-      allPlayers.map((player) => ({
-        id: player.id,
-        player_id: player.id,
-        name: (player.bio?.displayName || player.name || '').toLowerCase(),
-        team: (player.bio?.Team || '').toLowerCase(),
-        position:
-          POSITION_MAP[player.bio?.Position] || player.bio?.Position || '',
-        offenseRoles: [
-          player.roles?.offense1?.toLowerCase() || '',
-          player.roles?.offense2?.toLowerCase() || '',
-        ],
-        defenseRoles: [
-          player.roles?.defense1?.toLowerCase() || '',
-          player.roles?.defense2?.toLowerCase() || '',
-        ],
-        offenseSubroles: player.subRoles?.offense || [],
-        defenseSubroles: player.subRoles?.defense || [],
-        shootingProfile: (player.shootingProfile || '').toLowerCase(),
-        badges: player.badges || [],
-        salary: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.salariesByYear?.find((s) => s.year === 2025 || s.season?.startsWith('2025'))?.salary;
-        })(),
-        freeAgentYear: player.freeAgentYear?.toString() || player.bio?.display?.freeAgentYear?.toString(),
-        freeAgentType: (player.freeAgentType || player.bio?.display?.freeAgentType)?.toLowerCase(),
-        contractType: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.contractType?.toLowerCase();
-        })(),
-        extension: (() => {
-          const contracts = player.contracts ? Object.values(player.contracts) : [];
-          return contracts.find(c => c.isExtension);
-        })(),
-        options: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.options || [];
-        })(),
-        original: player,
-      })),
+      allPlayers.map((player) => {
+        const contractData = player.primaryContract ||
+          (player.contracts ? Object.values(player.contracts)[0] : null);
+
+        return {
+          id: player.id,
+          player_id: player.id,
+          name: (player.bio?.displayName || player.name || '').toLowerCase(),
+          team: (player.bio?.display?.team || '').toLowerCase(),
+          position:
+            player.formattedPosition ||
+            POSITION_MAP[player.bio?.position] ||
+            player.bio?.position ||
+            '',
+          offenseRoles: [
+            player.offenseRole?.toLowerCase() || '',
+            player.primaryEvaluation?.roles?.offense2?.toLowerCase() || '',
+          ],
+          defenseRoles: [
+            player.defenseRole?.toLowerCase() || '',
+            player.primaryEvaluation?.roles?.defense2?.toLowerCase() || '',
+          ],
+          offenseSubroles: player.subRoles?.offense || [],
+          defenseSubroles: player.subRoles?.defense || [],
+          shootingProfile: (player.shootingProfile || '').toLowerCase(),
+          badges: player.badges || [],
+          salary: contractData?.salariesByYear?.find(
+            (s) => s.year === 2025 || s.season?.startsWith('2025')
+          )?.salary,
+          freeAgentYear:
+            player.bio?.display?.freeAgentYear?.toString() ||
+            contractData?.freeAgency?.freeAgentYear?.toString() ||
+            null,
+          freeAgentType: (
+            player.bio?.display?.freeAgentType ||
+            contractData?.freeAgency?.freeAgentType ||
+            ''
+          ).toLowerCase(),
+          contractType: (contractData?.contractType || '').toLowerCase(),
+          extension: (player.contracts ? Object.values(player.contracts) : [])
+            .find((c) => c.isExtension),
+          options: contractData?.options || [],
+          original: player,
+        };
+      }),
     [allPlayers]
   );
 
@@ -194,7 +200,7 @@ const TierMakerBoard = ({ players = [], initialTierListId = '' }) => {
   const handleAddTeamRoster = () => {
     if (!selectedTeam) return;
     const teamPlayers = allPlayers.filter(
-      (p) => (p.bio?.Team || '').toLowerCase() === selectedTeam.id
+      (p) => (p.bio?.display?.team || '').toLowerCase() === selectedTeam.id
     );
     addPlayersToPool(teamPlayers);
     setSelectedTeam(null);

--- a/src/features/tierMaker/TierRow.jsx
+++ b/src/features/tierMaker/TierRow.jsx
@@ -39,7 +39,7 @@ const TierRow = ({
     </div>
     <div className="flex flex-wrap gap-[2px] flex-1">
       {players.map((player) => {
-        const playerId = player.id || player.player_id;
+        const playerId = player.id;
         return (
           <div key={playerId} className="relative">
             <TierPlayerTile player={player} />

--- a/src/features/tierMaker/TierRow.jsx
+++ b/src/features/tierMaker/TierRow.jsx
@@ -38,37 +38,40 @@ const TierRow = ({
       )}
     </div>
     <div className="flex flex-wrap gap-[2px] flex-1">
-      {players.map((player) => (
-        <div key={player.player_id} className="relative">
-          <TierPlayerTile player={player} />
-          {!screenshotMode && (
-            <div className="absolute top-1 right-1 flex flex-col gap-1">
-              {tier !== 'S' && (
+      {players.map((player) => {
+        const playerId = player.id || player.player_id;
+        return (
+          <div key={playerId} className="relative">
+            <TierPlayerTile player={player} />
+            {!screenshotMode && (
+              <div className="absolute top-1 right-1 flex flex-col gap-1">
+                {tier !== 'S' && (
+                  <button
+                    onClick={() => movePlayer(playerId, tier, 'up')}
+                    className="text-xs text-white bg-black/40 px-[6px] rounded hover:bg-white/10"
+                  >
+                    ↑
+                  </button>
+                )}
+                {tier !== 'Pool' && (
+                  <button
+                    onClick={() => movePlayer(playerId, tier, 'down')}
+                    className="text-xs text-white bg-black/40 px-[6px] rounded hover:bg-white/10"
+                  >
+                    ↓
+                  </button>
+                )}
                 <button
-                  onClick={() => movePlayer(player.player_id, tier, 'up')}
-                  className="text-xs text-white bg-black/40 px-[6px] rounded hover:bg-white/10"
+                  onClick={() => removePlayer(playerId, tier)}
+                  className="text-xs text-red-300 bg-black/40 px-[6px] rounded hover:bg-red-600"
                 >
-                  ↑
+                  ✕
                 </button>
-              )}
-              {tier !== 'Pool' && (
-                <button
-                  onClick={() => movePlayer(player.player_id, tier, 'down')}
-                  className="text-xs text-white bg-black/40 px-[6px] rounded hover:bg-white/10"
-                >
-                  ↓
-                </button>
-              )}
-              <button
-                onClick={() => removePlayer(player.player_id, tier)}
-                className="text-xs text-red-300 bg-black/40 px-[6px] rounded hover:bg-red-600"
-              >
-                ✕
-              </button>
-            </div>
-          )}
-        </div>
-      ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   </div>
 );

--- a/src/hooks/useRosterManager.js
+++ b/src/hooks/useRosterManager.js
@@ -30,45 +30,50 @@ export const useRosterManager = (allPlayers = [], isLoading = false) => {
 
   const processedPlayers = useMemo(
     () =>
-      allPlayers.map((player) => ({
-        id: player.id,
-        name: (player.bio?.displayName || player.name || '').toLowerCase(),
-        team: (player.bio?.Team || '').toLowerCase(),
-        position:
-          POSITION_MAP[player.bio?.Position] || player.bio?.Position || '',
-        offenseRoles: [
-          player.roles?.offense1?.toLowerCase() || '',
-          player.roles?.offense2?.toLowerCase() || '',
-        ],
-        defenseRoles: [
-          player.roles?.defense1?.toLowerCase() || '',
-          player.roles?.defense2?.toLowerCase() || '',
-        ],
-        offenseSubroles: player.subRoles?.offense || [],
-        defenseSubroles: player.subRoles?.defense || [],
-        shootingProfile: (player.shootingProfile || '').toLowerCase(),
-        badges: player.badges || [],
-        salary: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.salariesByYear?.find((s) => s.year === 2025 || s.season?.startsWith('2025'))?.salary;
-        })(),
-        freeAgentYear: player.freeAgentYear?.toString() || player.bio?.display?.freeAgentYear?.toString(),
-        freeAgentType: (player.freeAgentType || player.bio?.display?.freeAgentType)?.toLowerCase(),
-        contractType: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.contractType?.toLowerCase();
-        })(),
-        extension: (() => {
-          // Check if there's an extension contract in the contracts subcollection
-          const contracts = player.contracts ? Object.values(player.contracts) : [];
-          return contracts.find(c => c.isExtension);
-        })(),
-        options: (() => {
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
-          return contractData?.options || [];
-        })(),
-        original: player,
-      })),
+      allPlayers.map((player) => {
+        const contractData = player.primaryContract ||
+          (player.contracts ? Object.values(player.contracts)[0] : null);
+
+        return {
+          id: player.id,
+          name: (player.bio?.displayName || player.name || '').toLowerCase(),
+          team: (player.bio?.display?.team || '').toLowerCase(),
+          position:
+            player.formattedPosition ||
+            POSITION_MAP[player.bio?.position] ||
+            player.bio?.position ||
+            '',
+          offenseRoles: [
+            player.offenseRole?.toLowerCase() || '',
+            player.primaryEvaluation?.roles?.offense2?.toLowerCase() || '',
+          ],
+          defenseRoles: [
+            player.defenseRole?.toLowerCase() || '',
+            player.primaryEvaluation?.roles?.defense2?.toLowerCase() || '',
+          ],
+          offenseSubroles: player.subRoles?.offense || [],
+          defenseSubroles: player.subRoles?.defense || [],
+          shootingProfile: (player.shootingProfile || '').toLowerCase(),
+          badges: player.badges || [],
+          salary: contractData?.salariesByYear?.find(
+            (s) => s.year === 2025 || s.season?.startsWith('2025')
+          )?.salary,
+          freeAgentYear:
+            player.bio?.display?.freeAgentYear?.toString() ||
+            contractData?.freeAgency?.freeAgentYear?.toString() ||
+            null,
+          freeAgentType: (
+            player.bio?.display?.freeAgentType ||
+            contractData?.freeAgency?.freeAgentType ||
+            ''
+          ).toLowerCase(),
+          contractType: (contractData?.contractType || '').toLowerCase(),
+          extension: (player.contracts ? Object.values(player.contracts) : [])
+            .find((c) => c.isExtension),
+          options: contractData?.options || [],
+          original: player,
+        };
+      }),
     [allPlayers]
   );
 
@@ -111,15 +116,15 @@ export const useRosterManager = (allPlayers = [], isLoading = false) => {
       if (loadMethod === 'current') {
         if (!selectedTeam) return;
         const rawTeamPlayers = allPlayers.filter(
-          (p) => (p.bio?.Team || '').toLowerCase() === selectedTeam.id
+          (p) => (p.bio?.display?.team || '').toLowerCase() === selectedTeam.id
         );
 
         const teamPlayers = rawTeamPlayers
           .filter((p) => !isTwoWayContract(p))
           .sort(
             (a, b) =>
-              parseFloat(b.system?.stats?.MP || 0) -
-              parseFloat(a.system?.stats?.MP || 0)
+              parseFloat(b.MIN ?? b.latestSeasonStats?.MIN ?? 0) -
+              parseFloat(a.MIN ?? a.latestSeasonStats?.MIN ?? 0)
           );
 
         setRoster(buildInitialRoster(teamPlayers));

--- a/src/utils/filtering/playerFilterUtils.js
+++ b/src/utils/filtering/playerFilterUtils.js
@@ -42,7 +42,8 @@ export function filterPlayers(players = [], filters) {
 
     if (
       filters.team &&
-      (p.bio?.Team || '').toLowerCase() !== filters.team.toLowerCase()
+      (p.bio?.display?.team || '').toLowerCase() !==
+        filters.team.toLowerCase()
     ) {
       return false;
     }
@@ -94,7 +95,7 @@ export function filterPlayers(players = [], filters) {
 
     if (
       filters.offenseRole &&
-      ![p.roles?.offense1, p.roles?.offense2]
+      ![p.offenseRole, p.primaryEvaluation?.roles?.offense2]
         .filter(Boolean)
         .some((role) =>
           role.toLowerCase().includes(filters.offenseRole.toLowerCase())
@@ -105,7 +106,7 @@ export function filterPlayers(players = [], filters) {
 
     if (
       filters.defenseRole &&
-      ![p.roles?.defense1, p.roles?.defense2]
+      ![p.defenseRole, p.primaryEvaluation?.roles?.defense2]
         .filter(Boolean)
         .some((role) =>
           role.toLowerCase().includes(filters.defenseRole.toLowerCase())
@@ -150,14 +151,14 @@ export function filterPlayers(players = [], filters) {
 
     if (
       !passesStat('PTS', 'PPG', 'PPG') ||
-      !passesStat('TRB', 'RPG', 'RPG') ||
+      !passesStat('REB', 'RPG', 'RPG') ||
       !passesStat('AST', 'APG', 'APG') ||
       !passesStat('FG%', 'FGP', 'FGP') ||
-      !passesStat('3P%', 'TPP', 'TPP') ||
+      !passesStat('3PT%', 'TPP', 'TPP') ||
       !passesStat('FT%', 'FTP', 'FTP') ||
       !passesStat('eFG%', 'eFGP', 'eFGP') ||
-      !passesStat('MP', 'MIN', 'MIN') ||
-      !passesStat('G', 'G', 'G')
+      !passesStat('MIN', 'MIN', 'MIN') ||
+      !passesStat('GP', 'G', 'G')
     ) {
       return false;
     }
@@ -199,7 +200,8 @@ function checkForZeroContract(player) {
   const currentYear = 2025;
 
   // Get contract data from v2 structure
-  const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
+  const contractData = player.primaryContract ||
+    (player.contracts ? Object.values(player.contracts)[0] : null);
   
   // Check salariesByYear array in v2 structure
   if (contractData?.salariesByYear) {
@@ -290,7 +292,8 @@ export function sortPlayers(
           return parseInt(player.freeAgentYear || player.bio?.display?.freeAgentYear) - 2024 || -1;
         case 'totalContract':
           // Contract data is in contracts subcollection
-          const contractData = player.contracts ? Object.values(player.contracts)[0] : null;
+          const contractData = player.primaryContract ||
+            (player.contracts ? Object.values(player.contracts)[0] : null);
           return Array.isArray(contractData?.salariesByYear)
             ? contractData.salariesByYear.reduce((sum, s) => {
                 const val =

--- a/src/utils/roster/contractUtils.js
+++ b/src/utils/roster/contractUtils.js
@@ -1,6 +1,16 @@
 export function isTwoWayContract(player) {
-  const summary = player?.contract_summary || {};
-  const fieldsToCheck = [summary.signed_using, summary.type];
+  if (!player) return false;
+
+  const contract = player.primaryContract ||
+    (player.contracts ? Object.values(player.contracts)[0] : null) ||
+    player.contractView ||
+    null;
+
+  const fieldsToCheck = [
+    typeof contract?.signedUsing === 'string' ? contract.signedUsing : null,
+    typeof contract?.contractType === 'string' ? contract.contractType : null,
+  ];
+
   return fieldsToCheck.some(
     (val) =>
       typeof val === 'string' &&

--- a/src/utils/roster/enrichPlayerData.js
+++ b/src/utils/roster/enrichPlayerData.js
@@ -11,68 +11,82 @@ import { POSITION_MAP } from '@/utils/roles/roleUtils';
  * - evaluations: { [evalId]: { roles, traits, badges, etc. } }
  */
 export function enrichPlayerData(playerData) {
+  if (!playerData) return null;
+
   // v2 nested position data (ONLY v2 structure)
   const rawPosition = playerData.bio?.position;
   const formattedPosition = POSITION_MAP[rawPosition] || rawPosition || '—';
 
-  // v2 salary data from contracts subcollection
+  // Determine the primary contract (first contract document)
+  let primaryContractId = null;
+  let primaryContract = null;
+  if (playerData.contracts && Object.keys(playerData.contracts).length > 0) {
+    const [firstId, firstContract] = Object.entries(playerData.contracts).sort(
+      ([a], [b]) => a.localeCompare(b)
+    )[0];
+    primaryContractId = firstId;
+    primaryContract = firstContract || null;
+  }
+
   const salaryMap = {};
-  const contractData = playerData.contracts
-    ? Object.values(playerData.contracts)[0]
-    : null;
-  const annualSalaries = contractData?.salariesByYear || [];
+  const annualSalaries = primaryContract?.salariesByYear || [];
 
   annualSalaries.forEach((s) => {
+    const key = s.year || s.season;
+    if (!key) return;
+
     let raw = s.salary;
     if (typeof raw === 'string') {
-      raw = raw.replace(/[\$,]/g, '');
-      if (raw.includes('M')) {
-        raw = raw.replace('M', '');
-        salaryMap[s.year || s.season] = parseFloat(raw);
+      const cleaned = raw.replace(/[\$,]/g, '').trim();
+      if (cleaned.endsWith('M')) {
+        const value = parseFloat(cleaned.slice(0, -1));
+        salaryMap[key] = Number.isFinite(value) ? value : null;
       } else {
-        salaryMap[s.year || s.season] = parseFloat(raw) / 1_000_000;
+        const value = parseFloat(cleaned);
+        salaryMap[key] = Number.isFinite(value) ? value / 1_000_000 : null;
       }
     } else if (typeof raw === 'number') {
-      salaryMap[s.year || s.season] = raw / 1_000_000;
+      salaryMap[key] = raw / 1_000_000;
     } else {
-      salaryMap[s.year || s.season] = null;
+      salaryMap[key] = null;
     }
-    if (isNaN(salaryMap[s.year || s.season]))
-      salaryMap[s.year || s.season] = null;
+
+    if (Number.isNaN(salaryMap[key])) {
+      salaryMap[key] = null;
+    }
   });
 
   // v2 stats data from seasons subcollection
-  let currentStats = {};
-  if (playerData.seasons) {
-    const seasons = Object.entries(playerData.seasons);
-    if (seasons.length > 0) {
-      // Use most recent season
-      const [, seasonData] = seasons.sort((a, b) =>
-        b[0].localeCompare(a[0])
-      )[0];
-      currentStats = seasonData.stats || {};
-    }
+  let latestSeasonId = null;
+  let latestSeasonStats = {};
+  let latestSeasonMeta = {};
+  if (playerData.seasons && Object.keys(playerData.seasons).length > 0) {
+    const [seasonId, seasonData] = Object.entries(playerData.seasons)
+      .sort(([a], [b]) => b.localeCompare(a))[0];
+    latestSeasonId = seasonId;
+    latestSeasonStats = seasonData?.stats || {};
+    latestSeasonMeta = seasonData?.meta || {};
   }
 
-  // v2 evaluation data from evaluations subcollection
+  // v2 evaluation data from evaluations subcollection (use first entry)
   let evaluationData = {};
-  if (playerData.evaluations) {
-    const evals = Object.values(playerData.evaluations);
-    if (evals.length > 0) {
-      evaluationData = evals[0]; // Use first evaluation
-    }
+  if (playerData.evaluations && Object.keys(playerData.evaluations).length > 0) {
+    const [evaluation] = Object.values(playerData.evaluations);
+    evaluationData = evaluation || {};
   }
 
   return {
     ...playerData,
-    // Add convenience fields for backward compatibility (all from v2 structure)
+    // Convenience fields sourced exclusively from v2 structure
     name: playerData.bio?.displayName || '',
     formattedPosition,
     heightInInches: playerData.bio?.height || 0,
     weight: playerData.bio?.weight || 0,
     age: playerData.bio?.age || 0,
     team: playerData.bio?.display?.team || null,
-    headshotUrl: `/assets/headshots/${playerData.bio?.playerId || playerData.id}.png`,
+    headshotUrl: `/assets/headshots/${
+      playerData.bio?.playerId || playerData.id
+    }.png`,
     offenseRole: evaluationData.roles?.offense1 || '—',
     defenseRole: evaluationData.roles?.defense1 || '—',
     shootingProfile: evaluationData.shootingProfile || '—',
@@ -82,11 +96,17 @@ export function enrichPlayerData(playerData) {
     },
     traits: evaluationData.traits || {},
     badges: evaluationData.badges || [],
-    overallGrade: evaluationData.overallGrade,
+    overallGrade: evaluationData.overallGrade ?? null,
     salaryByYear: salaryMap,
-    PPG: currentStats.PTS ?? null,
-    RPG: currentStats.REB ?? null,
-    APG: currentStats.AST ?? null,
-    ...currentStats,
+    latestSeasonId,
+    latestSeasonStats,
+    latestSeasonMeta,
+    primaryContractId,
+    primaryContract,
+    primaryEvaluation: evaluationData,
+    PPG: latestSeasonStats.PTS ?? null,
+    RPG: latestSeasonStats.REB ?? null,
+    APG: latestSeasonStats.AST ?? null,
+    ...latestSeasonStats,
   };
 }

--- a/src/utils/roster/rosterUtils.js
+++ b/src/utils/roster/rosterUtils.js
@@ -2,19 +2,21 @@ import { POSITION_MAP } from '../roles';
 
 export function normalizePlayer(player) {
   if (!player) return null;
+  const playerId = player.bio?.playerId || player.id;
   return {
     ...player,
     displayName: player.bio?.displayName || player.name || 'Unknown Player',
-    headshot: player.headshot || `/assets/headshots/${player.id}.png`,
+    headshot: player.headshot || `/assets/headshots/${playerId}.png`,
     bio: {
       ...player.bio,
-      Position: player.bio?.Position || 'Unknown',
+      position: player.bio?.position || player.formattedPosition || 'Unknown',
     },
   };
 }
 
 export function buildInitialRoster(teamPlayers) {
-  const getPosition = (p) => (p.bio?.Position || '').toUpperCase();
+  const getPosition = (p) =>
+    (p.bio?.position || p.formattedPosition || '').toUpperCase();
   const starterSlots = [null, null, null, null, null];
   const positionPriorities = [
     { test: (pos) => pos.includes('G') && !pos.includes('F'), slots: [0, 1] },


### PR DESCRIPTION
## Summary
- normalize enriched player data to expose primary contracts, latest stats, and evaluation helpers from the players_v2 documents
- update roster, tier maker, list export, and profile UI to reference bio.display, seasons, and contracts data instead of legacy players fields
- simplify collection constants now that the legacy players collection is retired

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1f0ecaf788326b81ae1bf2e09bf11