### PR TITLE
Add Architect post-action handoff

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -5,6 +5,7 @@ ARCHITECT_FEATURE_README.md
 GMDashboard/
   GMDashboard.tsx
   components/
+    ArchitectPostActionHandoff.tsx
     ArchitectWorkspaceHeader.tsx
     CapAuditDebugPanel.tsx
     DeleteWorldModal.tsx
@@ -32,6 +33,7 @@ GMDashboard/
     useArchitectActions.types.ts
     useArchitectModals.ts
     useArchitectModePresentation.ts
+    useArchitectPostActionReceipt.ts
     useArchitectState.freeAgents.ts
     useArchitectState.helpers.ts
     useArchitectState.ts
@@ -41,6 +43,8 @@ GMDashboard/
     useArchitectWorkspaceContext.ts
     useScenarioActivityRail.ts
   offerSheetTypes.ts
+  postActionHandoff/
+    types.ts
   sections/
     CapSheetSection.tsx
     CapTableSection.tsx
@@ -485,5 +489,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-05-19T11:13:45.167Z*
+*Generated on: 2026-05-20T06:42:43.055Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -208,7 +208,10 @@ export const GMDashboard = () => {
     (selectedRulesYear && leagueContextByYear?.get(selectedRulesYear)) ||
     rulesLeagueContext;
 
-  const postActionReceipt = useArchitectPostActionReceipt();
+  const postActionReceiptScopeKey = `${worldId ?? 'sandbox'}:${normalizedTeamId}`;
+  const postActionReceipt = useArchitectPostActionReceipt(
+    postActionReceiptScopeKey
+  );
 
   const actions = useArchitectActions({
     teamId: normalizedTeamId,
@@ -700,4 +703,3 @@ export const GMDashboard = () => {
     </div>
   );
 };
-

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -17,7 +17,7 @@
  *  - 2025-12-12: Phase 3 refactor - extracted all handlers into useArchitectActions hook
  *  - 2025-12-14: Option B refactor - removed shadow cap sheet state, teamCapSheet is now the only source of truth
  */
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { EditContractModal } from '@/shared/components/EditContractModal';
 import { RosterSection } from './sections/RosterSection';
@@ -32,6 +32,9 @@ import { WorldTimeControls } from '@/features/architect/GMDashboard/components/W
 import { CapAuditDebugPanel } from '@/features/architect/GMDashboard/components/CapAuditDebugPanel';
 import { ArchitectWorkspaceHeader } from '@/features/architect/GMDashboard/components/ArchitectWorkspaceHeader';
 import { ScenarioMoveRail } from '@/features/architect/GMDashboard/components/ScenarioMoveRail';
+import { ArchitectPostActionHandoff } from '@/features/architect/GMDashboard/components/ArchitectPostActionHandoff';
+import { useArchitectPostActionReceipt } from './hooks/useArchitectPostActionReceipt';
+import { deriveSeasonAdvanceReceipt } from './postActionHandoff/types';
 import { useArchitectState } from './hooks/useArchitectState';
 import { useArchitectWorkspaceContext } from './hooks/useArchitectWorkspaceContext';
 import { useArchitectActions } from './hooks/useArchitectActions';
@@ -205,6 +208,8 @@ export const GMDashboard = () => {
     (selectedRulesYear && leagueContextByYear?.get(selectedRulesYear)) ||
     rulesLeagueContext;
 
+  const postActionReceipt = useArchitectPostActionReceipt();
+
   const actions = useArchitectActions({
     teamId: normalizedTeamId,
     userId,
@@ -214,7 +219,21 @@ export const GMDashboard = () => {
     modals,
     worldId,
     seasonId: toSeasonCode(currentYear),
+    publishPostActionReceipt: postActionReceipt.publish,
   });
+
+  const handleOffseasonAdvanceApplied = useCallback(
+    (aftermath: Parameters<NonNullable<OffseasonSectionProps['onAfterOffseasonAdvanceApplied']>>[0]) => {
+      const receipt = deriveSeasonAdvanceReceipt({
+        aftermath,
+        primaryTeamCode: normalizedTeamId,
+      });
+      if (receipt) {
+        postActionReceipt.publish(receipt);
+      }
+    },
+    [normalizedTeamId, postActionReceipt]
+  );
 
   const manualCapSheetMutationAuthority = useMemo(
     () => ({
@@ -362,6 +381,7 @@ export const GMDashboard = () => {
     worldSeason: worldCurrentSeason,
     worldSeasonLoading: worldMetadataLoading,
     onReloadWorldData: worldModeBoundary.onReloadWorldData,
+    onAfterOffseasonAdvanceApplied: handleOffseasonAdvanceApplied,
   };
 
   if (authLoading || isLoading) return <p>Loading GM Dashboard...</p>;
@@ -427,10 +447,20 @@ export const GMDashboard = () => {
         onNavigateToOffseason={() => setActiveTab('offseason')}
       />
 
+      <ArchitectPostActionHandoff
+        receipt={postActionReceipt.receipt}
+        onNavigateToCapSheet={() => setActiveTab('cap')}
+        onNavigateToRoster={() => setActiveTab('roster')}
+        onNavigateToHistory={() => setActiveTab('history')}
+        onDismiss={postActionReceipt.dismiss}
+      />
+
       <ScenarioMoveRail
         worldId={worldId}
         teamCode={normalizedTeamId}
         onOpenHistory={() => setActiveTab('history')}
+        refreshKey={postActionReceipt.generation}
+        highlightEventId={postActionReceipt.receipt?.eventId ?? null}
       />
 
       {showEmulatorUnavailableBanner && (

--- a/src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx
@@ -1,0 +1,148 @@
+/**
+ * FILE: src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx
+ * PURPOSE: Stage 2B post-action handoff strip — compact "what just committed" summary.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Renders the active session-scoped post-action receipt with deep links to
+ * Cap Sheet, Roster, and History. Navigation only — no mutation callbacks,
+ * no Firestore writes, no validation or delta claims.
+ *
+ * Truth authority: the receipt itself is a derived view of a successful
+ * committed mutation result. This component does not produce new truth.
+ */
+import type { ArchitectPostActionReceipt } from '../postActionHandoff/types';
+
+interface Props {
+  receipt: ArchitectPostActionReceipt | null;
+  onNavigateToCapSheet: () => void;
+  onNavigateToRoster: () => void;
+  onNavigateToHistory: () => void;
+  onDismiss: () => void;
+}
+
+const MAX_TEAM_CHIPS = 3;
+
+const formatHandoffDate = (iso: string | null): string | null => {
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) {
+    return iso.slice(0, 10) || null;
+  }
+  return new Date(parsed).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+export const ArchitectPostActionHandoff = ({
+  receipt,
+  onNavigateToCapSheet,
+  onNavigateToRoster,
+  onNavigateToHistory,
+  onDismiss,
+}: Props) => {
+  if (!receipt) {
+    return null;
+  }
+
+  const visibleTeams = receipt.changedTeamCodes.slice(0, MAX_TEAM_CHIPS);
+  const overflow = Math.max(
+    0,
+    receipt.changedTeamCodes.length - visibleTeams.length
+  );
+  const formattedDate = formatHandoffDate(receipt.occurredAt);
+
+  return (
+    <div
+      className="mb-4 rounded-md border border-green-400/30 bg-green-500/[0.07] px-3 py-2 text-xs text-white/80"
+      data-testid="architect-post-action-handoff"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className="rounded border border-green-400/40 bg-green-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-200"
+          data-testid="post-action-handoff-status-chip"
+        >
+          Committed
+        </span>
+        <span
+          className="font-semibold text-white/90"
+          data-testid="post-action-handoff-headline"
+        >
+          {receipt.headline}
+        </span>
+
+        {visibleTeams.length > 0 && (
+          <span
+            className="flex flex-wrap items-center gap-1"
+            data-testid="post-action-handoff-team-chips"
+          >
+            {visibleTeams.map((teamCode) => (
+              <span
+                key={teamCode}
+                className="rounded border border-white/15 bg-white/5 px-1.5 py-0.5 text-[10px] font-medium text-white/70"
+                data-testid={`post-action-handoff-team-chip-${teamCode}`}
+              >
+                {teamCode}
+              </span>
+            ))}
+            {overflow > 0 && (
+              <span
+                className="rounded border border-white/15 bg-white/5 px-1.5 py-0.5 text-[10px] font-medium text-white/50"
+                data-testid="post-action-handoff-team-chips-overflow"
+              >
+                +{overflow}
+              </span>
+            )}
+          </span>
+        )}
+
+        {formattedDate && (
+          <span className="text-white/40" data-testid="post-action-handoff-date">
+            {formattedDate}
+          </span>
+        )}
+
+        <span className="min-w-0 flex-1" />
+
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onNavigateToCapSheet}
+            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90"
+            data-testid="post-action-handoff-nav-cap"
+          >
+            View Cap Sheet
+          </button>
+          <button
+            type="button"
+            onClick={onNavigateToRoster}
+            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90"
+            data-testid="post-action-handoff-nav-roster"
+          >
+            View Roster
+          </button>
+          <button
+            type="button"
+            onClick={onNavigateToHistory}
+            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90"
+            data-testid="post-action-handoff-nav-history"
+          >
+            View History
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[11px] text-white/40 hover:bg-white/10 hover:text-white/70"
+            data-testid="post-action-handoff-dismiss"
+            aria-label="Dismiss post-action handoff"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx
@@ -65,7 +65,7 @@ export const ArchitectPostActionHandoff = ({
           className="rounded border border-green-400/40 bg-green-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-200"
           data-testid="post-action-handoff-status-chip"
         >
-          Committed
+          Committed world
         </span>
         <span
           className="font-semibold text-white/90"

--- a/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
+++ b/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
@@ -14,6 +14,17 @@ interface ScenarioMoveRailProps {
   worldId: string | null | undefined;
   teamCode: string | null | undefined;
   onOpenHistory: () => void;
+  /**
+   * Stage 2B refresh seam. Increment to trigger a re-read of committed
+   * world events after a successful committed mutation. Sandbox/no-world
+   * mode is a no-op.
+   */
+  refreshKey?: number;
+  /**
+   * Stage 2B handoff highlight. When this matches the `id` of a rail
+   * entry, that entry renders as "just committed". Skipped when null.
+   */
+  highlightEventId?: string | null;
 }
 
 const formatRailDate = (iso: string): string => {
@@ -31,10 +42,13 @@ export const ScenarioMoveRail = ({
   worldId,
   teamCode,
   onOpenHistory,
+  refreshKey = 0,
+  highlightEventId = null,
 }: ScenarioMoveRailProps) => {
   const { railState, localPendingDeferred } = useScenarioActivityRail({
     worldId,
     teamCode,
+    refreshKey,
   });
 
   return (
@@ -98,25 +112,45 @@ export const ScenarioMoveRail = ({
             className="space-y-1.5"
             data-testid="scenario-move-rail-entries"
           >
-            {railState.entries.map((entry) => (
-              <li
-                key={entry.id}
-                className="flex items-baseline gap-2 text-white/50"
-              >
-                <span className="shrink-0 rounded border border-green-500/20 bg-green-500/10 px-1 text-green-400/60 text-[10px] leading-4">
-                  World
-                </span>
-                <span className="shrink-0">{entry.typeLabel}</span>
-                <span className="text-white/35 min-w-0 truncate">
-                  {entry.summary}
-                </span>
-                {entry.occurredAt && (
-                  <span className="shrink-0 ml-auto pl-2 text-white/25">
-                    {formatRailDate(entry.occurredAt)}
+            {railState.entries.map((entry) => {
+              const isJustCommitted = Boolean(
+                highlightEventId && entry.id === highlightEventId
+              );
+              return (
+                <li
+                  key={entry.id}
+                  className={
+                    isJustCommitted
+                      ? 'flex items-baseline gap-2 text-white/80 rounded bg-green-500/[0.06] -mx-1 px-1'
+                      : 'flex items-baseline gap-2 text-white/50'
+                  }
+                  data-testid={
+                    isJustCommitted
+                      ? 'scenario-move-rail-entry-just-committed'
+                      : undefined
+                  }
+                >
+                  <span className="shrink-0 rounded border border-green-500/20 bg-green-500/10 px-1 text-green-400/60 text-[10px] leading-4">
+                    {isJustCommitted ? 'Just now' : 'World'}
                   </span>
-                )}
-              </li>
-            ))}
+                  <span className="shrink-0">{entry.typeLabel}</span>
+                  <span
+                    className={
+                      isJustCommitted
+                        ? 'text-white/70 min-w-0 truncate'
+                        : 'text-white/35 min-w-0 truncate'
+                    }
+                  >
+                    {entry.summary}
+                  </span>
+                  {entry.occurredAt && (
+                    <span className="shrink-0 ml-auto pl-2 text-white/25">
+                      {formatRailDate(entry.occurredAt)}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
           {localPendingDeferred && (
             <p className="mt-1.5 text-white/30 text-[10px]">

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.persistenceHelpers.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.persistenceHelpers.ts
@@ -30,6 +30,8 @@ import {
 import toast from 'react-hot-toast';
 import type { PlayerRulesProfileInput } from '@/features/architect/types';
 import type { ActionContext, EditModalContext } from './useArchitectModals';
+import type { ArchitectPostActionReceipt } from '../postActionHandoff/types';
+import { deriveReceiptFromMutationResult } from '../postActionHandoff/types';
 import {
   BASE_MODE_VALIDATOR_WORLD_ID,
   CAP_AUDIT_EVENT_SCHEMA_VERSION,
@@ -92,6 +94,13 @@ export interface UsePersistenceHelpersParams {
   finishSave: UseArchitectStateReturn['finishSave'];
   reloadActiveWorldTeamData: UseArchitectStateReturn['reloadActiveWorldTeamData'];
   refreshWorldRosterIndex: UseArchitectStateReturn['refreshWorldRosterIndex'];
+  /**
+   * Stage 2B post-action receipt publisher. Called after a successful
+   * committed mutation result resolves. Receives a receipt derived from
+   * the canonical mutation result; never invents new event truth.
+   * No-op when omitted.
+   */
+  publishPostActionReceipt?: (receipt: ArchitectPostActionReceipt) => void;
 }
 
 export function usePersistenceHelpers({
@@ -109,6 +118,7 @@ export function usePersistenceHelpers({
   finishSave,
   reloadActiveWorldTeamData,
   refreshWorldRosterIndex,
+  publishPostActionReceipt,
 }: UsePersistenceHelpersParams) {
 
   const setTeamCapSheetSafe = useCallback(
@@ -717,6 +727,19 @@ export function usePersistenceHelpers({
 
         await syncTeamFromMutationResult(mutationType, result);
         toast.success('Saved changes');
+        // Stage 2B: publish a derived post-action receipt from this
+        // already-successful committed result. Authority is unchanged —
+        // the receipt mirrors what the pipeline already returned.
+        if (publishPostActionReceipt) {
+          const receipt = deriveReceiptFromMutationResult({
+            mutationType,
+            result,
+            primaryTeamCode: teamCode || null,
+          });
+          if (receipt) {
+            publishPostActionReceipt(receipt);
+          }
+        }
         finishSave();
         return result;
       } catch (error: unknown) {
@@ -738,6 +761,8 @@ export function usePersistenceHelpers({
       worldId,
       evaluateMutationTruth,
       seasonId,
+      publishPostActionReceipt,
+      teamCode,
     ]
   );
 

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.signingExecution.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.signingExecution.ts
@@ -72,6 +72,8 @@ import type {
 } from './useArchitectActions.types';
 import type { UseArchitectStateReturn } from './useArchitectState';
 import type { PreparedCapAuditedMutationBoundary } from './useArchitectActions.persistenceHelpers';
+import type { ArchitectPostActionReceipt } from '../postActionHandoff/types';
+import { deriveReceiptFromMutationResult } from '../postActionHandoff/types';
 
 export interface UseSigningExecutionParams {
   teamCode: string;
@@ -118,6 +120,11 @@ export interface UseSigningExecutionParams {
     mutationType: string,
     result: PersistMutationResult
   ) => Promise<void>;
+  /**
+   * Stage 2B post-action receipt publisher. Receives a receipt derived
+   * from the canonical committed signing result. No-op when omitted.
+   */
+  publishPostActionReceipt?: (receipt: ArchitectPostActionReceipt) => void;
 }
 
 export function useSigningExecution({
@@ -138,6 +145,7 @@ export function useSigningExecution({
   buildCommittedWorldReloadPlan,
   applyCommittedWorldReloadPlan,
   syncTeamFromMutationResult,
+  publishPostActionReceipt,
 }: UseSigningExecutionParams) {
 
   const applyResolvedStandardSigningState = useCallback(
@@ -254,6 +262,17 @@ export function useSigningExecution({
         }
 
         toast.success('Saved changes');
+        // Stage 2B: derive a post-action receipt from the committed result.
+        if (publishPostActionReceipt) {
+          const receipt = deriveReceiptFromMutationResult({
+            mutationType: 'signFreeAgent',
+            result,
+            primaryTeamCode: teamCode || null,
+          });
+          if (receipt) {
+            publishPostActionReceipt(receipt);
+          }
+        }
         finishSave();
         return {
           success: true,
@@ -283,6 +302,8 @@ export function useSigningExecution({
       startSave,
       userId,
       worldId,
+      publishPostActionReceipt,
+      teamCode,
     ]
   );
 

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.ts
@@ -300,6 +300,7 @@ export function useArchitectActions({
   modals,
   worldId,
   seasonId,
+  publishPostActionReceipt,
 }: UseArchitectActionsParams): UseArchitectActionsReturn {
   // Normalize teamId (route slug like "lakers") to canonical teamCode (like "LAL")
   // This ensures all mutation payloads use the same team code format as Firestore base teams
@@ -357,6 +358,7 @@ export function useArchitectActions({
     finishSave,
     reloadActiveWorldTeamData: reloadActiveWorldTeamData!,
     refreshWorldRosterIndex,
+    publishPostActionReceipt,
   });
 
 
@@ -389,6 +391,7 @@ export function useArchitectActions({
     buildCommittedWorldReloadPlan,
     applyCommittedWorldReloadPlan,
     syncTeamFromMutationResult,
+    publishPostActionReceipt,
   });
 
 

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.types.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.types.ts
@@ -637,6 +637,14 @@ export interface UseArchitectActionsParams {
   modals: ArchitectModalsForActions;
   worldId: string | null;
   seasonId: string;
+  /**
+   * Stage 2B post-action receipt publisher. Optional; when provided,
+   * successful committed mutations route through internal publishers
+   * which derive receipts from canonical mutation results.
+   */
+  publishPostActionReceipt?: (
+    receipt: import('../postActionHandoff/types').ArchitectPostActionReceipt
+  ) => void;
 }
 
 /**

--- a/src/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt.ts
@@ -1,0 +1,46 @@
+/**
+ * FILE: src/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt.ts
+ * PURPOSE: Stage 2B session-scoped state for the post-action handoff strip.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Holds at most one active receipt at a time. Publishing a new receipt
+ * replaces the prior one. Dismissal clears the receipt manually.
+ *
+ * `generation` increments on every successful publish so dependent surfaces
+ * (e.g. the activity rail) can opt into a single, debounced refetch.
+ *
+ * Session-scoped only. Never persisted to Firestore. No new write authority.
+ */
+import { useCallback, useState } from 'react';
+import type { ArchitectPostActionReceipt } from '../postActionHandoff/types';
+
+export interface UseArchitectPostActionReceiptResult {
+  receipt: ArchitectPostActionReceipt | null;
+  generation: number;
+  publish: (receipt: ArchitectPostActionReceipt | null) => void;
+  dismiss: () => void;
+}
+
+export function useArchitectPostActionReceipt(): UseArchitectPostActionReceiptResult {
+  const [receipt, setReceipt] = useState<ArchitectPostActionReceipt | null>(
+    null
+  );
+  const [generation, setGeneration] = useState(0);
+
+  const publish = useCallback(
+    (next: ArchitectPostActionReceipt | null) => {
+      if (!next) {
+        return;
+      }
+      setReceipt(next);
+      setGeneration((prev) => prev + 1);
+    },
+    []
+  );
+
+  const dismiss = useCallback(() => {
+    setReceipt(null);
+  }, []);
+
+  return { receipt, generation, publish, dismiss };
+}

--- a/src/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt.ts
@@ -11,7 +11,7 @@
  *
  * Session-scoped only. Never persisted to Firestore. No new write authority.
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ArchitectPostActionReceipt } from '../postActionHandoff/types';
 
 export interface UseArchitectPostActionReceiptResult {
@@ -21,11 +21,25 @@ export interface UseArchitectPostActionReceiptResult {
   dismiss: () => void;
 }
 
-export function useArchitectPostActionReceipt(): UseArchitectPostActionReceiptResult {
+export function useArchitectPostActionReceipt(
+  scopeKey?: string | null
+): UseArchitectPostActionReceiptResult {
   const [receipt, setReceipt] = useState<ArchitectPostActionReceipt | null>(
     null
   );
   const [generation, setGeneration] = useState(0);
+  const lastScopeKeyRef = useRef<string | null | undefined>(scopeKey);
+
+  useEffect(() => {
+    if (scopeKey === undefined) {
+      return;
+    }
+    if (lastScopeKeyRef.current === scopeKey) {
+      return;
+    }
+    lastScopeKeyRef.current = scopeKey;
+    setReceipt(null);
+  }, [scopeKey]);
 
   const publish = useCallback(
     (next: ArchitectPostActionReceipt | null) => {

--- a/src/features/architect/GMDashboard/hooks/useScenarioActivityRail.ts
+++ b/src/features/architect/GMDashboard/hooks/useScenarioActivityRail.ts
@@ -88,24 +88,33 @@ export function deriveActivityRailState({
 export interface UseScenarioActivityRailArgs {
   worldId: string | null | undefined;
   teamCode: string | null | undefined;
+  /**
+   * Stage 2B refresh seam. When this value changes, the underlying
+   * committed-events fetch re-runs. Sandbox/no-world mode is a no-op.
+   * Truth source is unchanged — local/pending entries are never synthesized.
+   */
+  refreshKey?: number;
 }
 
 export interface UseScenarioActivityRailResult {
   railState: ArchitectActivityRailState;
   localPendingDeferred: true;
+  refetch: () => Promise<void>;
 }
 
 export function useScenarioActivityRail({
   worldId,
   teamCode,
+  refreshKey = 0,
 }: UseScenarioActivityRailArgs): UseScenarioActivityRailResult {
   const enabled = Boolean(worldId && teamCode);
 
-  const { events: rawEvents, loading, error, hasMore } = useWorldTeamEvents({
+  const { events: rawEvents, loading, error, hasMore, refetch } = useWorldTeamEvents({
     worldId: worldId ?? null,
     teamCode: teamCode ?? null,
     limit: RAIL_EVENT_LIMIT,
     enabled,
+    refreshKey,
   });
 
   const normalizedEvents = useMemo(
@@ -131,5 +140,6 @@ export function useScenarioActivityRail({
   return {
     railState,
     localPendingDeferred: true,
+    refetch,
   };
 }

--- a/src/features/architect/GMDashboard/postActionHandoff/types.ts
+++ b/src/features/architect/GMDashboard/postActionHandoff/types.ts
@@ -1,0 +1,193 @@
+/**
+ * FILE: src/features/architect/GMDashboard/postActionHandoff/types.ts
+ * PURPOSE: Stage 2B post-action receipt model + pure derivation from committed mutation results.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * The receipt is a session-scoped UI signal: a derived view of what just
+ * committed. It is NEVER a source of truth, never persisted, and never written
+ * to Firestore. Authority remains with the mutation pipeline / committed world
+ * event stream; this type only restates what the pipeline already returned.
+ */
+
+import type { PersistMutationResult } from '../hooks/useArchitectActions.types';
+import type { WorldAdvanceAftermath } from '../components/SeasonAdvanceModal';
+
+export type ArchitectPostActionReceiptKind =
+  | 'trade'
+  | 'signing'
+  | 'signAndTrade'
+  | 'offerSheet'
+  | 'contractAction'
+  | 'seasonAdvance';
+
+export interface ArchitectPostActionReceipt {
+  kind: ArchitectPostActionReceiptKind;
+  eventId: string | null;
+  occurredAt: string | null;
+  headline: string;
+  changedTeamCodes: string[];
+  primaryTeamCode: string | null;
+  primaryPlayerIds: string[];
+  message?: string;
+  authority?: 'committed-world';
+}
+
+const HEADLINE_BY_KIND: Record<ArchitectPostActionReceiptKind, string> = {
+  trade: 'Trade applied',
+  signing: 'Free agent signed',
+  signAndTrade: 'Sign-and-trade applied',
+  offerSheet: 'Offer sheet updated',
+  contractAction: 'Contract updated',
+  seasonAdvance: 'Season advanced',
+};
+
+const KIND_BY_MUTATION_TYPE: Record<string, ArchitectPostActionReceiptKind> = {
+  executeTrade: 'trade',
+  signFreeAgent: 'signing',
+  signAndTrade: 'signAndTrade',
+  storeOfferSheet: 'offerSheet',
+  matchOfferSheet: 'offerSheet',
+  declineOfferSheet: 'offerSheet',
+  finalizeMatchedOfferSheet: 'offerSheet',
+  finalizeDeclinedOfferSheet: 'offerSheet',
+};
+
+export function kindForMutationType(
+  mutationType: string
+): ArchitectPostActionReceiptKind {
+  return KIND_BY_MUTATION_TYPE[mutationType] ?? 'contractAction';
+}
+
+function extractEventId(result: PersistMutationResult): string | null {
+  const event = result?.event;
+  if (!event) return null;
+  if (typeof (event as { eventId?: string }).eventId === 'string') {
+    return (event as { eventId: string }).eventId;
+  }
+  if (typeof (event as { id?: string }).id === 'string') {
+    return (event as { id: string }).id;
+  }
+  return null;
+}
+
+function extractChangedTeamCodes(
+  result: PersistMutationResult
+): string[] {
+  const teams = result?.changedTeams || [];
+  const codes: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of teams) {
+    const code = typeof entry?.teamCode === 'string' ? entry.teamCode : null;
+    if (code && !seen.has(code)) {
+      seen.add(code);
+      codes.push(code);
+    }
+  }
+  if (codes.length === 0 && Array.isArray(result?.writesSummary?.teamCodes)) {
+    for (const code of result.writesSummary.teamCodes) {
+      if (typeof code === 'string' && code && !seen.has(code)) {
+        seen.add(code);
+        codes.push(code);
+      }
+    }
+  }
+  return codes;
+}
+
+function extractPrimaryPlayerIds(
+  result: PersistMutationResult
+): string[] {
+  const updates = result?.changedPlayers || [];
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of updates) {
+    const id = typeof entry?.playerId === 'string' ? entry.playerId : null;
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+  if (ids.length === 0 && Array.isArray(result?.writesSummary?.playerIds)) {
+    for (const id of result.writesSummary.playerIds) {
+      if (typeof id === 'string' && id && !seen.has(id)) {
+        seen.add(id);
+        ids.push(id);
+      }
+    }
+  }
+  return ids;
+}
+
+export interface DeriveReceiptFromMutationResultArgs {
+  mutationType: string;
+  result: PersistMutationResult;
+  primaryTeamCode?: string | null;
+  occurredAt?: string | null;
+  headlineOverride?: string;
+}
+
+/**
+ * Derive a post-action receipt from an already-successful mutation result.
+ * Returns null if the result is missing or unsuccessful — the receipt must
+ * never represent a failed/throwing apply.
+ */
+export function deriveReceiptFromMutationResult({
+  mutationType,
+  result,
+  primaryTeamCode = null,
+  occurredAt = null,
+  headlineOverride,
+}: DeriveReceiptFromMutationResultArgs): ArchitectPostActionReceipt | null {
+  if (!result || result.success !== true) {
+    return null;
+  }
+
+  const kind = kindForMutationType(mutationType);
+  const changedTeamCodes = extractChangedTeamCodes(result);
+  const primaryPlayerIds = extractPrimaryPlayerIds(result);
+  const eventId = extractEventId(result);
+  const headline = headlineOverride || HEADLINE_BY_KIND[kind];
+
+  return {
+    kind,
+    eventId,
+    occurredAt: occurredAt || null,
+    headline,
+    changedTeamCodes,
+    primaryTeamCode: primaryTeamCode || null,
+    primaryPlayerIds,
+    authority: 'committed-world',
+  };
+}
+
+export interface DeriveSeasonAdvanceReceiptArgs {
+  aftermath: WorldAdvanceAftermath;
+  primaryTeamCode?: string | null;
+}
+
+/**
+ * Derive a conservative receipt for a successful committed offseason
+ * advance from authoritative aftermath data. Headline includes the next
+ * season label when available.
+ */
+export function deriveSeasonAdvanceReceipt({
+  aftermath,
+  primaryTeamCode = null,
+}: DeriveSeasonAdvanceReceiptArgs): ArchitectPostActionReceipt | null {
+  if (!aftermath || typeof aftermath.nextWorldSeason !== 'string') {
+    return null;
+  }
+  const headline = aftermath.nextWorldSeason
+    ? `Season advanced to ${aftermath.nextWorldSeason}`
+    : HEADLINE_BY_KIND.seasonAdvance;
+  return {
+    kind: 'seasonAdvance',
+    eventId: null,
+    occurredAt: null,
+    headline,
+    changedTeamCodes: primaryTeamCode ? [primaryTeamCode] : [],
+    primaryTeamCode: primaryTeamCode || null,
+    primaryPlayerIds: [],
+    authority: 'committed-world',
+  };
+}

--- a/src/features/architect/GMDashboard/postActionHandoff/types.ts
+++ b/src/features/architect/GMDashboard/postActionHandoff/types.ts
@@ -29,7 +29,7 @@ export interface ArchitectPostActionReceipt {
   primaryTeamCode: string | null;
   primaryPlayerIds: string[];
   message?: string;
-  authority?: 'committed-world';
+  authority: 'committed-world';
 }
 
 const HEADLINE_BY_KIND: Record<ArchitectPostActionReceiptKind, string> = {
@@ -138,7 +138,13 @@ export function deriveReceiptFromMutationResult({
   occurredAt = null,
   headlineOverride,
 }: DeriveReceiptFromMutationResultArgs): ArchitectPostActionReceipt | null {
-  if (!result || result.success !== true) {
+  if (
+    !result ||
+    result.success !== true ||
+    result.skipped === true ||
+    result.persistedToWorld === false ||
+    result.appliedToLocalState === false
+  ) {
     return null;
   }
 

--- a/src/features/architect/GMDashboard/sections/OffseasonSection.tsx
+++ b/src/features/architect/GMDashboard/sections/OffseasonSection.tsx
@@ -94,6 +94,12 @@ type OffseasonSectionProps = {
   worldSeason?: string | null;
   worldSeasonLoading?: boolean;
   onReloadWorldData?: WorldAdvanceReloadHandler | null;
+  /**
+   * Stage 2B: fired after a successful committed season advance, once the
+   * authoritative aftermath has been applied to dashboard state. Receives
+   * the canonical aftermath data; callers may derive a receipt from it.
+   */
+  onAfterOffseasonAdvanceApplied?: (aftermath: WorldAdvanceAftermath) => void;
 };
 
 type WorldBackedOffseasonSurfaceProps = {
@@ -501,6 +507,7 @@ const OffseasonSection = ({
   worldSeason = null,
   worldSeasonLoading = false,
   onReloadWorldData,
+  onAfterOffseasonAdvanceApplied,
 }: OffseasonSectionProps) => {
   const [showAdvanceModal, setShowAdvanceModal] = useState(false);
   const [worldAdvanceReloadError, setWorldAdvanceReloadError] = useState<
@@ -541,6 +548,12 @@ const OffseasonSection = ({
         }
       );
 
+      // Stage 2B: hand authoritative aftermath data to the dashboard so a
+      // post-action receipt can be derived. No new event truth is created.
+      onAfterOffseasonAdvanceApplied?.(
+        committedWorldAdvancePlan.immediateAftermath
+      );
+
       if (onReloadWorldData) {
         try {
           await onReloadWorldData(
@@ -570,6 +583,7 @@ const OffseasonSection = ({
       setShowOffseasonModal,
       setWorldAdvanceReloadError,
       onReloadWorldData,
+      onAfterOffseasonAdvanceApplied,
     ]
   );
 

--- a/src/features/architect/history/hooks/useWorldTeamEvents.ts
+++ b/src/features/architect/history/hooks/useWorldTeamEvents.ts
@@ -80,6 +80,12 @@ export type UseWorldTeamEventsArgs = {
   teamCode: string | null | undefined;
   limit?: number;
   enabled?: boolean;
+  /**
+   * Optional cache-buster: when this value changes, the initial fetch
+   * re-runs. Used as a Stage 2B refresh seam so a successful committed
+   * mutation can re-read the rail without inventing new event truth.
+   */
+  refreshKey?: number;
 };
 
 export type UseWorldTeamEventsResult = {
@@ -90,6 +96,12 @@ export type UseWorldTeamEventsResult = {
   hasMore: boolean;
   resolution: WorldTeamEventsResolution | null;
   loadMore: (() => Promise<void>) | null;
+  /**
+   * Imperative refetch of the head of the timeline. Truth source is
+   * unchanged — calls `fetchWorldTeamEvents` exactly as the initial
+   * effect does. Sandbox/no-world mode is a no-op.
+   */
+  refetch: () => Promise<void>;
 };
 
 const AUTHORITATIVE_QUERY_CONTRACT: QueryContract = {
@@ -489,6 +501,7 @@ export function useWorldTeamEvents({
   teamCode,
   limit = DEFAULT_LIMIT,
   enabled = true,
+  refreshKey = 0,
 }: UseWorldTeamEventsArgs): UseWorldTeamEventsResult {
   const [events, setEvents] = useState<WorldEventRecord[]>([]);
   const [loadingInitial, setLoadingInitial] = useState(false);
@@ -560,7 +573,7 @@ export function useWorldTeamEvents({
     return () => {
       isActive = false;
     };
-  }, [canQuery, worldId, teamCode, limit]);
+  }, [canQuery, worldId, teamCode, limit, refreshKey]);
 
   const loadMore = useCallback(async () => {
     if (
@@ -613,6 +626,29 @@ export function useWorldTeamEvents({
     return loadMore;
   }, [hasMore, loadMore]);
 
+  const refetch = useCallback(async () => {
+    if (!canQuery || !worldId || !teamCode) {
+      return;
+    }
+    setLoadingInitial(true);
+    setError(null);
+    try {
+      const result = await fetchWorldTeamEvents({
+        worldId,
+        teamCode,
+        limit,
+      });
+      setEvents(mergeWorldEventPages(result.events));
+      setHasMore(result.hasMore);
+      setPaginationState(result.paginationState);
+      setResolution(result.resolution);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setLoadingInitial(false);
+    }
+  }, [canQuery, worldId, teamCode, limit]);
+
   return {
     events,
     loading: loadingInitial || loadingMore,
@@ -621,5 +657,6 @@ export function useWorldTeamEvents({
     hasMore,
     resolution,
     loadMore: loadMoreFn,
+    refetch,
   };
 }

--- a/src/features/architect/history/hooks/useWorldTeamEvents.ts
+++ b/src/features/architect/history/hooks/useWorldTeamEvents.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   collection,
   getDocs,
@@ -514,11 +514,16 @@ export function useWorldTeamEvents({
     useState<WorldTeamEventsResolution | null>(null);
 
   const canQuery = Boolean(enabled && worldId && teamCode);
+  const requestScopeKey = canQuery
+    ? `${worldId}:${teamCode}:${normalizePageSize(limit)}`
+    : null;
+  const lastRequestScopeKeyRef = useRef<string | null>(requestScopeKey);
 
   useEffect(() => {
     let isActive = true;
 
     if (!canQuery || !worldId || !teamCode) {
+      lastRequestScopeKeyRef.current = null;
       setEvents([]);
       setLoadingInitial(false);
       setLoadingMore(false);
@@ -531,10 +536,15 @@ export function useWorldTeamEvents({
       };
     }
 
-    setEvents([]);
-    setHasMore(false);
-    setPaginationState(null);
-    setResolution(null);
+    const isRefreshOnly = lastRequestScopeKeyRef.current === requestScopeKey;
+    lastRequestScopeKeyRef.current = requestScopeKey;
+
+    if (!isRefreshOnly) {
+      setEvents([]);
+      setHasMore(false);
+      setPaginationState(null);
+      setResolution(null);
+    }
     setLoadingInitial(true);
     setLoadingMore(false);
     setError(null);
@@ -557,10 +567,12 @@ export function useWorldTeamEvents({
         if (!isActive) {
           return;
         }
-        setEvents([]);
-        setHasMore(false);
-        setPaginationState(null);
-        setResolution(null);
+        if (!isRefreshOnly) {
+          setEvents([]);
+          setHasMore(false);
+          setPaginationState(null);
+          setResolution(null);
+        }
         setError(caught instanceof Error ? caught.message : String(caught));
       })
       .finally(() => {
@@ -573,7 +585,7 @@ export function useWorldTeamEvents({
     return () => {
       isActive = false;
     };
-  }, [canQuery, worldId, teamCode, limit, refreshKey]);
+  }, [canQuery, worldId, teamCode, limit, refreshKey, requestScopeKey]);
 
   const loadMore = useCallback(async () => {
     if (

--- a/src/tests/architect/architectActivityRail.stage1d.test.ts
+++ b/src/tests/architect/architectActivityRail.stage1d.test.ts
@@ -121,6 +121,21 @@ describe('Stage 1D activity rail state derivation', () => {
         expect(state.entries[0].authority).toBe('committed-world');
       }
     });
+
+    it('keeps stale committed entries visible while a refresh is loading', () => {
+      const state = deriveActivityRailState({
+        worldId: 'world_deadline',
+        normalizedEvents: [makeEvent({ summary: 'Previously loaded event' })],
+        loading: true,
+        error: null,
+        hasMore: false,
+      });
+
+      expect(state.status).toBe('available');
+      if (state.status === 'available') {
+        expect(state.entries[0].summary).toBe('Previously loaded event');
+      }
+    });
   });
 
   describe('world active — empty events', () => {

--- a/src/tests/architect/stage2b.postActionHandoff.test.tsx
+++ b/src/tests/architect/stage2b.postActionHandoff.test.tsx
@@ -11,7 +11,7 @@
 
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import {
   deriveReceiptFromMutationResult,
@@ -21,11 +21,38 @@ import {
 import { useArchitectPostActionReceipt } from '@/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt';
 import { ArchitectPostActionHandoff } from '@/features/architect/GMDashboard/components/ArchitectPostActionHandoff';
 import { useScenarioActivityRail } from '@/features/architect/GMDashboard/hooks/useScenarioActivityRail';
+import { useWorldTeamEvents } from '@/features/architect/history/hooks/useWorldTeamEvents';
 import type { PersistMutationResult } from '@/features/architect/GMDashboard/hooks/useArchitectActions.types';
 import type { ArchitectPostActionReceipt } from '@/features/architect/GMDashboard/postActionHandoff/types';
 
+const firestoreGetDocsSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('@/firebaseConfig', () => ({
+  db: {},
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn((...args: unknown[]) => ({ type: 'collection', args })),
+  getDocs: firestoreGetDocsSpy,
+  limit: vi.fn((count: number) => ({ type: 'limit', count })),
+  orderBy: vi.fn((field: string, direction: string) => ({
+    type: 'orderBy',
+    field,
+    direction,
+  })),
+  query: vi.fn((...args: unknown[]) => ({ type: 'query', args })),
+  startAfter: vi.fn((doc: unknown) => ({ type: 'startAfter', doc })),
+  where: vi.fn((field: string, operator: string, value: unknown) => ({
+    type: 'where',
+    field,
+    operator,
+    value,
+  })),
+}));
+
 afterEach(() => {
   cleanup();
+  firestoreGetDocsSpy.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -35,6 +62,8 @@ afterEach(() => {
 describe('Stage 2B — deriveReceiptFromMutationResult', () => {
   const baseSuccessResult: PersistMutationResult = {
     success: true,
+    appliedToLocalState: true,
+    persistedToWorld: true,
     changedTeams: [
       { teamCode: 'LAL', team: {} as never },
       { teamCode: 'BOS', team: {} as never },
@@ -86,6 +115,24 @@ describe('Stage 2B — deriveReceiptFromMutationResult', () => {
     ).toBeNull();
   });
 
+  it('returns null for explicitly skipped or non-persisted results', () => {
+    expect(
+      deriveReceiptFromMutationResult({
+        mutationType: 'executeTrade',
+        result: { ...baseSuccessResult, skipped: true },
+        primaryTeamCode: 'LAL',
+      })
+    ).toBeNull();
+
+    expect(
+      deriveReceiptFromMutationResult({
+        mutationType: 'executeTrade',
+        result: { ...baseSuccessResult, persistedToWorld: false },
+        primaryTeamCode: 'LAL',
+      })
+    ).toBeNull();
+  });
+
   it('returns null when result is missing entirely', () => {
     expect(
       deriveReceiptFromMutationResult({
@@ -99,6 +146,8 @@ describe('Stage 2B — deriveReceiptFromMutationResult', () => {
   it('falls back to writesSummary.teamCodes when changedTeams is empty', () => {
     const result: PersistMutationResult = {
       success: true,
+      appliedToLocalState: true,
+      persistedToWorld: true,
       changedTeams: [],
       writesSummary: {
         teamsPatched: 1,
@@ -233,6 +282,23 @@ describe('Stage 2B — useArchitectPostActionReceipt', () => {
     expect(result.current.generation).toBe(generationAfterPublish);
   });
 
+  it('clears the active receipt when the world/team scope changes', () => {
+    const { result, rerender } = renderHook(
+      ({ scopeKey }: { scopeKey: string }) =>
+        useArchitectPostActionReceipt(scopeKey),
+      { initialProps: { scopeKey: 'world_1:LAL' } }
+    );
+    act(() => {
+      result.current.publish(makeReceipt());
+    });
+    const generationAfterPublish = result.current.generation;
+
+    rerender({ scopeKey: 'world_1:BOS' });
+
+    expect(result.current.receipt).toBeNull();
+    expect(result.current.generation).toBe(generationAfterPublish);
+  });
+
   it('publishing null is a no-op', () => {
     const { result } = renderHook(() => useArchitectPostActionReceipt());
     act(() => {
@@ -288,7 +354,7 @@ describe('Stage 2B — ArchitectPostActionHandoff', () => {
 
     expect(screen.getByTestId('architect-post-action-handoff')).toBeInTheDocument();
     expect(screen.getByTestId('post-action-handoff-status-chip')).toHaveTextContent(
-      'Committed'
+      'Committed world'
     );
     expect(screen.getByTestId('post-action-handoff-headline')).toHaveTextContent(
       'Trade applied'
@@ -382,32 +448,18 @@ describe('Stage 2B — ArchitectPostActionHandoff', () => {
 // useScenarioActivityRail — refresh seam in sandbox/no-world mode
 // ---------------------------------------------------------------------------
 
-// Mock the Firestore-backed events fetch so we can assert the rail does not
-// re-trigger fetches in sandbox/no-world mode, but does when worldId is set.
-const fetchSpy = vi.fn(async () => ({
-  events: [],
-  hasMore: false,
-  paginationState: {
-    contracts: {} as never,
-    seenContracts: [] as never,
-  } as never,
-  resolution: 'empty' as const,
-}));
-
-vi.mock('@/features/architect/history/hooks/useWorldTeamEvents', async () => {
-  const actual = await vi.importActual<
-    typeof import('@/features/architect/history/hooks/useWorldTeamEvents')
-  >('@/features/architect/history/hooks/useWorldTeamEvents');
-  return {
-    ...actual,
-    fetchWorldTeamEvents: (...args: unknown[]) => fetchSpy(...(args as [])),
-  };
+const makeWorldEventDoc = (id: string, data: Record<string, unknown> = {}) => ({
+  id,
+  data: () => data,
 });
+
+const makeWorldEventsSnapshot = (
+  docs: Array<ReturnType<typeof makeWorldEventDoc>>
+) => ({ docs });
 
 describe('Stage 2B — useScenarioActivityRail refresh seam', () => {
   it('does not fetch in sandbox/no-world mode regardless of refreshKey', async () => {
-    fetchSpy.mockClear();
-    const { rerender } = renderHook(
+    const { result, rerender } = renderHook(
       ({ refreshKey }: { refreshKey: number }) =>
         useScenarioActivityRail({
           worldId: null,
@@ -419,7 +471,8 @@ describe('Stage 2B — useScenarioActivityRail refresh seam', () => {
     rerender({ refreshKey: 1 });
     rerender({ refreshKey: 2 });
     // Sandbox status — no fetch should ever be issued.
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.railState.status).toBe('sandbox');
+    expect(firestoreGetDocsSpy).not.toHaveBeenCalled();
   });
 
   it('returns sandbox rail state when worldId is missing', () => {
@@ -431,5 +484,74 @@ describe('Stage 2B — useScenarioActivityRail refresh seam', () => {
     );
     expect(result.current.railState.status).toBe('sandbox');
     expect(typeof result.current.refetch).toBe('function');
+  });
+
+  it('preserves previous committed entries while refreshKey refetches', async () => {
+    let resolveRefresh:
+      | ((snapshot: ReturnType<typeof makeWorldEventsSnapshot>) => void)
+      | null = null;
+    firestoreGetDocsSpy
+      .mockResolvedValueOnce(
+        makeWorldEventsSnapshot([
+          makeWorldEventDoc('evt_existing', {
+            occurredAt: '2026-05-01T00:00:00.000Z',
+            teamCodes: ['LAL'],
+            summary: 'Existing committed event',
+          }),
+        ])
+      )
+      .mockResolvedValueOnce(makeWorldEventsSnapshot([]))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          })
+      )
+      .mockResolvedValueOnce(makeWorldEventsSnapshot([]));
+
+    const { result, rerender } = renderHook(
+      ({ refreshKey }: { refreshKey: number }) =>
+        useWorldTeamEvents({
+          worldId: 'world_1',
+          teamCode: 'LAL',
+          limit: 1,
+          refreshKey,
+        }),
+      { initialProps: { refreshKey: 0 } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.events.map((event) => event.id)).toEqual([
+        'evt_existing',
+      ]);
+    });
+
+    rerender({ refreshKey: 1 });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+    expect(result.current.events.map((event) => event.id)).toEqual([
+      'evt_existing',
+    ]);
+
+    act(() => {
+      resolveRefresh?.(
+        makeWorldEventsSnapshot([
+          makeWorldEventDoc('evt_refreshed', {
+            occurredAt: '2026-05-02T00:00:00.000Z',
+            teamCodes: ['LAL'],
+            summary: 'Refreshed committed event',
+          }),
+        ])
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.events.map((event) => event.id)).toEqual([
+        'evt_refreshed',
+      ]);
+      expect(result.current.loading).toBe(false);
+    });
   });
 });

--- a/src/tests/architect/stage2b.postActionHandoff.test.tsx
+++ b/src/tests/architect/stage2b.postActionHandoff.test.tsx
@@ -1,0 +1,435 @@
+/**
+ * FILE: src/tests/architect/stage2b.postActionHandoff.test.tsx
+ * PURPOSE: Targeted tests for Stage 2B post-action handoff: receipt derivation,
+ *          handoff strip rendering, navigation buttons, dismiss, and the
+ *          activity-rail refresh seam.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Stage 1 (deriveActivityRailState) and Stage 2A (navigation) tests live in
+ * their own files; this file only covers Stage 2B surface area.
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import {
+  deriveReceiptFromMutationResult,
+  deriveSeasonAdvanceReceipt,
+  kindForMutationType,
+} from '@/features/architect/GMDashboard/postActionHandoff/types';
+import { useArchitectPostActionReceipt } from '@/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt';
+import { ArchitectPostActionHandoff } from '@/features/architect/GMDashboard/components/ArchitectPostActionHandoff';
+import { useScenarioActivityRail } from '@/features/architect/GMDashboard/hooks/useScenarioActivityRail';
+import type { PersistMutationResult } from '@/features/architect/GMDashboard/hooks/useArchitectActions.types';
+import type { ArchitectPostActionReceipt } from '@/features/architect/GMDashboard/postActionHandoff/types';
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// deriveReceiptFromMutationResult — pure derivation
+// ---------------------------------------------------------------------------
+
+describe('Stage 2B — deriveReceiptFromMutationResult', () => {
+  const baseSuccessResult: PersistMutationResult = {
+    success: true,
+    changedTeams: [
+      { teamCode: 'LAL', team: {} as never },
+      { teamCode: 'BOS', team: {} as never },
+    ],
+    changedPlayers: [{ playerId: 'player_1', player: {} as never }],
+    event: { eventId: 'evt_abc', id: 'evt_abc' },
+  };
+
+  it('derives a trade receipt from a successful executeTrade result', () => {
+    const receipt = deriveReceiptFromMutationResult({
+      mutationType: 'executeTrade',
+      result: baseSuccessResult,
+      primaryTeamCode: 'LAL',
+    });
+
+    expect(receipt).not.toBeNull();
+    expect(receipt!.kind).toBe('trade');
+    expect(receipt!.headline).toBe('Trade applied');
+    expect(receipt!.eventId).toBe('evt_abc');
+    expect(receipt!.changedTeamCodes).toEqual(['LAL', 'BOS']);
+    expect(receipt!.primaryTeamCode).toBe('LAL');
+    expect(receipt!.primaryPlayerIds).toEqual(['player_1']);
+    expect(receipt!.authority).toBe('committed-world');
+  });
+
+  it('derives a signing receipt from a successful signFreeAgent result', () => {
+    const receipt = deriveReceiptFromMutationResult({
+      mutationType: 'signFreeAgent',
+      result: baseSuccessResult,
+      primaryTeamCode: 'LAL',
+    });
+
+    expect(receipt).not.toBeNull();
+    expect(receipt!.kind).toBe('signing');
+    expect(receipt!.headline).toBe('Free agent signed');
+  });
+
+  it('returns null when the result is not successful', () => {
+    const failure: PersistMutationResult = {
+      ...baseSuccessResult,
+      success: false,
+    };
+    expect(
+      deriveReceiptFromMutationResult({
+        mutationType: 'executeTrade',
+        result: failure,
+        primaryTeamCode: 'LAL',
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when result is missing entirely', () => {
+    expect(
+      deriveReceiptFromMutationResult({
+        mutationType: 'executeTrade',
+        result: undefined as unknown as PersistMutationResult,
+        primaryTeamCode: 'LAL',
+      })
+    ).toBeNull();
+  });
+
+  it('falls back to writesSummary.teamCodes when changedTeams is empty', () => {
+    const result: PersistMutationResult = {
+      success: true,
+      changedTeams: [],
+      writesSummary: {
+        teamsPatched: 1,
+        teamsWritten: 1,
+        teamCodes: ['LAL'],
+        playersPatched: 0,
+        playersWritten: 0,
+        playerIds: [],
+        entitlementsPatched: 0,
+        entitlementsWritten: 0,
+        entitlementIds: [],
+        eventsWritten: 1,
+        eventWritten: true,
+        eventIds: ['evt_abc'],
+        worldMetadataPatched: 0,
+        worldStatsUpdated: false,
+      },
+      event: { eventId: 'evt_abc' },
+    };
+    const receipt = deriveReceiptFromMutationResult({
+      mutationType: 'executeTrade',
+      result,
+      primaryTeamCode: 'LAL',
+    });
+    expect(receipt!.changedTeamCodes).toEqual(['LAL']);
+  });
+
+  it('maps unknown mutation type to contractAction kind', () => {
+    expect(kindForMutationType('mysteryMutation')).toBe('contractAction');
+  });
+
+  it('preserves primaryTeamCode even if not present in changedTeams', () => {
+    const receipt = deriveReceiptFromMutationResult({
+      mutationType: 'executeTrade',
+      result: baseSuccessResult,
+      primaryTeamCode: 'MIA',
+    });
+    expect(receipt!.primaryTeamCode).toBe('MIA');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveSeasonAdvanceReceipt
+// ---------------------------------------------------------------------------
+
+describe('Stage 2B — deriveSeasonAdvanceReceipt', () => {
+  it('derives a seasonAdvance receipt with the next season label', () => {
+    const receipt = deriveSeasonAdvanceReceipt({
+      aftermath: {
+        nextWorldSeason: '2026-27',
+        nextViewingYear: 2027,
+        offseasonSummary: {},
+        committedTeamCapSheet: {} as never,
+      } as never,
+      primaryTeamCode: 'LAL',
+    });
+    expect(receipt).not.toBeNull();
+    expect(receipt!.kind).toBe('seasonAdvance');
+    expect(receipt!.headline).toBe('Season advanced to 2026-27');
+    expect(receipt!.changedTeamCodes).toEqual(['LAL']);
+  });
+
+  it('returns null when aftermath is missing nextWorldSeason', () => {
+    expect(
+      deriveSeasonAdvanceReceipt({
+        aftermath: { nextWorldSeason: null } as never,
+        primaryTeamCode: 'LAL',
+      })
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useArchitectPostActionReceipt
+// ---------------------------------------------------------------------------
+
+describe('Stage 2B — useArchitectPostActionReceipt', () => {
+  const makeReceipt = (
+    overrides: Partial<ArchitectPostActionReceipt> = {}
+  ): ArchitectPostActionReceipt => ({
+    kind: 'trade',
+    eventId: 'evt_1',
+    occurredAt: null,
+    headline: 'Trade applied',
+    changedTeamCodes: ['LAL'],
+    primaryTeamCode: 'LAL',
+    primaryPlayerIds: [],
+    authority: 'committed-world',
+    ...overrides,
+  });
+
+  it('publishes a receipt and increments generation', () => {
+    const { result } = renderHook(() => useArchitectPostActionReceipt());
+    expect(result.current.receipt).toBeNull();
+    expect(result.current.generation).toBe(0);
+
+    act(() => {
+      result.current.publish(makeReceipt());
+    });
+
+    expect(result.current.receipt?.headline).toBe('Trade applied');
+    expect(result.current.generation).toBe(1);
+  });
+
+  it('replaces the prior receipt on a subsequent publish', () => {
+    const { result } = renderHook(() => useArchitectPostActionReceipt());
+    act(() => {
+      result.current.publish(makeReceipt({ headline: 'Trade applied' }));
+    });
+    act(() => {
+      result.current.publish(
+        makeReceipt({ kind: 'signing', headline: 'Free agent signed' })
+      );
+    });
+
+    expect(result.current.receipt?.headline).toBe('Free agent signed');
+    expect(result.current.generation).toBe(2);
+  });
+
+  it('dismiss() clears the receipt but does not bump generation', () => {
+    const { result } = renderHook(() => useArchitectPostActionReceipt());
+    act(() => {
+      result.current.publish(makeReceipt());
+    });
+    const generationAfterPublish = result.current.generation;
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.receipt).toBeNull();
+    expect(result.current.generation).toBe(generationAfterPublish);
+  });
+
+  it('publishing null is a no-op', () => {
+    const { result } = renderHook(() => useArchitectPostActionReceipt());
+    act(() => {
+      result.current.publish(null);
+    });
+    expect(result.current.receipt).toBeNull();
+    expect(result.current.generation).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ArchitectPostActionHandoff component
+// ---------------------------------------------------------------------------
+
+describe('Stage 2B — ArchitectPostActionHandoff', () => {
+  const makeReceipt = (
+    overrides: Partial<ArchitectPostActionReceipt> = {}
+  ): ArchitectPostActionReceipt => ({
+    kind: 'trade',
+    eventId: 'evt_1',
+    occurredAt: '2026-05-01T00:00:00.000Z',
+    headline: 'Trade applied',
+    changedTeamCodes: ['LAL', 'BOS'],
+    primaryTeamCode: 'LAL',
+    primaryPlayerIds: ['player_1'],
+    authority: 'committed-world',
+    ...overrides,
+  });
+
+  it('renders nothing when receipt is null', () => {
+    const { container } = render(
+      <ArchitectPostActionHandoff
+        receipt={null}
+        onNavigateToCapSheet={vi.fn()}
+        onNavigateToRoster={vi.fn()}
+        onNavigateToHistory={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the committed receipt headline and chips', () => {
+    render(
+      <ArchitectPostActionHandoff
+        receipt={makeReceipt()}
+        onNavigateToCapSheet={vi.fn()}
+        onNavigateToRoster={vi.fn()}
+        onNavigateToHistory={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('architect-post-action-handoff')).toBeInTheDocument();
+    expect(screen.getByTestId('post-action-handoff-status-chip')).toHaveTextContent(
+      'Committed'
+    );
+    expect(screen.getByTestId('post-action-handoff-headline')).toHaveTextContent(
+      'Trade applied'
+    );
+    expect(screen.getByTestId('post-action-handoff-team-chip-LAL')).toBeInTheDocument();
+    expect(screen.getByTestId('post-action-handoff-team-chip-BOS')).toBeInTheDocument();
+  });
+
+  it('caps team chips at 3 and shows +N overflow', () => {
+    render(
+      <ArchitectPostActionHandoff
+        receipt={makeReceipt({
+          changedTeamCodes: ['LAL', 'BOS', 'MIA', 'GSW', 'NYK'],
+        })}
+        onNavigateToCapSheet={vi.fn()}
+        onNavigateToRoster={vi.fn()}
+        onNavigateToHistory={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('post-action-handoff-team-chip-LAL')).toBeInTheDocument();
+    expect(screen.getByTestId('post-action-handoff-team-chip-MIA')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('post-action-handoff-team-chip-GSW')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('post-action-handoff-team-chips-overflow')
+    ).toHaveTextContent('+2');
+  });
+
+  it('navigation buttons call the matching callbacks', () => {
+    const onNavigateToCapSheet = vi.fn();
+    const onNavigateToRoster = vi.fn();
+    const onNavigateToHistory = vi.fn();
+    const onDismiss = vi.fn();
+
+    render(
+      <ArchitectPostActionHandoff
+        receipt={makeReceipt()}
+        onNavigateToCapSheet={onNavigateToCapSheet}
+        onNavigateToRoster={onNavigateToRoster}
+        onNavigateToHistory={onNavigateToHistory}
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('post-action-handoff-nav-cap'));
+    expect(onNavigateToCapSheet).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('post-action-handoff-nav-roster'));
+    expect(onNavigateToRoster).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('post-action-handoff-nav-history'));
+    expect(onNavigateToHistory).toHaveBeenCalledTimes(1);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('dismiss button calls onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(
+      <ArchitectPostActionHandoff
+        receipt={makeReceipt()}
+        onNavigateToCapSheet={vi.fn()}
+        onNavigateToRoster={vi.fn()}
+        onNavigateToHistory={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    );
+    fireEvent.click(screen.getByTestId('post-action-handoff-dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without timestamp when occurredAt is null', () => {
+    render(
+      <ArchitectPostActionHandoff
+        receipt={makeReceipt({ occurredAt: null })}
+        onNavigateToCapSheet={vi.fn()}
+        onNavigateToRoster={vi.fn()}
+        onNavigateToHistory={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(
+      screen.queryByTestId('post-action-handoff-date')
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useScenarioActivityRail — refresh seam in sandbox/no-world mode
+// ---------------------------------------------------------------------------
+
+// Mock the Firestore-backed events fetch so we can assert the rail does not
+// re-trigger fetches in sandbox/no-world mode, but does when worldId is set.
+const fetchSpy = vi.fn(async () => ({
+  events: [],
+  hasMore: false,
+  paginationState: {
+    contracts: {} as never,
+    seenContracts: [] as never,
+  } as never,
+  resolution: 'empty' as const,
+}));
+
+vi.mock('@/features/architect/history/hooks/useWorldTeamEvents', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/features/architect/history/hooks/useWorldTeamEvents')
+  >('@/features/architect/history/hooks/useWorldTeamEvents');
+  return {
+    ...actual,
+    fetchWorldTeamEvents: (...args: unknown[]) => fetchSpy(...(args as [])),
+  };
+});
+
+describe('Stage 2B — useScenarioActivityRail refresh seam', () => {
+  it('does not fetch in sandbox/no-world mode regardless of refreshKey', async () => {
+    fetchSpy.mockClear();
+    const { rerender } = renderHook(
+      ({ refreshKey }: { refreshKey: number }) =>
+        useScenarioActivityRail({
+          worldId: null,
+          teamCode: 'LAL',
+          refreshKey,
+        }),
+      { initialProps: { refreshKey: 0 } }
+    );
+    rerender({ refreshKey: 1 });
+    rerender({ refreshKey: 2 });
+    // Sandbox status — no fetch should ever be issued.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns sandbox rail state when worldId is missing', () => {
+    const { result } = renderHook(() =>
+      useScenarioActivityRail({
+        worldId: null,
+        teamCode: 'LAL',
+      })
+    );
+    expect(result.current.railState.status).toBe('sandbox');
+    expect(typeof result.current.refetch).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Adds Stage 2B post-action consequence handoffs for Architect Operating Experience.

Stage 1 made Architect visually continuous. Stage 2A made it navigationally continuous. Stage 2B now explains what just happened after successful committed actions and refreshes committed activity without inventing event truth.

## Added

- `ArchitectPostActionReceipt` model and pure derivation helpers
- session-scoped post-action receipt state hook
- `ArchitectPostActionHandoff` strip under the workspace header
- receipt publication for trade apply, free-agent signing, generic committed contract-action mutation results, and offseason season advance
- activity rail refresh seam via receipt generation key
- just-committed event highlight when the refreshed rail contains the receipt event id

## Review Corrections

- Receipts now clear on active world/team scope changes.
- Activity rail refresh preserves existing committed entries while refetching instead of blanking stale committed truth.
- Receipts no longer derive from explicitly skipped, non-persisted, or non-applied mutation results.
- Receipt authority is required as `committed-world`.
- Handoff chip copy now says `Committed world`.

## Guardrails

- No mutation authority moved
- No Firestore writes added
- No schema changes
- No committed-write path changes
- No validation behavior changes
- No baseline/cap/apron delta claims
- No scenario comparison
- No draft ledger
- No History modal deep-linking
- No local/pending/optimistic rail entries
- `mutationPipeline`, `seasonManager`, and `worldManager` untouched

## Validation Reported

- Stage 2B + Stage 1/2A focused tests: passed
- focused UI tests: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `git diff --check`: passed

`npm run test:diff -- --reporter=dot` selected the broad Architect tier and hit unrelated pre-existing source-scan/guardrail failures, so focused validation was used instead. Full suite was not run because `RUN FULL SUITE` was not authorized.

## Explicitly Deferred

- History modal deep-linking
- offseason sticky reopen badge
- baseline/cap-delta/apron-crossing claims
- scenario comparison
- draft asset ledger
- local/pending/optimistic rail entries
- broad toast refactor