### PR TITLE
Architect World Operating Experience Stage 1

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -29,12 +29,14 @@ GMDashboard/
     useArchitectActions.types.normalizers.ts
     useArchitectActions.types.ts
     useArchitectModals.ts
+    useArchitectModePresentation.ts
     useArchitectState.freeAgents.ts
     useArchitectState.helpers.ts
     useArchitectState.ts
     useArchitectState.types.ts
     useArchitectState.worldLoader.ts
     useArchitectState.worldTracker.ts
+    useArchitectWorkspaceContext.ts
   offerSheetTypes.ts
   sections/
     CapSheetSection.tsx
@@ -480,5 +482,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-05-18T04:31:42.439Z*
+*Generated on: 2026-05-19T09:37:18.544Z*
 *Auto-updated by: npm run docs*

--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -10,6 +10,7 @@ GMDashboard/
     DeleteWorldModal.tsx
     DraftPositionsInput.tsx
     OfferSheetList.tsx
+    ScenarioMoveRail.tsx
     SeasonAdvanceModal.helpers.ts
     SeasonAdvanceModal.tsx
     SeasonAdvanceModal.types.ts
@@ -38,6 +39,7 @@ GMDashboard/
     useArchitectState.worldLoader.ts
     useArchitectState.worldTracker.ts
     useArchitectWorkspaceContext.ts
+    useScenarioActivityRail.ts
   offerSheetTypes.ts
   sections/
     CapSheetSection.tsx
@@ -483,5 +485,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-05-19T09:52:50.573Z*
+*Generated on: 2026-05-19T11:13:45.167Z*
 *Auto-updated by: npm run docs*

--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -5,6 +5,7 @@ ARCHITECT_FEATURE_README.md
 GMDashboard/
   GMDashboard.tsx
   components/
+    ArchitectWorkspaceHeader.tsx
     CapAuditDebugPanel.tsx
     DeleteWorldModal.tsx
     DraftPositionsInput.tsx
@@ -482,5 +483,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-05-19T09:37:18.544Z*
+*Generated on: 2026-05-19T09:52:50.573Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/ARCHITECT_FEATURE_README.md
+++ b/src/features/architect/ARCHITECT_FEATURE_README.md
@@ -20,7 +20,10 @@ Architect is intentionally layered. The fastest way to route work is:
 - **Dashboard adapters:** `useArchitectState.ts` and `useArchitectActions.ts` coordinate dashboard state and UI actions, but they are not the final read or write authorities.
 - **World operating presentation seams:** `useArchitectModePresentation.ts` and
   `useArchitectWorkspaceContext.ts` derive read-only labels and workspace view
-  models from dashboard-owned state for future cockpit/status UI.
+  models from dashboard-owned state. `ArchitectWorkspaceHeader.tsx` renders the
+  persistent cockpit strip. `useScenarioActivityRail.ts` and `ScenarioMoveRail.tsx`
+  provide the read-only activity rail using committed world event history via
+  the existing `useWorldTeamEvents` authorized read path.
 - **World lifecycle authority:** `worldManager.ts` owns world metadata, world lifecycle operations, and world-level metadata writes.
 - **World-aware read authority:** `teamLoader.ts` owns the explicit `world -> parent world -> base` fallback contract for team and player reads.
 - **Base hydration authority:** `firebaseTeamPlanHelpers.ts` owns base-only hydration for teams, players, and free agents.
@@ -36,9 +39,15 @@ Architect is intentionally layered. The fastest way to route work is:
 - **Where do world-aware reads live?** `teamLoader.ts` is the world-aware fallback authority.
 - **Where do committed writes live?** `mutationPipeline.ts` for general mutations, `worldManager.ts` for world metadata/lifecycle writes, and `seasonManager.ts` for season advancement writes.
 - **What happens without an active world?** `useArchitectState.ts` publishes the dashboard `sandbox` boundary, while `useArchitectActions.ts` may apply `local-validated` local state or preview/local-only seams without creating committed world truth.
-- **Where does Stage 1A operating context live?** The dashboard hook helpers
-  compose existing state into presentation-only mode labels and workspace
-  summaries. They do not read Firestore, write Firestore, or authorize actions.
+- **Where does the Stage 1 World Operating Experience layer live?** The cockpit
+  strip (`ArchitectWorkspaceHeader.tsx`) and activity rail (`ScenarioMoveRail.tsx`)
+  are read-only UI components. The workspace context hooks
+  (`useArchitectModePresentation.ts`, `useArchitectWorkspaceContext.ts`) compose
+  existing dashboard state without Firestore reads, writes, or action authority.
+  The activity rail hook (`useScenarioActivityRail.ts`) reads committed world
+  events through the existing `useWorldTeamEvents` authorized read path only — it
+  does not write Firestore, does not reconstruct events from local/draft state, and
+  is disabled when no world is active.
 - **How do `mutationPipeline.ts` and `seasonManager.ts` relate?** They are sibling committed-write authorities: point-in-time world mutations go through `mutationPipeline.ts`, while whole-world season transitions go through `seasonManager.ts`.
 - **What files are orchestration/adapters?** `GMDashboard.tsx`, `useArchitectState.ts`, `useArchitectActions.ts`, and `worldTeamData.ts`.
 - **Where should cap totals and contract-year truth come from?** Use `computeTeamCapTotals.ts` for canonical team totals and `contractUtils.ts` for shared contract shaping/year lookups instead of rebuilding those calculations in downstream surfaces.

--- a/src/features/architect/ARCHITECT_FEATURE_README.md
+++ b/src/features/architect/ARCHITECT_FEATURE_README.md
@@ -18,6 +18,9 @@ Architect is intentionally layered. The fastest way to route work is:
 
 - **Composition shell:** `GMDashboard.tsx` composes the dashboard surface only.
 - **Dashboard adapters:** `useArchitectState.ts` and `useArchitectActions.ts` coordinate dashboard state and UI actions, but they are not the final read or write authorities.
+- **World operating presentation seams:** `useArchitectModePresentation.ts` and
+  `useArchitectWorkspaceContext.ts` derive read-only labels and workspace view
+  models from dashboard-owned state for future cockpit/status UI.
 - **World lifecycle authority:** `worldManager.ts` owns world metadata, world lifecycle operations, and world-level metadata writes.
 - **World-aware read authority:** `teamLoader.ts` owns the explicit `world -> parent world -> base` fallback contract for team and player reads.
 - **Base hydration authority:** `firebaseTeamPlanHelpers.ts` owns base-only hydration for teams, players, and free agents.
@@ -33,6 +36,9 @@ Architect is intentionally layered. The fastest way to route work is:
 - **Where do world-aware reads live?** `teamLoader.ts` is the world-aware fallback authority.
 - **Where do committed writes live?** `mutationPipeline.ts` for general mutations, `worldManager.ts` for world metadata/lifecycle writes, and `seasonManager.ts` for season advancement writes.
 - **What happens without an active world?** `useArchitectState.ts` publishes the dashboard `sandbox` boundary, while `useArchitectActions.ts` may apply `local-validated` local state or preview/local-only seams without creating committed world truth.
+- **Where does Stage 1A operating context live?** The dashboard hook helpers
+  compose existing state into presentation-only mode labels and workspace
+  summaries. They do not read Firestore, write Firestore, or authorize actions.
 - **How do `mutationPipeline.ts` and `seasonManager.ts` relate?** They are sibling committed-write authorities: point-in-time world mutations go through `mutationPipeline.ts`, while whole-world season transitions go through `seasonManager.ts`.
 - **What files are orchestration/adapters?** `GMDashboard.tsx`, `useArchitectState.ts`, `useArchitectActions.ts`, and `worldTeamData.ts`.
 - **Where should cap totals and contract-year truth come from?** Use `computeTeamCapTotals.ts` for canonical team totals and `contractUtils.ts` for shared contract shaping/year lookups instead of rebuilding those calculations in downstream surfaces.

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -31,6 +31,7 @@ import { WorldSelector } from '@/features/architect/GMDashboard/components/World
 import { WorldTimeControls } from '@/features/architect/GMDashboard/components/WorldTimeControls';
 import { CapAuditDebugPanel } from '@/features/architect/GMDashboard/components/CapAuditDebugPanel';
 import { ArchitectWorkspaceHeader } from '@/features/architect/GMDashboard/components/ArchitectWorkspaceHeader';
+import { ScenarioMoveRail } from '@/features/architect/GMDashboard/components/ScenarioMoveRail';
 import { useArchitectState } from './hooks/useArchitectState';
 import { useArchitectWorkspaceContext } from './hooks/useArchitectWorkspaceContext';
 import { useArchitectActions } from './hooks/useArchitectActions';
