### PR TITLE
Add Architect navigation continuity

### DIFF
--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -327,6 +327,7 @@ export const GMDashboard = () => {
     currentYear,
     playersMap,
     onApplyTrade: actions.applyTradeToCapSheet as TradeSectionProps['onApplyTrade'],
+    onAfterTradeApplied: () => setActiveTab('cap'),
     primaryTeamData: teamCapSheet,
     onEditContract: (player) =>
       actions.handleEditContract(
@@ -343,6 +344,7 @@ export const GMDashboard = () => {
     playersMap,
     outgoingOfferSheets: teamCapSheet?.offerSheets || [],
     incomingOfferSheets: teamCapSheet?.incomingOfferSheets || [],
+    onAfterSigningComplete: () => setActiveTab('cap'),
   };
   const offseasonSectionSurface: OffseasonSectionProps = {
     teamCapSheet,
@@ -419,7 +421,11 @@ export const GMDashboard = () => {
         </div>
       </div>
 
-      <ArchitectWorkspaceHeader context={workspaceContext} />
+      <ArchitectWorkspaceHeader
+        context={workspaceContext}
+        onNavigateToCapSheet={() => setActiveTab('cap')}
+        onNavigateToOffseason={() => setActiveTab('offseason')}
+      />
 
       <ScenarioMoveRail
         worldId={worldId}
@@ -630,7 +636,13 @@ export const GMDashboard = () => {
                 <strong>MLE reset for new season.</strong>
               </p>
             )}
-            <button type="button" onClick={closeOffseasonModal}>
+            <button
+              type="button"
+              onClick={() => {
+                closeOffseasonModal();
+                setActiveTab('cap');
+              }}
+            >
               Close
             </button>
           </div>

--- a/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
@@ -14,6 +14,8 @@ import type { ArchitectModePresentationTone } from '../hooks/useArchitectModePre
 
 interface Props {
   context: ArchitectWorkspaceContext;
+  onNavigateToCapSheet?: (() => void) | null;
+  onNavigateToOffseason?: (() => void) | null;
 }
 
 const TONE_CLASS: Record<ArchitectModePresentationTone, string> = {
@@ -94,7 +96,7 @@ const ExceptionLine = ({
   );
 };
 
-export const ArchitectWorkspaceHeader = ({ context }: Props) => {
+export const ArchitectWorkspaceHeader = ({ context, onNavigateToCapSheet, onNavigateToOffseason }: Props) => {
   const { team, world, seasons, worldDate, mode, status, roster, cap, exceptions, draftAssets, recentActivity } = context;
 
   return (
@@ -147,10 +149,22 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
         )}
 
         {seasons.viewingSeasonDiffersFromWorldSeason === true && (
-          <span className="rounded border border-amber-300/30 bg-amber-400/10 px-1.5 py-0.5 text-amber-200">
-            ⚠ Viewing {seasons.selectedViewingSeasonLabel ?? '?'} ≠ World{' '}
-            {seasons.authoritativeWorldSeasonLabel ?? '?'}
-          </span>
+          onNavigateToOffseason ? (
+            <button
+              type="button"
+              onClick={onNavigateToOffseason}
+              className="rounded border border-amber-300/30 bg-amber-400/10 px-1.5 py-0.5 text-amber-200 hover:bg-amber-400/20 cursor-pointer"
+              data-testid="season-mismatch-nav-offseason"
+            >
+              ⚠ Viewing {seasons.selectedViewingSeasonLabel ?? '?'} ≠ World{' '}
+              {seasons.authoritativeWorldSeasonLabel ?? '?'}
+            </button>
+          ) : (
+            <span className="rounded border border-amber-300/30 bg-amber-400/10 px-1.5 py-0.5 text-amber-200">
+              ⚠ Viewing {seasons.selectedViewingSeasonLabel ?? '?'} ≠ World{' '}
+              {seasons.authoritativeWorldSeasonLabel ?? '?'}
+            </span>
+          )
         )}
 
         <span className="min-w-0 flex-1" />
@@ -178,7 +192,7 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
         </span>
       </div>
 
-      {/* Row 2: Compact roster count · cap posture */}
+      {/* Row 2: Compact roster count · cap posture (cap posture navigates to Cap Sheet) */}
       <div className="mt-1.5 flex flex-wrap items-center gap-2 text-white/40">
         {roster.status === 'available' && (
           <span>Roster: {roster.count}</span>
@@ -189,7 +203,18 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
         {cap.status === 'available' && (
           <>
             {(roster.status === 'available' || roster.status === 'loading') && <Sep />}
-            <CapSummary cap={cap} />
+            {onNavigateToCapSheet ? (
+              <button
+                type="button"
+                onClick={onNavigateToCapSheet}
+                className="flex items-center gap-2 hover:text-white/70 cursor-pointer"
+                data-testid="cap-posture-nav-cap-sheet"
+              >
+                <CapSummary cap={cap} />
+              </button>
+            ) : (
+              <CapSummary cap={cap} />
+            )}
           </>
         )}
         {cap.status === 'loading' && (
@@ -203,10 +228,24 @@ export const ArchitectWorkspaceHeader = ({ context }: Props) => {
       {/* Row 3: Franchise summary indicators — exceptions, draft assets, activity */}
       <div className="mt-1 flex flex-wrap items-center gap-3 border-t border-white/5 pt-1.5 text-white/30">
         {exceptions.status === 'available' && exceptions.hasAnyActive ? (
-          <ExceptionLine
-            exc={exceptions}
-            seasonMismatch={seasons.viewingSeasonDiffersFromWorldSeason === true}
-          />
+          onNavigateToCapSheet ? (
+            <button
+              type="button"
+              onClick={onNavigateToCapSheet}
+              className="hover:text-white/60 cursor-pointer"
+              data-testid="exceptions-nav-cap-sheet"
+            >
+              <ExceptionLine
+                exc={exceptions}
+                seasonMismatch={seasons.viewingSeasonDiffersFromWorldSeason === true}
+              />
+            </button>
+          ) : (
+            <ExceptionLine
+              exc={exceptions}
+              seasonMismatch={seasons.viewingSeasonDiffersFromWorldSeason === true}
+            />
+          )
         ) : exceptions.status === 'loading' ? (
           <span className="italic">Exceptions loading…</span>
         ) : (

--- a/src/features/architect/GMDashboard/offerSheetTypes.ts
+++ b/src/features/architect/GMDashboard/offerSheetTypes.ts
@@ -58,4 +58,5 @@ export interface FreeAgencySectionProps {
   playersMap?: Record<string, unknown>;
   outgoingOfferSheets?: OfferSheetLike[] | null;
   incomingOfferSheets?: OfferSheetLike[] | null;
+  onAfterSigningComplete?: (() => void) | null;
 }

--- a/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
+++ b/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
@@ -45,14 +45,25 @@ const FreeAgencySection = ({
   playersMap,
   outgoingOfferSheets,
   incomingOfferSheets,
+  onAfterSigningComplete,
 }: FreeAgencySectionProps) => {
   const offerSheetSectionAvailability = actionOwner.offerSheetSectionAvailability;
   const offerSheetLifecycleActionOwner =
     offerSheetSectionAvailability.lifecycleActionOwner;
   const offerSheetLifecycleDisabledReason =
     offerSheetSectionAvailability.actionsDisabledReason || undefined;
+
+  const wrappedSignFreeAgent: typeof actionOwner.dualPathSigning.signFreeAgent =
+    async (playerObj, contract) => {
+      const result = await actionOwner.dualPathSigning.signFreeAgent(playerObj, contract);
+      if (result?.success) {
+        onAfterSigningComplete?.();
+      }
+      return result;
+    };
+
   const freeAgentPoolActionOwner = {
-    dualPathSigning: actionOwner.dualPathSigning,
+    dualPathSigning: { signFreeAgent: wrappedSignFreeAgent },
     freeAgentModalAvailability: actionOwner.freeAgentModalAvailability,
   } satisfies FreeAgentPoolActionOwner;
   const incomingOfferSheetSurface = {

--- a/src/features/architect/GMDashboard/sections/TradeSection.tsx
+++ b/src/features/architect/GMDashboard/sections/TradeSection.tsx
@@ -19,6 +19,7 @@ type ForwardedTradeEditorProps = Pick<
   | 'currentYear'
   | 'playersMap'
   | 'onApplyTrade'
+  | 'onAfterTradeApplied'
   | 'primaryTeamData'
   | 'onEditContract'
   | 'worldId'
@@ -34,6 +35,7 @@ const TradeSection = ({
   currentYear,
   playersMap,
   onApplyTrade,
+  onAfterTradeApplied,
   primaryTeamData,
   onEditContract,
   worldId = null, // World ID for world-aware team loading
@@ -46,6 +48,7 @@ const TradeSection = ({
     currentYear,
     playersMap,
     onApplyTrade,
+    onAfterTradeApplied,
     primaryTeamData,
     onEditContract,
     worldId,

--- a/src/features/architect/tradeMachine/TradeEditor.tsx
+++ b/src/features/architect/tradeMachine/TradeEditor.tsx
@@ -48,6 +48,7 @@ export const TradeEditor = ({
   currentYear,
   playersMap = {},
   onApplyTrade,
+  onAfterTradeApplied,
   primaryTeamData = null,
   onEditContract,
   worldId = null, // World ID for world-aware team loading
@@ -661,6 +662,7 @@ export const TradeEditor = ({
                 await onApplyTrade(tradeData);
                 // TM-PICKS-E1: Re-resolve entitlements so UI reflects new ownership
                 refreshEntitlements();
+                onAfterTradeApplied?.();
               } catch (error: unknown) {
                 console.error('[TradeEditor] Trade application failed:', error);
                 toast.error(

--- a/src/features/architect/tradeMachine/TradeEditor.types.ts
+++ b/src/features/architect/tradeMachine/TradeEditor.types.ts
@@ -81,6 +81,7 @@ export interface TradeEditorProps {
   onApplyTrade?:
     | ((tradeData: TradeDataEntryLike[]) => Promise<unknown> | unknown)
     | null;
+  onAfterTradeApplied?: (() => void) | null;
   primaryTeamData?: PrimaryTeamDataLike;
   onEditContract?: ((player: PlayerLike) => void) | null;
   worldId?: string | null;

--- a/src/tests/architect/stage2a.navigationContinuity.test.tsx
+++ b/src/tests/architect/stage2a.navigationContinuity.test.tsx
@@ -44,24 +44,32 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 const baseMode = {
-  kind: 'world' as const,
+  kind: 'committed-world' as const,
   worldId: 'world_1',
+  label: 'Committed World',
   shortLabel: 'World',
   detail: 'Committed world mode',
   tone: 'success' as const,
+  isCommittedWorldTruth: true,
 };
 
 const baseContext: ArchitectWorkspaceContext = {
   team: { status: 'available', id: 'LAL', label: 'LAL' },
-  world: { status: 'active', worldId: 'world_1', label: 'My World' },
+  world: {
+    status: 'available',
+    id: 'world_1',
+    label: 'My World',
+    labelSource: 'provided',
+  },
   seasons: {
-    selectedViewingSeasonLabel: '2025-26',
     selectedViewingSeason: 2026,
+    selectedViewingSeasonLabel: '2025-26',
+    authoritativeWorldSeason: '2025-26',
     authoritativeWorldSeasonStatus: 'available',
     authoritativeWorldSeasonLabel: '2025-26',
     viewingSeasonDiffersFromWorldSeason: false,
   },
-  worldDate: { status: 'unavailable' },
+  worldDate: { status: 'unavailable', value: null, label: '' },
   mode: baseMode,
   status: {
     isLoading: false,
@@ -96,15 +104,16 @@ const contextWithCap: ArchitectWorkspaceContext = {
     isOverTax: false,
     isAtOrAboveFirstApron: false,
     isAboveSecondApron: false,
-    source: 'capSheet',
+    source: 'computeTeamCapTotals',
   },
 };
 
 const contextWithSeasonMismatch: ArchitectWorkspaceContext = {
   ...contextWithCap,
   seasons: {
-    selectedViewingSeasonLabel: '2024-25',
     selectedViewingSeason: 2025,
+    selectedViewingSeasonLabel: '2024-25',
+    authoritativeWorldSeason: '2025-26',
     authoritativeWorldSeasonStatus: 'available',
     authoritativeWorldSeasonLabel: '2025-26',
     viewingSeasonDiffersFromWorldSeason: true,

--- a/src/tests/architect/stage2a.navigationContinuity.test.tsx
+++ b/src/tests/architect/stage2a.navigationContinuity.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * FILE: src/tests/architect/stage2a.navigationContinuity.test.tsx
+ * PURPOSE: Targeted tests for Stage 2A navigation continuity callbacks.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Covers:
+ * - ArchitectWorkspaceHeader: onNavigateToCapSheet / onNavigateToOffseason button wiring
+ * - FreeAgencySection: onAfterSigningComplete fires only on success
+ */
+
+import React from 'react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { ArchitectWorkspaceHeader } from '@/features/architect/GMDashboard/components/ArchitectWorkspaceHeader';
+import { FreeAgencySection } from '@/features/architect/GMDashboard/sections/FreeAgencySection';
+import type { ArchitectWorkspaceContext } from '@/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext';
+import type { FreeAgencyActionOwner } from '@/features/architect/GMDashboard/hooks/useArchitectActions';
+
+// FreeAgentPool mock that exposes signFreeAgent via a test button so we can
+// trigger it without rendering the full pool UI.
+vi.mock('@/features/architect/freeAgency/FreeAgentPool', () => ({
+  FreeAgentPool: ({ actionOwner }: { actionOwner: { dualPathSigning: { signFreeAgent: (...args: unknown[]) => unknown } } }) => (
+    <button
+      data-testid="mock-trigger-sign"
+      onClick={() =>
+        actionOwner.dualPathSigning.signFreeAgent(
+          { id: 'player_1', name: 'Test Player' },
+          { salary: 5_000_000 }
+        )
+      }
+    >
+      Sign
+    </button>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Minimal context fixtures
+// ---------------------------------------------------------------------------
+
+const baseMode = {
+  kind: 'world' as const,
+  worldId: 'world_1',
+  shortLabel: 'World',
+  detail: 'Committed world mode',
+  tone: 'success' as const,
+};
+
+const baseContext: ArchitectWorkspaceContext = {
+  team: { status: 'available', id: 'LAL', label: 'LAL' },
+  world: { status: 'active', worldId: 'world_1', label: 'My World' },
+  seasons: {
+    selectedViewingSeasonLabel: '2025-26',
+    selectedViewingSeason: 2026,
+    authoritativeWorldSeasonStatus: 'available',
+    authoritativeWorldSeasonLabel: '2025-26',
+    viewingSeasonDiffersFromWorldSeason: false,
+  },
+  worldDate: { status: 'unavailable' },
+  mode: baseMode,
+  status: {
+    isLoading: false,
+    isSaving: false,
+    worldMetadataLoading: false,
+    hasError: false,
+    errorMessage: null,
+  },
+  roster: { status: 'unavailable', count: null, source: null },
+  cap: { status: 'unavailable', reason: 'no data' },
+  exceptions: { status: 'unavailable', deferralHint: 'see-cap-sheet', reason: 'no data' },
+  draftAssets: { status: 'unavailable', deferralHint: 'see-trade-history', reason: 'no data' },
+  recentActivity: { status: 'deferred', entryPoint: 'history-tab' },
+};
+
+const contextWithCap: ArchitectWorkspaceContext = {
+  ...baseContext,
+  cap: {
+    status: 'available',
+    season: 2026,
+    seasonLabel: '2025-26',
+    totalCapAllocations: 145_000_000,
+    salaryCap: 140_588_000,
+    capSpace: -4_412_000,
+    luxuryTax: 170_814_000,
+    taxSpace: 25_814_000,
+    firstApron: 178_132_000,
+    firstApronSpace: 33_132_000,
+    secondApron: 188_931_000,
+    secondApronSpace: 43_931_000,
+    isOverCap: true,
+    isOverTax: false,
+    isAtOrAboveFirstApron: false,
+    isAboveSecondApron: false,
+    source: 'capSheet',
+  },
+};
+
+const contextWithSeasonMismatch: ArchitectWorkspaceContext = {
+  ...contextWithCap,
+  seasons: {
+    selectedViewingSeasonLabel: '2024-25',
+    selectedViewingSeason: 2025,
+    authoritativeWorldSeasonStatus: 'available',
+    authoritativeWorldSeasonLabel: '2025-26',
+    viewingSeasonDiffersFromWorldSeason: true,
+  },
+};
+
+const contextWithExceptions: ArchitectWorkspaceContext = {
+  ...contextWithCap,
+  exceptions: {
+    status: 'available',
+    tpeCount: 1,
+    hasAvailableMle: true,
+    hasAvailableBae: false,
+    hasAvailableRoom: false,
+    hasAnyActive: true,
+    worldSeasonBasis: false,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// ArchitectWorkspaceHeader — cap posture navigation
+// ---------------------------------------------------------------------------
+
+describe('ArchitectWorkspaceHeader — onNavigateToCapSheet', () => {
+  it('renders cap posture as a button when onNavigateToCapSheet is provided', () => {
+    render(
+      <ArchitectWorkspaceHeader
+        context={contextWithCap}
+        onNavigateToCapSheet={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByTestId('cap-posture-nav-cap-sheet')
+    ).toBeInTheDocument();
+  });
+
+  it('calls onNavigateToCapSheet when the cap posture button is clicked', () => {
+    const onNavigateToCapSheet = vi.fn();
+    render(
+      <ArchitectWorkspaceHeader
+        context={contextWithCap}
+        onNavigateToCapSheet={onNavigateToCapSheet}
+      />
+    );
+    fireEvent.click(screen.getByTestId('cap-posture-nav-cap-sheet'));
+    expect(onNavigateToCapSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders cap posture as static text when onNavigateToCapSheet is not provided', () => {
+    render(<ArchitectWorkspaceHeader context={contextWithCap} />);
+    expect(
+      screen.queryByTestId('cap-posture-nav-cap-sheet')
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ArchitectWorkspaceHeader — season mismatch navigation
+// ---------------------------------------------------------------------------
+
+describe('ArchitectWorkspaceHeader — onNavigateToOffseason', () => {
+  it('renders season mismatch as a button when onNavigateToOffseason is provided', () => {
+    render(
+      <ArchitectWorkspaceHeader
+        context={contextWithSeasonMismatch}
+        onNavigateToOffseason={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByTestId('season-mismatch-nav-offseason')
+    ).toBeInTheDocument();
+  });
+
+  it('calls onNavigateToOffseason when the season mismatch button is clicked', () => {
+    const onNavigateToOffseason = vi.fn();
+    render(
+      <ArchitectWorkspaceHeader
+        context={contextWithSeasonMismatch}
+        onNavigateToOffseason={onNavigateToOffseason}
+      />
+    );
+    fireEvent.click(screen.getByTestId('season-mismatch-nav-offseason'));
+    expect(onNavigateToOffseason).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders season mismatch as static text when onNavigateToOffseason is not provided', () => {
+    render(<ArchitectWorkspaceHeader context={contextWithSeasonMismatch} />);
+    expect(
+      screen.queryByTestId('season-mismatch-nav-offseason')
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ArchitectWorkspaceHeader — exceptions navigation
+// ---------------------------------------------------------------------------
+
+describe('ArchitectWorkspaceHeader — exceptions onNavigateToCapSheet', () => {
+  it('renders exceptions as a button when onNavigateToCapSheet is provided and exceptions are active', () => {
+    render(
+      <ArchitectWorkspaceHeader
+        context={contextWithExceptions}
+        onNavigateToCapSheet={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByTestId('exceptions-nav-cap-sheet')
+    ).toBeInTheDocument();
+  });
+
+  it('calls onNavigateToCapSheet when the exceptions button is clicked', () => {
+    const onNavigateToCapSheet = vi.fn();
+    render(
+      <ArchitectWorkspaceHeader
+        context={contextWithExceptions}
+        onNavigateToCapSheet={onNavigateToCapSheet}
+      />
+    );
+    fireEvent.click(screen.getByTestId('exceptions-nav-cap-sheet'));
+    expect(onNavigateToCapSheet).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FreeAgencySection — onAfterSigningComplete callback
+// ---------------------------------------------------------------------------
+
+const mockDualPathSigning = (
+  result: { success: boolean }
+): FreeAgencyActionOwner['dualPathSigning'] => ({
+  signFreeAgent: vi.fn().mockResolvedValue(result),
+});
+
+const buildFreeAgencyActionOwner = (
+  signResult: { success: boolean }
+): FreeAgencyActionOwner => ({
+  dualPathSigning: mockDualPathSigning(signResult),
+  worldOnly: null,
+  freeAgentModalAvailability: {
+    visibleActions: ['signNew'],
+    actionLabelsOverride: {},
+    showOfferSheetToggle: false,
+    signAndTradeInitiation: null,
+    offerSheetInitiation: null,
+  },
+  offerSheetSectionAvailability: {
+    actionsDisabled: true,
+    actionsDisabledReason: 'World required',
+    lifecycleActionOwner: null,
+  },
+});
+
+describe('FreeAgencySection — onAfterSigningComplete', () => {
+  it('calls onAfterSigningComplete when signing succeeds', async () => {
+    const onAfterSigningComplete = vi.fn();
+    render(
+      <FreeAgencySection
+        freeAgents={[]}
+        currentYear={2026}
+        actionOwner={buildFreeAgencyActionOwner({ success: true })}
+        onAfterSigningComplete={onAfterSigningComplete}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('mock-trigger-sign'));
+
+    await vi.waitFor(() => {
+      expect(onAfterSigningComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not call onAfterSigningComplete when signing fails', async () => {
+    const onAfterSigningComplete = vi.fn();
+    render(
+      <FreeAgencySection
+        freeAgents={[]}
+        currentYear={2026}
+        actionOwner={buildFreeAgencyActionOwner({ success: false })}
+        onAfterSigningComplete={onAfterSigningComplete}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('mock-trigger-sign'));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onAfterSigningComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when onAfterSigningComplete is not provided and signing succeeds', async () => {
+    render(
+      <FreeAgencySection
+        freeAgents={[]}
+        currentYear={2026}
+        actionOwner={buildFreeAgencyActionOwner({ success: true })}
+      />
+    );
+
+    expect(() =>
+      fireEvent.click(screen.getByTestId('mock-trigger-sign'))
+    ).not.toThrow();
+  });
+});

--- a/src/tests/architect/systemIntegration.step2Handoff.guardrail.test.ts
+++ b/src/tests/architect/systemIntegration.step2Handoff.guardrail.test.ts
@@ -141,8 +141,13 @@ describe('Architect System Integration Step 2 handoff guardrails', () => {
     expect(freeAgencySectionSource).toContain(
       'const offerSheetLifecycleDisabledReason ='
     );
+    // Stage 2A: signFreeAgent is wrapped for navigation-only (onAfterSigningComplete)
+    // but still delegates to actionOwner.dualPathSigning.signFreeAgent for the actual mutation.
     expect(freeAgencySectionSource).toContain(
-      'dualPathSigning: actionOwner.dualPathSigning,'
+      'actionOwner.dualPathSigning.signFreeAgent'
+    );
+    expect(freeAgencySectionSource).toContain(
+      'dualPathSigning: { signFreeAgent: wrappedSignFreeAgent }'
     );
     expect(freeAgencySectionSource).toContain(
       'freeAgentModalAvailability: actionOwner.freeAgentModalAvailability,'


### PR DESCRIPTION
## Summary

Adds Stage 2A navigation continuity for Architect Operating Experience.

Stage 1 made Architect visibly continuous. Stage 2A adds the first safe cross-surface navigation continuity so users are guided toward the next natural inspection surface after key actions or warnings.

## Added

- Successful trade apply → Cap Sheet tab
- Successful free-agent signing → Cap Sheet tab
- Workspace header affordances:
  - cap posture / exceptions → Cap Sheet
  - season mismatch → Offseason
- Offseason summary modal close → Cap Sheet

## Guardrails

- No new mutation authority
- No new Firestore reads or writes
- No schema changes
- No new committed-write path
- No changes to `mutationPipeline`, `seasonManager`, or `worldManager`
- No legal validation behavior change
- Header affordances are navigation-only and degrade to static text without callbacks

## Validation Reported

- `npm run typecheck`: passed
- targeted Stage 2A navigation tests: 11/11 passed
- `systemIntegration.step2Handoff.guardrail.test.ts`: 6/6 passed
- `npm run build`: passed, with pre-existing chunk-size warnings only
- `npm run test:architect -- --reporter=dot`: pre-existing baseline failures unchanged; no new failures introduced

## Notes

The signing continuity wrapper still delegates mutation behavior to `actionOwner.dualPathSigning.signFreeAgent` and only fires the navigation callback when the returned result succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic navigation to the Cap Sheet tab after completing trades and free-agent signings.

* **Improvements**
  * Workspace header gains clickable controls to jump to Cap Sheet and Offseason views.

* **Tests**
  * Added and updated tests covering navigation callbacks and integration around signing/trade completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bet-Zero/scoutzero/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->