@@ -419,6 +420,12 @@ export const GMDashboard = () => {
       </div>
 
       <ArchitectWorkspaceHeader context={workspaceContext} />
+
+      <ScenarioMoveRail
+        worldId={worldId}
+        teamCode={normalizedTeamId}
+        onOpenHistory={() => setActiveTab('history')}
+      />
 
       {showEmulatorUnavailableBanner && (
         <div

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -30,7 +30,9 @@ import { HistorySection } from './sections/HistorySection';
 import { WorldSelector } from '@/features/architect/GMDashboard/components/WorldSelector';
 import { WorldTimeControls } from '@/features/architect/GMDashboard/components/WorldTimeControls';
 import { CapAuditDebugPanel } from '@/features/architect/GMDashboard/components/CapAuditDebugPanel';
+import { ArchitectWorkspaceHeader } from '@/features/architect/GMDashboard/components/ArchitectWorkspaceHeader';
 import { useArchitectState } from './hooks/useArchitectState';
+import { useArchitectWorkspaceContext } from './hooks/useArchitectWorkspaceContext';
 import { useArchitectActions } from './hooks/useArchitectActions';
 import { useArchitectModals } from './hooks/useArchitectModals';
 import { usePlayerRulesProfiles } from '@/features/architect/hooks/usePlayerRulesProfiles';
@@ -145,6 +147,21 @@ export const GMDashboard = () => {
     setOffseasonSummary,
     reloadActiveWorldTeamData,
   } = state;
+
+  const workspaceContext = useArchitectWorkspaceContext({
+    teamCapSheet,
+    teamId: normalizedTeamId,
+    currentYear,
+    worldId,
+    activeWorldLabel: null,
+    worldAsOfDate,
+    worldCurrentSeason,
+    worldMetadataLoading,
+    isLoading,
+    isSaving,
+    error,
+    worldModeBoundary,
+  });
 
   const isEmulatorMode = FIREBASE_TARGET_MODE === 'EMULATOR';
   const showEmulatorUnavailableBanner =
@@ -400,6 +417,9 @@ export const GMDashboard = () => {
           </label>
         </div>
       </div>
+
+      <ArchitectWorkspaceHeader context={workspaceContext} />
+
       {showEmulatorUnavailableBanner && (
         <div
           className="mb-3 rounded-md border border-amber-300/40 bg-amber-300/10 px-3 py-2 text-amber-100 text-sm"

--- a/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
@@ -1,12 +1,15 @@
 /**
  * FILE: src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
- * PURPOSE: Read-only Stage 1B persistent workspace header/status strip for GMDashboard.
+ * PURPOSE: Read-only Stage 1B/1C persistent workspace header/status strip for GMDashboard.
  * OWNERSHIP: Feature: architect/GMDashboard
  *
- * Surfaces active team, world, date, season, mode, and posture at a glance.
- * Consumes the Stage 1A workspace context seam. No mutation authority.
+ * Surfaces active team, world, date, season, mode, posture, and franchise summary indicators.
+ * Consumes the Stage 1A/1C workspace context seam. No mutation authority.
  */
-import type { ArchitectWorkspaceContext } from '../hooks/useArchitectWorkspaceContext';
+import type {
+  ArchitectWorkspaceContext,
+  ArchitectWorkspaceExceptionsSummary,
+} from '../hooks/useArchitectWorkspaceContext';
 import type { ArchitectModePresentationTone } from '../hooks/useArchitectModePresentation';
 
 interface Props {
@@ -66,8 +69,33 @@ const CapSummary = ({ cap }: { cap: CapAvailable }) => (
   </>
 );
 
+type ExceptionsAvailable = Extract<ArchitectWorkspaceExceptionsSummary, { status: 'available' }>;
+
+const ExceptionLine = ({
+  exc,
+  seasonMismatch,
+}: {
+  exc: ExceptionsAvailable;
+  seasonMismatch: boolean;
+}) => {
+  const flags: string[] = [];
+  if (exc.hasAvailableMle) flags.push('MLE');
+  if (exc.hasAvailableBae) flags.push('BAE');
+  if (exc.hasAvailableRoom) flags.push('Room Exc.');
+  if (exc.tpeCount > 0) flags.push(`TPE ×${exc.tpeCount}`);
+
+  return (
+    <span>
+      Exc: {flags.length > 0 ? flags.join(' · ') : 'none available'}
+      {seasonMismatch && (
+        <span className="ml-1 text-white/20">(world season)</span>
+      )}
+    </span>
+  );
+};
+
 export const ArchitectWorkspaceHeader = ({ context }: Props) => {
-  const { team, world, seasons, worldDate, mode, status, roster, cap } = context;
+  const { team, world, seasons, worldDate, mode, status, roster, cap, exceptions, draftAssets, recentActivity } = context;
 
   return (
     <div
@@ -170,6 +198,24 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
             <span className="italic">Cap loading…</span>
           </>
         )}
+      </div>
+
+      {/* Row 3: Franchise summary indicators — exceptions, draft assets, activity */}
+      <div className="mt-1 flex flex-wrap items-center gap-2 border-t border-white/5 pt-1.5 text-white/30">
+        {exceptions.status === 'available' && exceptions.hasAnyActive ? (
+          <ExceptionLine
+            exc={exceptions}
+            seasonMismatch={seasons.viewingSeasonDiffersFromWorldSeason === true}
+          />
+        ) : exceptions.status === 'loading' ? (
+          <span className="italic">Exceptions loading…</span>
+        ) : (
+          <span>Exceptions: see Cap Sheet</span>
+        )}
+        <Sep />
+        <span>{draftAssets.deferralHint === 'see-trade-history' ? 'Draft picks: see Trade & History' : 'Draft picks: unavailable'}</span>
+        <Sep />
+        <span>{recentActivity.entryPoint === 'history-tab' ? 'Activity: see History' : 'Activity: unavailable'}</span>
       </div>
     </div>
   );

--- a/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
@@ -120,7 +120,8 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
 
         {seasons.viewingSeasonDiffersFromWorldSeason === true && (
           <span className="rounded border border-amber-300/30 bg-amber-400/10 px-1.5 py-0.5 text-amber-200">
-            ⚠ Season mismatch
+            ⚠ Viewing {seasons.selectedViewingSeasonLabel ?? '?'} ≠ World{' '}
+            {seasons.authoritativeWorldSeasonLabel ?? '?'}
           </span>
         )}
 
@@ -159,13 +160,13 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
         )}
         {cap.status === 'available' && (
           <>
-            {roster.status === 'available' && <Sep />}
+            {(roster.status === 'available' || roster.status === 'loading') && <Sep />}
             <CapSummary cap={cap} />
           </>
         )}
         {cap.status === 'loading' && (
           <>
-            <Sep />
+            {(roster.status === 'available' || roster.status === 'loading') && <Sep />}
             <span className="italic">Cap loading…</span>
           </>
         )}

--- a/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
@@ -86,9 +86,9 @@ const ExceptionLine = ({
 
   return (
     <span>
-      Exc: {flags.length > 0 ? flags.join(' · ') : 'none available'}
+      Exc: {flags.join(' · ')}
       {seasonMismatch && (
-        <span className="ml-1 text-white/20">(world season)</span>
+        <span className="ml-1 text-white/30">(world season)</span>
       )}
     </span>
   );
@@ -201,7 +201,7 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
       </div>
 
       {/* Row 3: Franchise summary indicators — exceptions, draft assets, activity */}
-      <div className="mt-1 flex flex-wrap items-center gap-2 border-t border-white/5 pt-1.5 text-white/30">
+      <div className="mt-1 flex flex-wrap items-center gap-3 border-t border-white/5 pt-1.5 text-white/30">
         {exceptions.status === 'available' && exceptions.hasAnyActive ? (
           <ExceptionLine
             exc={exceptions}
@@ -212,10 +212,8 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
         ) : (
           <span>Exceptions: see Cap Sheet</span>
         )}
-        <Sep />
-        <span>{draftAssets.deferralHint === 'see-trade-history' ? 'Draft picks: see Trade & History' : 'Draft picks: unavailable'}</span>
-        <Sep />
-        <span>{recentActivity.entryPoint === 'history-tab' ? 'Activity: see History' : 'Activity: unavailable'}</span>
+        <span>Draft picks: see Trade & History</span>
+        <span>Activity: see History</span>
       </div>
     </div>
   );

--- a/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
@@ -1,0 +1,175 @@
+/**
+ * FILE: src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
+ * PURPOSE: Read-only Stage 1B persistent workspace header/status strip for GMDashboard.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Surfaces active team, world, date, season, mode, and posture at a glance.
+ * Consumes the Stage 1A workspace context seam. No mutation authority.
+ */
+import type { ArchitectWorkspaceContext } from '../hooks/useArchitectWorkspaceContext';
+import type { ArchitectModePresentationTone } from '../hooks/useArchitectModePresentation';
+
+interface Props {
+  context: ArchitectWorkspaceContext;
+}
+
+const TONE_CLASS: Record<ArchitectModePresentationTone, string> = {
+  success: 'bg-green-500/15 text-green-200 border-green-400/30',
+  neutral: 'bg-white/10 text-white/70 border-white/10',
+  info: 'bg-blue-500/15 text-blue-200 border-blue-400/30',
+  warning: 'bg-amber-400/15 text-amber-200 border-amber-300/30',
+  danger: 'bg-rose-500/15 text-rose-200 border-rose-300/30',
+  muted: 'bg-white/5 text-white/40 border-white/10',
+};
+
+const fmt = (v: number) => `$${(Math.abs(v) / 1_000_000).toFixed(1)}M`;
+
+type CapAvailable = Extract<ArchitectWorkspaceContext['cap'], { status: 'available' }>;
+
+const Sep = () => (
+  <span className="text-white/20" aria-hidden="true">
+    ·
+  </span>
+);
+
+const CapSummary = ({ cap }: { cap: CapAvailable }) => (
+  <>
+    <span>
+      {cap.seasonLabel}:{' '}
+      {cap.isOverCap ? (
+        <span className="text-rose-300">{fmt(cap.capSpace)} over cap</span>
+      ) : (
+        <span className="text-green-300">{fmt(cap.capSpace)} space</span>
+      )}
+    </span>
+    <Sep />
+    <span>
+      Tax:{' '}
+      {cap.isOverTax ? (
+        <span className="text-amber-300">{fmt(cap.taxSpace)} over</span>
+      ) : (
+        <span>{fmt(cap.taxSpace)} space</span>
+      )}
+    </span>
+    {cap.isAtOrAboveFirstApron && (
+      <>
+        <Sep />
+        <span className="text-amber-200">1st Apron</span>
+      </>
+    )}
+    {cap.isAboveSecondApron && (
+      <>
+        <Sep />
+        <span className="text-rose-200">2nd Apron</span>
+      </>
+    )}
+  </>
+);
+
+export const ArchitectWorkspaceHeader = ({ context }: Props) => {
+  const { team, world, seasons, worldDate, mode, status, roster, cap } = context;
+
+  return (
+    <div
+      className="mb-4 rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/70"
+      data-testid="architect-workspace-header"
+    >
+      {/* Row 1: Identity · date · season · mode */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-semibold text-white/90">{team.label}</span>
+        <Sep />
+        <span>{world.label}</span>
+
+        {worldDate.status === 'available' && (
+          <>
+            <Sep />
+            <span className="text-white/50">As of {worldDate.value}</span>
+          </>
+        )}
+        {worldDate.status === 'loading' && (
+          <>
+            <Sep />
+            <span className="italic text-white/30">Date loading…</span>
+          </>
+        )}
+        {worldDate.status === 'unavailable' && world.status !== 'sandbox' && (
+          <>
+            <Sep />
+            <span className="text-white/30">Date unavailable</span>
+          </>
+        )}
+
+        <Sep />
+        <span>Viewing {seasons.selectedViewingSeasonLabel ?? '—'}</span>
+
+        {seasons.authoritativeWorldSeasonStatus === 'available' &&
+          seasons.authoritativeWorldSeasonLabel && (
+            <>
+              <Sep />
+              <span className="text-white/50">
+                World {seasons.authoritativeWorldSeasonLabel}
+              </span>
+            </>
+          )}
+        {seasons.authoritativeWorldSeasonStatus === 'loading' && (
+          <>
+            <Sep />
+            <span className="italic text-white/30">World season loading…</span>
+          </>
+        )}
+
+        {seasons.viewingSeasonDiffersFromWorldSeason === true && (
+          <span className="rounded border border-amber-300/30 bg-amber-400/10 px-1.5 py-0.5 text-amber-200">
+            ⚠ Season mismatch
+          </span>
+        )}
+
+        <span className="min-w-0 flex-1" />
+
+        {status.hasError && (
+          <span
+            className="text-rose-300"
+            title={status.errorMessage ?? undefined}
+          >
+            Error
+          </span>
+        )}
+        {status.isSaving && (
+          <span className="italic text-white/50">Saving…</span>
+        )}
+        {(status.isLoading || status.worldMetadataLoading) && !status.hasError && (
+          <span className="italic text-white/30">Loading…</span>
+        )}
+
+        <span
+          className={`rounded border px-2 py-0.5 font-semibold ${TONE_CLASS[mode.tone]}`}
+          title={mode.detail}
+        >
+          {mode.shortLabel}
+        </span>
+      </div>
+
+      {/* Row 2: Compact roster count · cap posture */}
+      <div className="mt-1.5 flex flex-wrap items-center gap-2 text-white/40">
+        {roster.status === 'available' && (
+          <span>Roster: {roster.count}</span>
+        )}
+        {roster.status === 'loading' && (
+          <span className="italic">Roster loading…</span>
+        )}
+        {cap.status === 'available' && (
+          <>
+            {roster.status === 'available' && <Sep />}
+            <CapSummary cap={cap} />
+          </>
+        )}
+        {cap.status === 'loading' && (
+          <>
+            <Sep />
+            <span className="italic">Cap loading…</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
+++ b/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
@@ -1,0 +1,129 @@
+/**
+ * FILE: src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
+ * PURPOSE: Read-only Stage 1D persistent activity rail for GMDashboard.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Shows recent committed world events for the active team and world.
+ * In sandbox/no-world mode, shows a conservative placeholder.
+ * Local and pending activity are explicitly deferred.
+ * No mutation authority.
+ */
+import { useScenarioActivityRail } from '../hooks/useScenarioActivityRail';
+
+interface ScenarioMoveRailProps {
+  worldId: string | null | undefined;
+  teamCode: string | null | undefined;
+  onOpenHistory: () => void;
+}
+
+const formatRailDate = (iso: string): string => {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) {
+    return iso.slice(0, 10) || '—';
+  }
+  return new Date(parsed).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+export const ScenarioMoveRail = ({
+  worldId,
+  teamCode,
+  onOpenHistory,
+}: ScenarioMoveRailProps) => {
+  const { railState, localPendingDeferred } = useScenarioActivityRail({
+    worldId,
+    teamCode,
+  });
+
+  return (
+    <div
+      className="mb-4 rounded-md border border-white/10 bg-white/[0.015] px-3 py-2 text-xs"
+      data-testid="scenario-move-rail"
+    >
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-white/40 font-medium">Recent Activity</span>
+        <button
+          type="button"
+          onClick={onOpenHistory}
+          className="text-white/25 hover:text-white/50 text-[11px] transition-colors"
+          data-testid="scenario-move-rail-open-history"
+        >
+          Full History →
+        </button>
+      </div>
+
+      {railState.status === 'sandbox' && (
+        <p
+          className="text-white/25 italic"
+          data-testid="scenario-move-rail-sandbox"
+        >
+          Activity rail uses committed world events. Select a world to see
+          scenario activity.
+        </p>
+      )}
+
+      {railState.status === 'loading' && (
+        <p
+          className="text-white/25 italic"
+          data-testid="scenario-move-rail-loading"
+        >
+          Loading recent activity…
+        </p>
+      )}
+
+      {railState.status === 'error' && (
+        <p
+          className="text-rose-300/70"
+          data-testid="scenario-move-rail-error"
+        >
+          Unable to load recent activity.
+        </p>
+      )}
+
+      {railState.status === 'empty' && (
+        <p
+          className="text-white/25 italic"
+          data-testid="scenario-move-rail-empty"
+        >
+          No committed activity for this team in the active world.
+        </p>
+      )}
+
+      {railState.status === 'available' && (
+        <>
+          <ul
+            className="space-y-1.5"
+            data-testid="scenario-move-rail-entries"
+          >
+            {railState.entries.map((entry) => (
+              <li
+                key={entry.id}
+                className="flex items-baseline gap-2 text-white/50"
+              >
+                <span className="shrink-0 rounded border border-green-500/20 bg-green-500/10 px-1 text-green-400/60 text-[10px] leading-4">
+                  World
+                </span>
+                <span className="shrink-0">{entry.typeLabel}</span>
+                <span className="text-white/35 min-w-0 truncate">
+                  {entry.summary}
+                </span>
+                {entry.occurredAt && (
+                  <span className="shrink-0 ml-auto pl-2 text-white/20">
+                    {formatRailDate(entry.occurredAt)}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+          {localPendingDeferred && (
+            <p className="mt-1.5 text-white/20 text-[10px]">
+              Local and pending activity not shown.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
+++ b/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
@@ -76,6 +76,7 @@ export const ScenarioMoveRail = ({
       {railState.status === 'error' && (
         <p
           className="text-rose-300/70"
+          title={railState.message}
           data-testid="scenario-move-rail-error"
         >
           Unable to load recent activity.
@@ -110,7 +111,7 @@ export const ScenarioMoveRail = ({
                   {entry.summary}
                 </span>
                 {entry.occurredAt && (
-                  <span className="shrink-0 ml-auto pl-2 text-white/20">
+                  <span className="shrink-0 ml-auto pl-2 text-white/25">
                     {formatRailDate(entry.occurredAt)}
                   </span>
                 )}
@@ -118,7 +119,7 @@ export const ScenarioMoveRail = ({
             ))}
           </ul>
           {localPendingDeferred && (
-            <p className="mt-1.5 text-white/20 text-[10px]">
+            <p className="mt-1.5 text-white/30 text-[10px]">
               Local and pending activity not shown.
             </p>
           )}

--- a/src/features/architect/GMDashboard/hooks/useArchitectModePresentation.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectModePresentation.ts
@@ -1,0 +1,204 @@
+/**
+ * FILE: src/features/architect/GMDashboard/hooks/useArchitectModePresentation.ts
+ * PURPOSE: Read-only presentation seam for Architect world/sandbox/preview authority labels.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ */
+
+import { useMemo } from 'react';
+import type { ArchitectWorldModeBoundary } from './useArchitectState';
+
+export type ArchitectModePresentationKind =
+  | 'committed-world'
+  | 'sandbox'
+  | 'local-only-preview'
+  | 'pending-world-preview'
+  | 'failed-world-preview'
+  | 'dev-only-preview'
+  | 'loading'
+  | 'unavailable'
+  | 'error';
+
+export type ArchitectModePresentationTone =
+  | 'success'
+  | 'neutral'
+  | 'info'
+  | 'warning'
+  | 'danger'
+  | 'muted';
+
+export interface ArchitectModePresentation {
+  kind: ArchitectModePresentationKind;
+  label: string;
+  shortLabel: string;
+  detail: string;
+  tone: ArchitectModePresentationTone;
+  worldId: string | null;
+  isCommittedWorldTruth: boolean;
+}
+
+export interface ArchitectModePresentationInput {
+  worldId?: string | null;
+  worldModeBoundary?: ArchitectWorldModeBoundary | null;
+  isLoading?: boolean;
+  worldMetadataLoading?: boolean;
+  error?: string | null;
+  authorityOverride?: ArchitectModePresentationKind | null;
+}
+
+export type ArchitectEntryAuthorityKind =
+  | 'committed-world'
+  | 'sandbox'
+  | 'local-only-preview'
+  | 'pending-world-preview'
+  | 'failed-world-preview'
+  | 'dev-only-preview'
+  | 'unavailable';
+
+const PRESENTATION_BY_KIND: Record<
+  ArchitectModePresentationKind,
+  Omit<ArchitectModePresentation, 'worldId'>
+> = {
+  'committed-world': {
+    kind: 'committed-world',
+    label: 'Committed World',
+    shortLabel: 'World',
+    detail: 'This view reflects saved world state.',
+    tone: 'success',
+    isCommittedWorldTruth: true,
+  },
+  sandbox: {
+    kind: 'sandbox',
+    label: 'Sandbox',
+    shortLabel: 'Sandbox',
+    detail: 'No active world is selected. This is a local operating view.',
+    tone: 'neutral',
+    isCommittedWorldTruth: false,
+  },
+  'local-only-preview': {
+    kind: 'local-only-preview',
+    label: 'Local Preview',
+    shortLabel: 'Local',
+    detail: 'This entry is local-only and is not saved as committed world truth.',
+    tone: 'warning',
+    isCommittedWorldTruth: false,
+  },
+  'pending-world-preview': {
+    kind: 'pending-world-preview',
+    label: 'Pending World Save',
+    shortLabel: 'Pending',
+    detail: 'This preview is waiting for committed world persistence evidence.',
+    tone: 'info',
+    isCommittedWorldTruth: false,
+  },
+  'failed-world-preview': {
+    kind: 'failed-world-preview',
+    label: 'Failed Preview',
+    shortLabel: 'Failed',
+    detail: 'This preview did not become committed world truth.',
+    tone: 'danger',
+    isCommittedWorldTruth: false,
+  },
+  'dev-only-preview': {
+    kind: 'dev-only-preview',
+    label: 'Developer Preview',
+    shortLabel: 'DEV',
+    detail: 'This entry is a development-only preview and is not committed.',
+    tone: 'muted',
+    isCommittedWorldTruth: false,
+  },
+  loading: {
+    kind: 'loading',
+    label: 'Loading Context',
+    shortLabel: 'Loading',
+    detail: 'Architect is resolving the active operating context.',
+    tone: 'muted',
+    isCommittedWorldTruth: false,
+  },
+  unavailable: {
+    kind: 'unavailable',
+    label: 'Context Unavailable',
+    shortLabel: 'Unavailable',
+    detail: 'Architect cannot reliably identify the operating context yet.',
+    tone: 'muted',
+    isCommittedWorldTruth: false,
+  },
+  error: {
+    kind: 'error',
+    label: 'Context Error',
+    shortLabel: 'Error',
+    detail: 'Architect encountered an error while resolving operating context.',
+    tone: 'danger',
+    isCommittedWorldTruth: false,
+  },
+};
+
+const withWorldId = (
+  kind: ArchitectModePresentationKind,
+  worldId: string | null,
+  detailOverride?: string
+): ArchitectModePresentation => {
+  const base = PRESENTATION_BY_KIND[kind];
+  return {
+    ...base,
+    detail: detailOverride || base.detail,
+    worldId,
+  };
+};
+
+export function deriveArchitectEntryAuthorityPresentation(
+  authorityKind: ArchitectEntryAuthorityKind,
+  worldId: string | null = null
+): ArchitectModePresentation {
+  return withWorldId(authorityKind, worldId);
+}
+
+export function deriveArchitectModePresentation({
+  worldId = null,
+  worldModeBoundary = null,
+  isLoading = false,
+  worldMetadataLoading = false,
+  error = null,
+  authorityOverride = null,
+}: ArchitectModePresentationInput): ArchitectModePresentation {
+  if (authorityOverride) {
+    return withWorldId(authorityOverride, worldId);
+  }
+
+  if (error) {
+    return withWorldId('error', worldId, error);
+  }
+
+  if (isLoading || worldMetadataLoading) {
+    return withWorldId('loading', worldId);
+  }
+
+  if (!worldId) {
+    return withWorldId('sandbox', null);
+  }
+
+  if (
+    !worldModeBoundary ||
+    worldModeBoundary.kind !== 'world' ||
+    worldModeBoundary.worldId !== worldId
+  ) {
+    return withWorldId('unavailable', worldId);
+  }
+
+  return withWorldId('committed-world', worldId);
+}
+
+export function useArchitectModePresentation(
+  input: ArchitectModePresentationInput
+): ArchitectModePresentation {
+  return useMemo(
+    () => deriveArchitectModePresentation(input),
+    [
+      input.authorityOverride,
+      input.error,
+      input.isLoading,
+      input.worldId,
+      input.worldMetadataLoading,
+      input.worldModeBoundary,
+    ]
+  );
+}

--- a/src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts
@@ -21,11 +21,6 @@ import {
 
 type AvailabilityStatus = 'available' | 'loading' | 'unavailable';
 
-type WorkspaceSummaryPlaceholder = {
-  status: 'unavailable';
-  reason: string;
-};
-
 export type ArchitectWorkspaceTeamContext =
   | {
       status: 'available';
@@ -104,6 +99,34 @@ export type ArchitectWorkspaceCapSummary =
       reason: string;
     };
 
+export type ArchitectWorkspaceExceptionsSummary =
+  | {
+      status: 'available';
+      tpeCount: number;
+      hasAvailableMle: boolean;
+      hasAvailableBae: boolean;
+      hasAvailableRoom: boolean;
+      hasAnyActive: boolean;
+      worldSeasonBasis: true;
+    }
+  | { status: 'loading' }
+  | {
+      status: 'unavailable';
+      deferralHint: 'see-cap-sheet';
+      reason: string;
+    };
+
+export type ArchitectWorkspaceDraftAssetsSummary = {
+  status: 'unavailable';
+  deferralHint: 'see-trade-history';
+  reason: string;
+};
+
+export type ArchitectWorkspaceActivityIndicator = {
+  status: 'deferred';
+  entryPoint: 'history-tab';
+};
+
 export interface ArchitectWorkspaceStatusContext {
   isLoading: boolean;
   isSaving: boolean;
@@ -121,8 +144,9 @@ export interface ArchitectWorkspaceContext {
   status: ArchitectWorkspaceStatusContext;
   roster: ArchitectWorkspaceRosterSummary;
   cap: ArchitectWorkspaceCapSummary;
-  exceptions: WorkspaceSummaryPlaceholder;
-  draftAssets: WorkspaceSummaryPlaceholder;
+  exceptions: ArchitectWorkspaceExceptionsSummary;
+  draftAssets: ArchitectWorkspaceDraftAssetsSummary;
+  recentActivity: ArchitectWorkspaceActivityIndicator;
 }
 
 export interface ArchitectWorkspaceContextInput {
@@ -382,6 +406,47 @@ function deriveCapSummary({
   }
 }
 
+function deriveExceptionsSummary(
+  teamCapSheet: CapSheet | null | undefined,
+  isLoading: boolean
+): ArchitectWorkspaceExceptionsSummary {
+  if (isLoading && !teamCapSheet) {
+    return { status: 'loading' };
+  }
+
+  if (!teamCapSheet) {
+    return {
+      status: 'unavailable',
+      deferralHint: 'see-cap-sheet',
+      reason: 'Team cap sheet is not available.',
+    };
+  }
+
+  const exc = teamCapSheet.exceptions;
+  if (!exc) {
+    return {
+      status: 'unavailable',
+      deferralHint: 'see-cap-sheet',
+      reason: 'No exception data on cap sheet. Full details in Cap Sheet.',
+    };
+  }
+
+  const tpeCount = Array.isArray(exc.tpe) ? exc.tpe.length : 0;
+  const hasAvailableMle = exc.mle?.available === true;
+  const hasAvailableBae = exc.bae?.available === true;
+  const hasAvailableRoom = exc.room?.available === true;
+
+  return {
+    status: 'available',
+    tpeCount,
+    hasAvailableMle,
+    hasAvailableBae,
+    hasAvailableRoom,
+    hasAnyActive: tpeCount > 0 || hasAvailableMle || hasAvailableBae || hasAvailableRoom,
+    worldSeasonBasis: true,
+  };
+}
+
 export function deriveArchitectWorkspaceContext({
   teamCapSheet = null,
   teamId = null,
@@ -428,15 +493,16 @@ export function deriveArchitectWorkspaceContext({
     },
     roster: deriveRosterSummary(teamCapSheet, isLoading),
     cap: deriveCapSummary({ teamCapSheet, currentYear, isLoading }),
-    exceptions: {
-      status: 'unavailable',
-      reason:
-        'Exception and TPE posture remains with the current cap-sheet authority until a reliable workspace summary seam is added.',
-    },
+    exceptions: deriveExceptionsSummary(teamCapSheet, isLoading),
     draftAssets: {
       status: 'unavailable',
+      deferralHint: 'see-trade-history',
       reason:
         'No canonical active-world draft asset summary is exposed to the workspace context yet.',
+    },
+    recentActivity: {
+      status: 'deferred',
+      entryPoint: 'history-tab',
     },
   };
 }

--- a/src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts
@@ -1,0 +1,464 @@
+/**
+ * FILE: src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts
+ * PURPOSE: Read-only Stage 1A workspace context view model for future Architect operating UI.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ */
+
+import { useMemo } from 'react';
+import type {
+  ArchitectWorldModeBoundary,
+  CapSheet,
+} from './useArchitectState';
+import {
+  computeTeamCapTotals,
+  type ComputedTeamCapTotals,
+} from '@/features/architect/utils/capTotals/computeTeamCapTotals';
+import { toSeasonKey } from '@/features/architect/utils/seasonFormat';
+import {
+  deriveArchitectModePresentation,
+  type ArchitectModePresentation,
+} from './useArchitectModePresentation';
+
+type AvailabilityStatus = 'available' | 'loading' | 'unavailable';
+
+type WorkspaceSummaryPlaceholder = {
+  status: 'unavailable';
+  reason: string;
+};
+
+export type ArchitectWorkspaceTeamContext =
+  | {
+      status: 'available';
+      id: string;
+      label: string;
+    }
+  | {
+      status: 'loading' | 'unavailable';
+      id: null;
+      label: string;
+    };
+
+export type ArchitectWorkspaceWorldContext =
+  | {
+      status: 'available' | 'loading';
+      id: string;
+      label: string;
+      labelSource: 'provided' | 'world-id-fallback';
+    }
+  | {
+      status: 'sandbox';
+      id: null;
+      label: 'Sandbox';
+      labelSource: 'sandbox';
+    };
+
+export interface ArchitectWorkspaceSeasonContext {
+  selectedViewingSeason: number | null;
+  selectedViewingSeasonLabel: string | null;
+  authoritativeWorldSeason: string | null;
+  authoritativeWorldSeasonLabel: string | null;
+  authoritativeWorldSeasonStatus: AvailabilityStatus;
+  viewingSeasonDiffersFromWorldSeason: boolean | null;
+}
+
+export interface ArchitectWorkspaceWorldDateContext {
+  status: AvailabilityStatus;
+  value: string | null;
+  label: string;
+}
+
+export type ArchitectWorkspaceRosterSummary =
+  | {
+      status: 'available';
+      count: number;
+      source: 'players' | 'roster';
+    }
+  | {
+      status: 'loading' | 'unavailable';
+      count: null;
+      source: null;
+    };
+
+export type ArchitectWorkspaceCapSummary =
+  | {
+      status: 'available';
+      season: number;
+      seasonLabel: string;
+      totalCapAllocations: number;
+      salaryCap: number;
+      capSpace: number;
+      luxuryTax: number;
+      taxSpace: number;
+      firstApron: number;
+      firstApronSpace: number;
+      secondApron: number;
+      secondApronSpace: number;
+      isOverCap: boolean;
+      isOverTax: boolean;
+      isAtOrAboveFirstApron: boolean;
+      isAboveSecondApron: boolean;
+      source: ComputedTeamCapTotals['_meta']['source'];
+    }
+  | {
+      status: 'loading' | 'unavailable';
+      reason: string;
+    };
+
+export interface ArchitectWorkspaceStatusContext {
+  isLoading: boolean;
+  isSaving: boolean;
+  worldMetadataLoading: boolean;
+  hasError: boolean;
+  errorMessage: string | null;
+}
+
+export interface ArchitectWorkspaceContext {
+  team: ArchitectWorkspaceTeamContext;
+  world: ArchitectWorkspaceWorldContext;
+  seasons: ArchitectWorkspaceSeasonContext;
+  worldDate: ArchitectWorkspaceWorldDateContext;
+  mode: ArchitectModePresentation;
+  status: ArchitectWorkspaceStatusContext;
+  roster: ArchitectWorkspaceRosterSummary;
+  cap: ArchitectWorkspaceCapSummary;
+  exceptions: WorkspaceSummaryPlaceholder;
+  draftAssets: WorkspaceSummaryPlaceholder;
+}
+
+export interface ArchitectWorkspaceContextInput {
+  teamCapSheet?: CapSheet | null;
+  teamId?: string | null;
+  currentYear?: number | null;
+  worldId?: string | null;
+  activeWorldLabel?: string | null;
+  worldAsOfDate?: string | null;
+  worldCurrentSeason?: string | null;
+  worldMetadataLoading?: boolean;
+  isLoading?: boolean;
+  isSaving?: boolean;
+  error?: string | null;
+  worldModeBoundary?: ArchitectWorldModeBoundary | null;
+}
+
+const firstUsableString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return String(value);
+    }
+  }
+
+  return null;
+};
+
+const abbreviateWorldId = (worldId: string): string => {
+  const clean = worldId.trim();
+  if (clean.length <= 12) return clean;
+  return `${clean.slice(0, 8)}...${clean.slice(-4)}`;
+};
+
+const toStableSeasonLabel = (season: string | number | null | undefined) => {
+  if (season === null || season === undefined || season === '') return null;
+  return toSeasonKey(season);
+};
+
+function deriveTeamContext({
+  teamCapSheet,
+  teamId,
+  isLoading,
+}: Pick<
+  ArchitectWorkspaceContextInput,
+  'teamCapSheet' | 'teamId' | 'isLoading'
+>): ArchitectWorkspaceTeamContext {
+  if (isLoading && !teamCapSheet) {
+    return { status: 'loading', id: null, label: 'Loading team' };
+  }
+
+  const id = firstUsableString(
+    teamCapSheet?.teamCode,
+    teamCapSheet?.abbreviation,
+    teamCapSheet?.id,
+    teamId
+  );
+  const label = firstUsableString(teamCapSheet?.teamName, id);
+
+  if (!id || !label) {
+    return { status: 'unavailable', id: null, label: 'Team unavailable' };
+  }
+
+  return { status: 'available', id, label };
+}
+
+function deriveWorldContext({
+  worldId,
+  activeWorldLabel,
+  worldMetadataLoading,
+}: Pick<
+  ArchitectWorkspaceContextInput,
+  'worldId' | 'activeWorldLabel' | 'worldMetadataLoading'
+>): ArchitectWorkspaceWorldContext {
+  if (!worldId) {
+    return {
+      status: 'sandbox',
+      id: null,
+      label: 'Sandbox',
+      labelSource: 'sandbox',
+    };
+  }
+
+  const providedLabel = firstUsableString(activeWorldLabel);
+  return {
+    status: worldMetadataLoading ? 'loading' : 'available',
+    id: worldId,
+    label: providedLabel || `World ${abbreviateWorldId(worldId)}`,
+    labelSource: providedLabel ? 'provided' : 'world-id-fallback',
+  };
+}
+
+function deriveSeasonContext({
+  currentYear,
+  worldId,
+  worldCurrentSeason,
+  worldMetadataLoading,
+}: Pick<
+  ArchitectWorkspaceContextInput,
+  'currentYear' | 'worldId' | 'worldCurrentSeason' | 'worldMetadataLoading'
+>): ArchitectWorkspaceSeasonContext {
+  const selectedViewingSeason =
+    typeof currentYear === 'number' && Number.isFinite(currentYear)
+      ? currentYear
+      : null;
+  const selectedViewingSeasonLabel = toStableSeasonLabel(selectedViewingSeason);
+  const authoritativeWorldSeasonLabel = toStableSeasonLabel(worldCurrentSeason);
+  const authoritativeWorldSeasonStatus: AvailabilityStatus = !worldId
+    ? 'unavailable'
+    : worldMetadataLoading
+    ? 'loading'
+    : authoritativeWorldSeasonLabel
+    ? 'available'
+    : 'unavailable';
+
+  return {
+    selectedViewingSeason,
+    selectedViewingSeasonLabel,
+    authoritativeWorldSeason: worldCurrentSeason || null,
+    authoritativeWorldSeasonLabel,
+    authoritativeWorldSeasonStatus,
+    viewingSeasonDiffersFromWorldSeason:
+      selectedViewingSeasonLabel && authoritativeWorldSeasonLabel
+        ? selectedViewingSeasonLabel !== authoritativeWorldSeasonLabel
+        : null,
+  };
+}
+
+function deriveWorldDateContext({
+  worldId,
+  worldAsOfDate,
+  worldMetadataLoading,
+}: Pick<
+  ArchitectWorkspaceContextInput,
+  'worldId' | 'worldAsOfDate' | 'worldMetadataLoading'
+>): ArchitectWorkspaceWorldDateContext {
+  if (!worldId) {
+    return {
+      status: 'unavailable',
+      value: null,
+      label: 'No active world date',
+    };
+  }
+
+  if (worldMetadataLoading) {
+    return {
+      status: 'loading',
+      value: worldAsOfDate || null,
+      label: 'Loading world date',
+    };
+  }
+
+  if (!worldAsOfDate) {
+    return {
+      status: 'unavailable',
+      value: null,
+      label: 'World date unavailable',
+    };
+  }
+
+  return {
+    status: 'available',
+    value: worldAsOfDate,
+    label: worldAsOfDate,
+  };
+}
+
+function deriveRosterSummary(
+  teamCapSheet: CapSheet | null | undefined,
+  isLoading: boolean
+): ArchitectWorkspaceRosterSummary {
+  if (isLoading && !teamCapSheet) {
+    return { status: 'loading', count: null, source: null };
+  }
+
+  if (Array.isArray(teamCapSheet?.players)) {
+    return {
+      status: 'available',
+      count: teamCapSheet.players.length,
+      source: 'players',
+    };
+  }
+
+  if (Array.isArray(teamCapSheet?.roster)) {
+    return {
+      status: 'available',
+      count: teamCapSheet.roster.length,
+      source: 'roster',
+    };
+  }
+
+  return { status: 'unavailable', count: null, source: null };
+}
+
+function deriveCapSummary({
+  teamCapSheet,
+  currentYear,
+  isLoading,
+}: Pick<
+  ArchitectWorkspaceContextInput,
+  'teamCapSheet' | 'currentYear' | 'isLoading'
+>): ArchitectWorkspaceCapSummary {
+  if (isLoading && !teamCapSheet) {
+    return { status: 'loading', reason: 'Team cap sheet is loading.' };
+  }
+
+  if (!teamCapSheet) {
+    return {
+      status: 'unavailable',
+      reason: 'Team cap sheet is not available.',
+    };
+  }
+
+  if (typeof currentYear !== 'number' || !Number.isFinite(currentYear)) {
+    return {
+      status: 'unavailable',
+      reason: 'Selected viewing season is not available.',
+    };
+  }
+
+  try {
+    const totals = computeTeamCapTotals(teamCapSheet, currentYear);
+    const capSpace = -totals.deltas.vsCap;
+    const taxSpace = -totals.deltas.vsLuxuryTax;
+    const firstApronSpace = -totals.deltas.vsFirstApron;
+    const secondApronSpace = -totals.deltas.vsSecondApron;
+
+    return {
+      status: 'available',
+      season: currentYear,
+      seasonLabel: toSeasonKey(currentYear),
+      totalCapAllocations: totals.totalCapAllocations,
+      salaryCap: totals.salaryCap,
+      capSpace,
+      luxuryTax: totals.luxuryTax,
+      taxSpace,
+      firstApron: totals.firstApron,
+      firstApronSpace,
+      secondApron: totals.secondApron,
+      secondApronSpace,
+      isOverCap: totals.deltas.vsCap > 0,
+      isOverTax: totals.deltas.vsLuxuryTax > 0,
+      isAtOrAboveFirstApron: totals.deltas.vsFirstApron >= 0,
+      isAboveSecondApron: totals.deltas.vsSecondApron > 0,
+      source: totals._meta.source,
+    };
+  } catch (error) {
+    return {
+      status: 'unavailable',
+      reason:
+        error instanceof Error
+          ? error.message
+          : 'Cap posture could not be derived.',
+    };
+  }
+}
+
+export function deriveArchitectWorkspaceContext({
+  teamCapSheet = null,
+  teamId = null,
+  currentYear = null,
+  worldId = null,
+  activeWorldLabel = null,
+  worldAsOfDate = null,
+  worldCurrentSeason = null,
+  worldMetadataLoading = false,
+  isLoading = false,
+  isSaving = false,
+  error = null,
+  worldModeBoundary = null,
+}: ArchitectWorkspaceContextInput): ArchitectWorkspaceContext {
+  const normalizedError = error?.trim() || null;
+
+  return {
+    team: deriveTeamContext({ teamCapSheet, teamId, isLoading }),
+    world: deriveWorldContext({ worldId, activeWorldLabel, worldMetadataLoading }),
+    seasons: deriveSeasonContext({
+      currentYear,
+      worldId,
+      worldCurrentSeason,
+      worldMetadataLoading,
+    }),
+    worldDate: deriveWorldDateContext({
+      worldId,
+      worldAsOfDate,
+      worldMetadataLoading,
+    }),
+    mode: deriveArchitectModePresentation({
+      worldId,
+      worldModeBoundary,
+      isLoading,
+      worldMetadataLoading,
+      error: normalizedError,
+    }),
+    status: {
+      isLoading,
+      isSaving,
+      worldMetadataLoading,
+      hasError: Boolean(normalizedError),
+      errorMessage: normalizedError,
+    },
+    roster: deriveRosterSummary(teamCapSheet, isLoading),
+    cap: deriveCapSummary({ teamCapSheet, currentYear, isLoading }),
+    exceptions: {
+      status: 'unavailable',
+      reason:
+        'Exception and TPE posture remains with the current cap-sheet authority until a reliable workspace summary seam is added.',
+    },
+    draftAssets: {
+      status: 'unavailable',
+      reason:
+        'No canonical active-world draft asset summary is exposed to the workspace context yet.',
+    },
+  };
+}
+
+export function useArchitectWorkspaceContext(
+  input: ArchitectWorkspaceContextInput
+): ArchitectWorkspaceContext {
+  return useMemo(
+    () => deriveArchitectWorkspaceContext(input),
+    [
+      input.activeWorldLabel,
+      input.currentYear,
+      input.error,
+      input.isLoading,
+      input.isSaving,
+      input.teamCapSheet,
+      input.teamId,
+      input.worldAsOfDate,
+      input.worldCurrentSeason,
+      input.worldId,
+      input.worldMetadataLoading,
+      input.worldModeBoundary,
+    ]
+  );
+}

--- a/src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts
@@ -107,7 +107,7 @@ export type ArchitectWorkspaceExceptionsSummary =
       hasAvailableBae: boolean;
       hasAvailableRoom: boolean;
       hasAnyActive: boolean;
-      worldSeasonBasis: true;
+      worldSeasonBasis: boolean;
     }
   | { status: 'loading' }
   | {
@@ -408,7 +408,8 @@ function deriveCapSummary({
 
 function deriveExceptionsSummary(
   teamCapSheet: CapSheet | null | undefined,
-  isLoading: boolean
+  isLoading: boolean,
+  worldId: string | null | undefined
 ): ArchitectWorkspaceExceptionsSummary {
   if (isLoading && !teamCapSheet) {
     return { status: 'loading' };
@@ -443,7 +444,7 @@ function deriveExceptionsSummary(
     hasAvailableBae,
     hasAvailableRoom,
     hasAnyActive: tpeCount > 0 || hasAvailableMle || hasAvailableBae || hasAvailableRoom,
-    worldSeasonBasis: true,
+    worldSeasonBasis: Boolean(worldId),
   };
 }
 
@@ -493,7 +494,7 @@ export function deriveArchitectWorkspaceContext({
     },
     roster: deriveRosterSummary(teamCapSheet, isLoading),
     cap: deriveCapSummary({ teamCapSheet, currentYear, isLoading }),
-    exceptions: deriveExceptionsSummary(teamCapSheet, isLoading),
+    exceptions: deriveExceptionsSummary(teamCapSheet, isLoading, worldId),
     draftAssets: {
       status: 'unavailable',
       deferralHint: 'see-trade-history',

--- a/src/features/architect/GMDashboard/hooks/useScenarioActivityRail.ts
+++ b/src/features/architect/GMDashboard/hooks/useScenarioActivityRail.ts
@@ -1,0 +1,135 @@
+/**
+ * FILE: src/features/architect/GMDashboard/hooks/useScenarioActivityRail.ts
+ * PURPOSE: Read-only Stage 1D activity rail derivation and hook for ScenarioMoveRail.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * deriveActivityRailState: pure, testable. Converts normalized world events and
+ * loading/error state into a discriminated rail state.
+ *
+ * useScenarioActivityRail: hook wrapping useWorldTeamEvents and normalization.
+ * Returns rail state ready for ScenarioMoveRail to render.
+ *
+ * Truth authority: committed world events from useWorldTeamEvents.
+ * Local/pending activity: explicitly deferred in Stage 1D (localPendingDeferred: true).
+ */
+
+import { useMemo } from 'react';
+import { useWorldTeamEvents } from '@/features/architect/history/hooks/useWorldTeamEvents';
+import {
+  normalizeWorldEventsForTeamHistory,
+  type TeamHistoryWorldEventRow,
+} from '@/features/architect/history/utils/normalizeWorldEventsForTeamHistory';
+
+const RAIL_EVENT_LIMIT = 5;
+
+export type ArchitectActivityRailEntry = {
+  id: string;
+  typeLabel: string;
+  summary: string;
+  occurredAt: string | null;
+  authority: 'committed-world';
+};
+
+export type ArchitectActivityRailState =
+  | { status: 'sandbox' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'empty' }
+  | {
+      status: 'available';
+      entries: ArchitectActivityRailEntry[];
+      hasMore: boolean;
+    };
+
+export interface DeriveActivityRailStateInput {
+  worldId: string | null | undefined;
+  normalizedEvents: TeamHistoryWorldEventRow[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+}
+
+export function deriveActivityRailState({
+  worldId,
+  normalizedEvents,
+  loading,
+  error,
+  hasMore,
+}: DeriveActivityRailStateInput): ArchitectActivityRailState {
+  if (!worldId) {
+    return { status: 'sandbox' };
+  }
+
+  if (loading && normalizedEvents.length === 0) {
+    return { status: 'loading' };
+  }
+
+  if (error && normalizedEvents.length === 0) {
+    return { status: 'error', message: error };
+  }
+
+  if (normalizedEvents.length === 0) {
+    return { status: 'empty' };
+  }
+
+  return {
+    status: 'available',
+    entries: normalizedEvents.slice(0, RAIL_EVENT_LIMIT).map((row) => ({
+      id: row.id,
+      typeLabel: row.category || row.type || 'World Event',
+      summary: row.summary || '—',
+      occurredAt: row.occurredAt || row.timestamp || null,
+      authority: 'committed-world',
+    })),
+    hasMore,
+  };
+}
+
+export interface UseScenarioActivityRailArgs {
+  worldId: string | null | undefined;
+  teamCode: string | null | undefined;
+}
+
+export interface UseScenarioActivityRailResult {
+  railState: ArchitectActivityRailState;
+  localPendingDeferred: true;
+}
+
+export function useScenarioActivityRail({
+  worldId,
+  teamCode,
+}: UseScenarioActivityRailArgs): UseScenarioActivityRailResult {
+  const enabled = Boolean(worldId && teamCode);
+
+  const { events: rawEvents, loading, error, hasMore } = useWorldTeamEvents({
+    worldId: worldId ?? null,
+    teamCode: teamCode ?? null,
+    limit: RAIL_EVENT_LIMIT,
+    enabled,
+  });
+
+  const normalizedEvents = useMemo(
+    () =>
+      enabled
+        ? normalizeWorldEventsForTeamHistory(rawEvents, teamCode ?? null)
+        : [],
+    [enabled, rawEvents, teamCode]
+  );
+
+  const railState = useMemo(
+    () =>
+      deriveActivityRailState({
+        worldId,
+        normalizedEvents,
+        loading,
+        error,
+        hasMore,
+      }),
+    [worldId, normalizedEvents, loading, error, hasMore]
+  );
+
+  return {
+    railState,
+    localPendingDeferred: true,
+  };
+}

--- a/src/tests/architect/architectActivityRail.stage1d.test.ts
+++ b/src/tests/architect/architectActivityRail.stage1d.test.ts
@@ -1,0 +1,281 @@
+/**
+ * FILE: src/tests/architect/architectActivityRail.stage1d.test.ts
+ * PURPOSE: Unit tests for Stage 1D ScenarioMoveRail derivation logic.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Tests cover deriveActivityRailState directly (pure function, no Firestore).
+ * Component-level rendering is not tested here — useWorldTeamEvents requires
+ * Firestore and the repo does not have a stable component test pattern for that.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  deriveActivityRailState,
+} from '@/features/architect/GMDashboard/hooks/useScenarioActivityRail';
+import type { TeamHistoryWorldEventRow } from '@/features/architect/history/utils/normalizeWorldEventsForTeamHistory';
+import type { DisplaySection } from '@/features/architect/history/utils/normalizeWorldEventsForTeamHistory.utils';
+
+const makeEvent = (
+  overrides: Partial<TeamHistoryWorldEventRow> = {}
+): TeamHistoryWorldEventRow => ({
+  id: 'evt_1',
+  category: 'Contract',
+  type: 'Sign',
+  timestamp: '2026-01-15T00:00:00.000Z',
+  occurredAt: '2026-01-15T00:00:00.000Z',
+  teamCodes: ['LAL'],
+  teamsInvolved: ['LAL'],
+  playerIds: ['player_1'],
+  primaryDeltas: 'Sign: Player One',
+  capDelta: null,
+  summary: 'Signed Player One to a standard contract',
+  detailSections: [] as DisplaySection[],
+  eventId: 'evt_1',
+  operationId: null,
+  mutationType: 'signFreeAgent',
+  beforeTotalsByTeam: {},
+  afterTotalsByTeam: {},
+  raw: {},
+  ...overrides,
+});
+
+describe('Stage 1D activity rail state derivation', () => {
+  describe('sandbox / no-world mode', () => {
+    it('returns sandbox status when worldId is null', () => {
+      const state = deriveActivityRailState({
+        worldId: null,
+        normalizedEvents: [],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('sandbox');
+    });
+
+    it('returns sandbox status when worldId is undefined', () => {
+      const state = deriveActivityRailState({
+        worldId: undefined,
+        normalizedEvents: [],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('sandbox');
+    });
+
+    it('sandbox status overrides events if somehow events are passed without a world', () => {
+      const state = deriveActivityRailState({
+        worldId: null,
+        normalizedEvents: [makeEvent()],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('sandbox');
+    });
+  });
+
+  describe('world active — loading and error states', () => {
+    it('returns loading when world is active and no events have loaded yet', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [],
+        loading: true,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('loading');
+    });
+
+    it('returns error when world is active, fetch failed, and no stale events', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [],
+        loading: false,
+        error: 'Permission denied',
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('error');
+      if (state.status === 'error') {
+        expect(state.message).toBe('Permission denied');
+      }
+    });
+
+    it('falls through to available when error occurs alongside stale events', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [makeEvent()],
+        loading: false,
+        error: 'Reload failed but stale events remain',
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+    });
+  });
+
+  describe('world active — empty events', () => {
+    it('returns empty when world is active but no committed events found', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('empty');
+    });
+  });
+
+  describe('world active — committed events available', () => {
+    it('returns available state with entries when committed events exist', () => {
+      const events = [
+        makeEvent({ id: 'evt_1', summary: 'Signed Player One' }),
+        makeEvent({ id: 'evt_2', summary: 'Traded Player Two', category: 'Trade' }),
+      ];
+
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: events,
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries).toHaveLength(2);
+        expect(state.entries[0].id).toBe('evt_1');
+        expect(state.entries[0].summary).toBe('Signed Player One');
+        expect(state.entries[1].id).toBe('evt_2');
+        expect(state.entries[1].typeLabel).toBe('Trade');
+      }
+    });
+
+    it('all entries carry committed-world authority label', () => {
+      const events = [makeEvent(), makeEvent({ id: 'evt_2' })];
+
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: events,
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        for (const entry of state.entries) {
+          expect(entry.authority).toBe('committed-world');
+        }
+      }
+    });
+
+    it('caps entries at 5 regardless of events array length', () => {
+      const events = Array.from({ length: 10 }, (_, i) =>
+        makeEvent({ id: `evt_${i}`, summary: `Event ${i}` })
+      );
+
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: events,
+        loading: false,
+        error: null,
+        hasMore: true,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries).toHaveLength(5);
+        expect(state.hasMore).toBe(true);
+      }
+    });
+
+    it('preserves hasMore:false when no further events', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [makeEvent()],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.hasMore).toBe(false);
+      }
+    });
+
+    it('uses category as typeLabel when available', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [makeEvent({ id: 'evt_1', category: 'Trade' })],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries[0].typeLabel).toBe('Trade');
+      }
+    });
+
+    it('falls back to type when category is empty', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [makeEvent({ id: 'evt_1', category: '', type: 'Waive' })],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries[0].typeLabel).toBe('Waive');
+      }
+    });
+
+    it('preserves occurredAt on entries for date display', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [
+          makeEvent({ id: 'evt_1', occurredAt: '2026-02-15T00:00:00.000Z' }),
+        ],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries[0].occurredAt).toBe('2026-02-15T00:00:00.000Z');
+      }
+    });
+  });
+
+  describe('local / pending activity deferral', () => {
+    it('does not include local or pending entries — no such entries in the derivation input', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [makeEvent()],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        for (const entry of state.entries) {
+          expect(entry.authority).toBe('committed-world');
+        }
+      }
+    });
+  });
+});

--- a/src/tests/architect/architectActivityRail.stage1d.test.ts
+++ b/src/tests/architect/architectActivityRail.stage1d.test.ts
@@ -116,6 +116,10 @@ describe('Stage 1D activity rail state derivation', () => {
       });
 
       expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries).toHaveLength(1);
+        expect(state.entries[0].authority).toBe('committed-world');
+      }
     });
   });
 
@@ -239,6 +243,42 @@ describe('Stage 1D activity rail state derivation', () => {
       expect(state.status).toBe('available');
       if (state.status === 'available') {
         expect(state.entries[0].typeLabel).toBe('Waive');
+      }
+    });
+
+    it('uses timestamp as fallback when occurredAt is null', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [
+          makeEvent({
+            id: 'evt_1',
+            occurredAt: null,
+            timestamp: '2026-01-20T00:00:00.000Z',
+          }),
+        ],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries[0].occurredAt).toBe('2026-01-20T00:00:00.000Z');
+      }
+    });
+
+    it('falls back to World Event label when both category and type are empty', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [makeEvent({ id: 'evt_1', category: '', type: '' })],
+        loading: false,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries[0].typeLabel).toBe('World Event');
       }
     });
 

--- a/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
+++ b/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
@@ -99,6 +99,24 @@ describe('Stage 1A Architect mode presentation', () => {
     expect(unavailable.isCommittedWorldTruth).toBe(false);
   });
 
+  it('reports error state with higher priority than loading state', () => {
+    const errorOnly = deriveArchitectModePresentation({
+      worldId: 'world_deadline',
+      error: 'Connection failed',
+    });
+    const errorDuringLoad = deriveArchitectModePresentation({
+      worldId: 'world_deadline',
+      worldMetadataLoading: true,
+      error: 'Connection failed',
+    });
+
+    expect(errorOnly.kind).toBe('error');
+    expect(errorOnly.tone).toBe('danger');
+    expect(errorOnly.isCommittedWorldTruth).toBe(false);
+    expect(errorDuringLoad.kind).toBe('error');
+    expect(errorDuringLoad.kind).not.toBe('loading');
+  });
+
   it('keeps local, pending, failed, and DEV preview labels non-committed', () => {
     expect(
       deriveArchitectEntryAuthorityPresentation('local-only-preview')
@@ -213,6 +231,23 @@ describe('Stage 1A Architect workspace context derivation', () => {
     expect(context.mode.kind).toBe('loading');
     expect(context.roster.status).toBe('loading');
     expect(context.cap.status).toBe('loading');
+  });
+
+  it('uses world id as conservative fallback label when no world name is available', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamFixture,
+      currentYear: 2026,
+      worldId: 'world_12345678abcd',
+      activeWorldLabel: null,
+      worldModeBoundary: worldBoundary('world_12345678abcd'),
+    });
+
+    expect(context.world.status).toBe('available');
+    if (context.world.status === 'available') {
+      expect(context.world.labelSource).toBe('world-id-fallback');
+      expect(context.world.label).toMatch(/^World /);
+      expect(context.world.id).toBe('world_12345678abcd');
+    }
   });
 
   it('represents no-world operation without world season authority', () => {

--- a/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
+++ b/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
@@ -14,6 +14,7 @@ import type {
   ArchitectWorldModeBoundary,
   CapSheet,
 } from '@/features/architect/GMDashboard/hooks/useArchitectState';
+import type { ArchitectExceptionsLike } from '@/features/architect/GMDashboard/hooks/useArchitectState';
 
 const sandboxBoundary: ArchitectWorldModeBoundary = {
   kind: 'sandbox',
@@ -196,8 +197,15 @@ describe('Stage 1A Architect workspace context derivation', () => {
       expect(context.cap.source).toBe('computeTeamCapTotals');
       expect(Number.isFinite(context.cap.totalCapAllocations)).toBe(true);
     }
+    // teamFixture has no exceptions field → unavailable with see-cap-sheet hint
     expect(context.exceptions.status).toBe('unavailable');
+    if (context.exceptions.status === 'unavailable') {
+      expect(context.exceptions.deferralHint).toBe('see-cap-sheet');
+    }
     expect(context.draftAssets.status).toBe('unavailable');
+    expect(context.draftAssets.deferralHint).toBe('see-trade-history');
+    expect(context.recentActivity.status).toBe('deferred');
+    expect(context.recentActivity.entryPoint).toBe('history-tab');
   });
 
   it('does not assume selected viewing season matches authoritative world season', () => {
@@ -267,5 +275,115 @@ describe('Stage 1A Architect workspace context derivation', () => {
     expect(context.seasons.authoritativeWorldSeasonStatus).toBe('unavailable');
     expect(context.seasons.viewingSeasonDiffersFromWorldSeason).toBeNull();
     expect(context.worldDate.status).toBe('unavailable');
+  });
+});
+
+describe('Stage 1C exception summary derivation', () => {
+  const teamWithExceptions = {
+    ...teamFixture,
+    exceptions: {
+      mle: { available: true, totalAmount: 12_400_000 },
+      bae: null,
+      room: null,
+      tpe: [
+        { id: 'tpe_1', remainingAmount: 8_000_000 },
+        { id: 'tpe_2', remainingAmount: 3_500_000 },
+      ],
+    } satisfies ArchitectExceptionsLike,
+  } as CapSheet;
+
+  it('derives available exception summary from cap sheet exceptions data', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamWithExceptions,
+      currentYear: 2026,
+      worldId: 'world_deadline',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.exceptions.status).toBe('available');
+    if (context.exceptions.status === 'available') {
+      expect(context.exceptions.hasAvailableMle).toBe(true);
+      expect(context.exceptions.hasAvailableBae).toBe(false);
+      expect(context.exceptions.hasAvailableRoom).toBe(false);
+      expect(context.exceptions.tpeCount).toBe(2);
+      expect(context.exceptions.hasAnyActive).toBe(true);
+      expect(context.exceptions.worldSeasonBasis).toBe(true);
+    }
+  });
+
+  it('returns unavailable with see-cap-sheet hint when cap sheet has no exceptions field', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamFixture,
+      currentYear: 2026,
+      worldId: 'world_deadline',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.exceptions.status).toBe('unavailable');
+    if (context.exceptions.status === 'unavailable') {
+      expect(context.exceptions.deferralHint).toBe('see-cap-sheet');
+    }
+  });
+
+  it('returns loading when cap sheet is loading', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: null,
+      currentYear: 2026,
+      worldId: 'world_deadline',
+      isLoading: true,
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.exceptions.status).toBe('loading');
+  });
+
+  it('draft assets always carries see-trade-history deferral hint', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamFixture,
+      currentYear: 2026,
+      worldId: 'world_deadline',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.draftAssets.status).toBe('unavailable');
+    expect(context.draftAssets.deferralHint).toBe('see-trade-history');
+  });
+
+  it('recent activity always points to history tab', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamFixture,
+      currentYear: 2026,
+      worldId: 'world_deadline',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.recentActivity.status).toBe('deferred');
+    expect(context.recentActivity.entryPoint).toBe('history-tab');
+  });
+
+  it('hasAnyActive is false when exceptions exist but none are available', () => {
+    const teamWithEmptyExceptions = {
+      ...teamFixture,
+      exceptions: {
+        mle: null,
+        bae: null,
+        room: null,
+        tpe: [],
+      } satisfies ArchitectExceptionsLike,
+    } as CapSheet;
+
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamWithEmptyExceptions,
+      currentYear: 2026,
+      worldId: 'world_deadline',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.exceptions.status).toBe('available');
+    if (context.exceptions.status === 'available') {
+      expect(context.exceptions.hasAnyActive).toBe(false);
+      expect(context.exceptions.tpeCount).toBe(0);
+      expect(context.exceptions.hasAvailableMle).toBe(false);
+    }
   });
 });

--- a/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
+++ b/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
@@ -361,6 +361,29 @@ describe('Stage 1C exception summary derivation', () => {
     expect(context.recentActivity.entryPoint).toBe('history-tab');
   });
 
+  it('worldSeasonBasis is false in sandbox mode because no active world provides season authority', () => {
+    const teamWithExceptions = {
+      ...teamFixture,
+      exceptions: {
+        mle: { available: true, totalAmount: 12_400_000 },
+        tpe: [],
+      } satisfies ArchitectExceptionsLike,
+    } as CapSheet;
+
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamWithExceptions,
+      currentYear: 2026,
+      worldId: null,
+      worldModeBoundary: sandboxBoundary,
+    });
+
+    expect(context.exceptions.status).toBe('available');
+    if (context.exceptions.status === 'available') {
+      expect(context.exceptions.worldSeasonBasis).toBe(false);
+      expect(context.exceptions.hasAvailableMle).toBe(true);
+    }
+  });
+
   it('hasAnyActive is false when exceptions exist but none are available', () => {
     const teamWithEmptyExceptions = {
       ...teamFixture,

--- a/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
+++ b/src/tests/architect/architectWorkspaceContext.stage1a.test.ts
@@ -1,0 +1,236 @@
+/**
+ * FILE: src/tests/architect/architectWorkspaceContext.stage1a.test.ts
+ * PURPOSE: Unit coverage for Stage 1A read-only Architect workspace presentation seams.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  deriveArchitectEntryAuthorityPresentation,
+  deriveArchitectModePresentation,
+} from '@/features/architect/GMDashboard/hooks/useArchitectModePresentation';
+import { deriveArchitectWorkspaceContext } from '@/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext';
+import type {
+  ArchitectWorldModeBoundary,
+  CapSheet,
+} from '@/features/architect/GMDashboard/hooks/useArchitectState';
+
+const sandboxBoundary: ArchitectWorldModeBoundary = {
+  kind: 'sandbox',
+  worldId: null,
+  onReloadWorldData: null,
+};
+
+const worldBoundary = (worldId: string): ArchitectWorldModeBoundary => ({
+  kind: 'world',
+  worldId,
+  onReloadWorldData: vi.fn(async () => null),
+});
+
+const teamFixture = {
+  teamCode: 'LAL',
+  teamName: 'Los Angeles Lakers',
+  players: [
+    {
+      id: 'player_1',
+      name: 'Player One',
+      contract: {
+        contractType: 'Standard',
+        salariesByYear: [{ season: '2025-26', salary: 10_000_000 }],
+      },
+    },
+    {
+      id: 'player_2',
+      name: 'Player Two',
+      contract: {
+        contractType: 'Standard',
+        salariesByYear: [{ season: '2025-26', salary: 12_000_000 }],
+      },
+    },
+  ],
+  capHolds: [],
+  deadCap: [],
+} as CapSheet;
+
+describe('Stage 1A Architect mode presentation', () => {
+  it('labels active world state as committed world truth', () => {
+    const presentation = deriveArchitectModePresentation({
+      worldId: 'world_deadline',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(presentation).toMatchObject({
+      kind: 'committed-world',
+      label: 'Committed World',
+      shortLabel: 'World',
+      worldId: 'world_deadline',
+      isCommittedWorldTruth: true,
+    });
+  });
+
+  it('labels no-world state as sandbox without committed-world authority', () => {
+    const presentation = deriveArchitectModePresentation({
+      worldId: null,
+      worldModeBoundary: sandboxBoundary,
+    });
+
+    expect(presentation).toMatchObject({
+      kind: 'sandbox',
+      label: 'Sandbox',
+      worldId: null,
+      isCommittedWorldTruth: false,
+    });
+  });
+
+  it('reports loading and unavailable context states conservatively', () => {
+    const loading = deriveArchitectModePresentation({
+      worldId: 'world_deadline',
+      worldModeBoundary: worldBoundary('world_deadline'),
+      worldMetadataLoading: true,
+    });
+    const unavailable = deriveArchitectModePresentation({
+      worldId: 'world_deadline',
+      worldModeBoundary: sandboxBoundary,
+    });
+
+    expect(loading.kind).toBe('loading');
+    expect(loading.isCommittedWorldTruth).toBe(false);
+    expect(unavailable.kind).toBe('unavailable');
+    expect(unavailable.isCommittedWorldTruth).toBe(false);
+  });
+
+  it('keeps local, pending, failed, and DEV preview labels non-committed', () => {
+    expect(
+      deriveArchitectEntryAuthorityPresentation('local-only-preview')
+    ).toMatchObject({
+      kind: 'local-only-preview',
+      label: 'Local Preview',
+      isCommittedWorldTruth: false,
+    });
+    expect(
+      deriveArchitectEntryAuthorityPresentation('pending-world-preview')
+    ).toMatchObject({
+      kind: 'pending-world-preview',
+      label: 'Pending World Save',
+      isCommittedWorldTruth: false,
+    });
+    expect(
+      deriveArchitectEntryAuthorityPresentation('failed-world-preview')
+    ).toMatchObject({
+      kind: 'failed-world-preview',
+      label: 'Failed Preview',
+      isCommittedWorldTruth: false,
+    });
+    expect(
+      deriveArchitectEntryAuthorityPresentation('dev-only-preview')
+    ).toMatchObject({
+      kind: 'dev-only-preview',
+      label: 'Developer Preview',
+      isCommittedWorldTruth: false,
+    });
+  });
+});
+
+describe('Stage 1A Architect workspace context derivation', () => {
+  it('derives reliable active team, world, season, roster, and cap posture fields', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamFixture,
+      teamId: 'LAL',
+      currentYear: 2026,
+      worldId: 'world_deadline',
+      activeWorldLabel: 'Deadline World',
+      worldAsOfDate: '2026-02-01',
+      worldCurrentSeason: '2025-26',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.team).toMatchObject({
+      status: 'available',
+      id: 'LAL',
+      label: 'Los Angeles Lakers',
+    });
+    expect(context.world).toMatchObject({
+      status: 'available',
+      id: 'world_deadline',
+      label: 'Deadline World',
+      labelSource: 'provided',
+    });
+    expect(context.seasons).toMatchObject({
+      selectedViewingSeason: 2026,
+      selectedViewingSeasonLabel: '2025-26',
+      authoritativeWorldSeason: '2025-26',
+      authoritativeWorldSeasonLabel: '2025-26',
+      viewingSeasonDiffersFromWorldSeason: false,
+    });
+    expect(context.worldDate).toMatchObject({
+      status: 'available',
+      value: '2026-02-01',
+    });
+    expect(context.mode.kind).toBe('committed-world');
+    expect(context.roster).toMatchObject({
+      status: 'available',
+      count: 2,
+      source: 'players',
+    });
+    expect(context.cap.status).toBe('available');
+    if (context.cap.status === 'available') {
+      expect(context.cap.seasonLabel).toBe('2025-26');
+      expect(context.cap.source).toBe('computeTeamCapTotals');
+      expect(Number.isFinite(context.cap.totalCapAllocations)).toBe(true);
+    }
+    expect(context.exceptions.status).toBe('unavailable');
+    expect(context.draftAssets.status).toBe('unavailable');
+  });
+
+  it('does not assume selected viewing season matches authoritative world season', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamFixture,
+      currentYear: 2027,
+      worldId: 'world_deadline',
+      worldCurrentSeason: '2025-26',
+      worldModeBoundary: worldBoundary('world_deadline'),
+    });
+
+    expect(context.seasons.selectedViewingSeasonLabel).toBe('2026-27');
+    expect(context.seasons.authoritativeWorldSeasonLabel).toBe('2025-26');
+    expect(context.seasons.viewingSeasonDiffersFromWorldSeason).toBe(true);
+  });
+
+  it('keeps loading state visible without inventing unavailable summaries', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: null,
+      currentYear: 2026,
+      worldId: 'world_loading',
+      worldMetadataLoading: true,
+      isLoading: true,
+      worldModeBoundary: worldBoundary('world_loading'),
+    });
+
+    expect(context.team.status).toBe('loading');
+    expect(context.world.status).toBe('loading');
+    expect(context.seasons.authoritativeWorldSeasonStatus).toBe('loading');
+    expect(context.worldDate.status).toBe('loading');
+    expect(context.mode.kind).toBe('loading');
+    expect(context.roster.status).toBe('loading');
+    expect(context.cap.status).toBe('loading');
+  });
+
+  it('represents no-world operation without world season authority', () => {
+    const context = deriveArchitectWorkspaceContext({
+      teamCapSheet: teamFixture,
+      currentYear: 2026,
+      worldId: null,
+      worldModeBoundary: sandboxBoundary,
+    });
+
+    expect(context.world).toMatchObject({
+      status: 'sandbox',
+      id: null,
+      label: 'Sandbox',
+    });
+    expect(context.mode.kind).toBe('sandbox');
+    expect(context.seasons.authoritativeWorldSeasonStatus).toBe('unavailable');
+    expect(context.seasons.viewingSeasonDiffersFromWorldSeason).toBeNull();
+    expect(context.worldDate.status).toBe('unavailable');
+  });
+});


### PR DESCRIPTION
## Summary

Stage 1 PR for the Architect World Operating Experience.

Core principle: worlds provide persistence; the World Operating Experience provides continuity.

This PR adds the read-only operating layer that makes active world context and franchise state visible while users move between roster, cap sheet, cap table, trade, free agency, offseason, and history.

## Included

- Stage 1A: read-only workspace/mode presentation foundation via `useArchitectModePresentation` and `useArchitectWorkspaceContext`.
- Stage 1B: persistent `ArchitectWorkspaceHeader` rendered from `GMDashboard`.
- Stage 1C: conservative cockpit summary indicators for cap/roster/exceptions, with draft assets and activity initially deferred.
- Stage 1D: read-only `ScenarioMoveRail` / activity rail using History/world-event sources and committed-world authority labels.
- Correction passes for Stage 1B, 1C, and 1D to tighten truth labels, wrapping behavior, visibility, and tests.

## Latest Validation Reported

- `architectActivityRail.stage1d.test.ts`: 17/17 passed
- `architectWorkspaceContext.stage1a.test.ts`: 17/17 passed
- `tsc --noEmit`: 0 errors
- `npm run build`: succeeded

Earlier validation also reported `npm run validate:project` and `npm run test:diff -- --reporter=dot`. `GMDashboard.smoke.test.tsx` has a pre-existing unrelated mock/export failure.

## Guardrails Preserved

No mutation authority, Firestore writes, schema changes, action shortcuts, draft ledger, baseline delta engine, scenario comparison, or local/pending committed-history blending were added.

`mutationPipeline`, `seasonManager`, and `worldManager` remain untouched.

## Deferred

- canonical draft asset summary
- world name/description beyond conservative world-id fallback
- local/pending activity entries
- full baseline deltas
- cross-surface action continuity
- scenario comparison

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Architect workspace header displaying team identity, world/season context, roster count, and cap posture summary
  * Added recent activity rail showing recent scenario moves with timestamp and status indicators
  * Enhanced dashboard with loading, error, and unavailable state indicators for workspace context

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bet-Zero/scoutzero/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->