### PR TITLE
Add Architect player roster continuity

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -44,6 +44,7 @@ GMDashboard/
     useScenarioActivityRail.ts
   offerSheetTypes.ts
   postActionHandoff/
+    playerFocus.ts
     types.ts
   sections/
     CapSheetSection.tsx
@@ -489,5 +490,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-05-20T06:42:43.055Z*
+*Generated on: 2026-05-21T03:15:58.671Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -212,6 +212,13 @@ export const GMDashboard = () => {
   const postActionReceipt = useArchitectPostActionReceipt(
     postActionReceiptScopeKey
   );
+  // Stage 2C: derive a session-scoped focused player id from the most recent
+  // committed post-action receipt. Visual-only — receipt dismiss/clear
+  // automatically clears the highlight. Multi-player receipts (trades) use
+  // the first primary id; matching is name-fallback tolerant in
+  // playerMatchesFocus.
+  const focusedPlayerId =
+    postActionReceipt.receipt?.primaryPlayerIds?.[0] ?? null;
 
   const actions = useArchitectActions({
     teamId: normalizedTeamId,
@@ -342,6 +349,7 @@ export const GMDashboard = () => {
     manualCapSheetMutationAuthority,
     playersMap,
     capSheetDevFixtureControls: actions.capSheetDevTools,
+    highlightPlayerId: focusedPlayerId,
   };
   const tradeSectionSurface: TradeSectionProps = {
     primaryTeam: normalizedTeamId,
@@ -559,6 +567,12 @@ export const GMDashboard = () => {
             teamCapSheet={teamCapSheet}
             playersMap={playersMap}
             teamId={normalizedTeamId}
+            onOpenPlayerContractModal={(player) =>
+              actions.handleEditContract(
+                player as Parameters<typeof actions.handleEditContract>[0]
+              )
+            }
+            highlightPlayerId={focusedPlayerId}
           />
         )}
 
@@ -581,6 +595,7 @@ export const GMDashboard = () => {
             }
             playersMap={playersMap}
             getRulesProfileForYear={getProfileForYear}
+            highlightPlayerId={focusedPlayerId}
           />
         )}
 

--- a/src/features/architect/GMDashboard/postActionHandoff/playerFocus.ts
+++ b/src/features/architect/GMDashboard/postActionHandoff/playerFocus.ts
@@ -82,6 +82,15 @@ export const collectPlayerFocusKeys = (
  * permissive across `id` / `player_id` / `bio.playerId` and a normalized
  * name fallback because committed receipts only carry a single
  * `playerId` token per change.
+ *
+ * Matching is **exact-equality only** on either a direct key or a
+ * normalized-name key — never a substring match. Empty / whitespace
+ * focus ids are treated as no-match (early return).
+ *
+ * Caveat: if the focus token happens to be a player name and two
+ * roster members share the exact same normalized full name, both will
+ * be highlighted. This is acceptable for a visual signal and is by
+ * design — the receipt is the authority, not the highlight.
  */
 export const playerMatchesFocus = (
   player: FocusablePlayerIdentity | null | undefined,

--- a/src/features/architect/GMDashboard/postActionHandoff/playerFocus.ts
+++ b/src/features/architect/GMDashboard/postActionHandoff/playerFocus.ts
@@ -1,0 +1,103 @@
+/**
+ * FILE: src/features/architect/GMDashboard/postActionHandoff/playerFocus.ts
+ * PURPOSE: Stage 2C player-focus identity matching helpers (visual-only).
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * `focusedPlayerId` is the optional id of the player that the dashboard
+ * wants the active section surfaces (Roster, Cap Sheet, Full Cap Table)
+ * to render as "just changed". It is derived from a Stage 2B post-action
+ * receipt and is purely a visual highlight signal — no mutation, no
+ * Firestore reads/writes, no derivation of cap/roster truth.
+ */
+
+type FocusablePlayerIdentity = {
+  id?: string | number | null;
+  player_id?: string | number | null;
+  playerId?: string | number | null;
+  name?: string | null;
+  displayName?: string | null;
+  bio?:
+    | {
+        playerId?: string | number | null;
+        displayName?: string | null;
+      }
+    | null;
+};
+
+const COMBINING_MARKS = /[̀-ͯ]/g;
+const NON_ALPHANUMERIC = /[^a-zA-Z0-9]/g;
+
+const toStringKey = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+};
+
+const normalizeNameKey = (value: unknown): string | null => {
+  const key = toStringKey(value);
+  if (!key) return null;
+  const normalized = key
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .replace(NON_ALPHANUMERIC, '')
+    .toLowerCase();
+  return normalized || null;
+};
+
+export const collectPlayerFocusKeys = (
+  player: FocusablePlayerIdentity | null | undefined
+): string[] => {
+  if (!player) return [];
+  const direct = [
+    player.id,
+    player.player_id,
+    player.playerId,
+    player.bio?.playerId,
+    player.name,
+    player.displayName,
+    player.bio?.displayName,
+  ]
+    .map(toStringKey)
+    .filter((k): k is string => Boolean(k));
+
+  const normalized = [
+    player.name,
+    player.displayName,
+    player.bio?.displayName,
+  ]
+    .map(normalizeNameKey)
+    .filter((k): k is string => Boolean(k));
+
+  return Array.from(new Set([...direct, ...normalized]));
+};
+
+/**
+ * Returns true when the candidate player identity matches the focus id
+ * derived from a Stage 2B post-action receipt. Matching is intentionally
+ * permissive across `id` / `player_id` / `bio.playerId` and a normalized
+ * name fallback because committed receipts only carry a single
+ * `playerId` token per change.
+ */
+export const playerMatchesFocus = (
+  player: FocusablePlayerIdentity | null | undefined,
+  focusedPlayerId: string | null | undefined
+): boolean => {
+  if (!focusedPlayerId || !player) return false;
+  const focusKey = toStringKey(focusedPlayerId);
+  if (!focusKey) return false;
+  const focusKeys = new Set<string>();
+  focusKeys.add(focusKey);
+  const normalizedFocusKey = normalizeNameKey(focusedPlayerId);
+  if (normalizedFocusKey) focusKeys.add(normalizedFocusKey);
+
+  const candidateKeys = collectPlayerFocusKeys(player);
+  for (const key of candidateKeys) {
+    if (focusKeys.has(key)) return true;
+  }
+  return false;
+};

--- a/src/features/architect/GMDashboard/sections/CapSheetSection.tsx
+++ b/src/features/architect/GMDashboard/sections/CapSheetSection.tsx
@@ -24,6 +24,7 @@ type ForwardedCapSheetProps = Pick<
   | 'teamCapSheet'
   | 'onOpenPlayerContractModal'
   | 'manualCapSheetMutationAuthority'
+  | 'highlightPlayerId'
 >;
 
 type DevFixtureAction = (() => unknown) | null;
@@ -70,6 +71,7 @@ const CapSheetSection = ({
   onClearCapSheetFixtures = null,
   hasInjectedCapSheetFixtures = false,
   capSheetDevFixtureControls = null,
+  highlightPlayerId = null,
 }: CapSheetSectionProps) => {
   const [selectedYear, setSelectedYear] = useState(currentYear);
 
@@ -172,6 +174,7 @@ const CapSheetSection = ({
           onSelectedYearChange={setSelectedYear}
           onOpenPlayerContractModal={onOpenPlayerContractModal}
           manualCapSheetMutationAuthority={manualCapSheetMutationAuthority}
+          highlightPlayerId={highlightPlayerId}
         />
       </section>
 

--- a/src/features/architect/GMDashboard/sections/CapTableSection.tsx
+++ b/src/features/architect/GMDashboard/sections/CapTableSection.tsx
@@ -7,6 +7,7 @@ type ForwardedCapTableProps = Pick<
   | 'onLaunchContractAction'
   | 'onRenounceCapHold'
   | 'getRulesProfileForYear'
+  | 'highlightPlayerId'
 >;
 
 type CapTableSectionProps = ForwardedCapTableProps & {
@@ -22,6 +23,7 @@ const CapTableSection = ({
   onRenounceCapHold,
   playersMap,
   getRulesProfileForYear,
+  highlightPlayerId = null,
 }: CapTableSectionProps) => (
   <CapSheetFull
     teamCapSheet={teamCapSheet}
@@ -30,6 +32,7 @@ const CapTableSection = ({
     onLaunchContractAction={onLaunchContractAction}
     onRenounceCapHold={onRenounceCapHold}
     getRulesProfileForYear={getRulesProfileForYear}
+    highlightPlayerId={highlightPlayerId}
   />
 );
 

--- a/src/features/architect/GMDashboard/sections/RosterSection.tsx
+++ b/src/features/architect/GMDashboard/sections/RosterSection.tsx
@@ -1,7 +1,12 @@
 /**
- * FILE: src/features/architect/GMDashboard/sections/RosterSection.jsx
+ * FILE: src/features/architect/GMDashboard/sections/RosterSection.tsx
  * PURPOSE: Render the GM dashboard roster section via RosterVisual.
  * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Stage 2C: forwards the dashboard-owned `onOpenPlayerContractModal`
+ * callback (routed through `useArchitectActions.handleEditContract`)
+ * and the receipt-derived `highlightPlayerId` into RosterVisual. No
+ * mutation authority is added at this layer — the modal owns commits.
  *
  * HISTORY:
  *  - 2025-12-12: Header added for documentation compliance (single-step task)
@@ -16,17 +21,43 @@ import {
   type RosterVisualDetailsMap,
 } from '@/features/architect/shared/RosterVisual';
 
+type RosterPlayerLike = Record<string, unknown>;
+
 type RosterSectionProps = {
   teamCapSheet: RosterVisualCapSheetInput | null | undefined;
   playersMap?: RosterVisualDetailsMap;
   teamId?: string | null;
+  /**
+   * Stage 2C: dashboard-owned contract-modal opener. When provided,
+   * clicking a roster card opens the existing EditContractModal
+   * through `useArchitectActions.handleEditContract`. No mutation
+   * authority is created at this layer.
+   */
+  onOpenPlayerContractModal?: ((player: RosterPlayerLike) => void) | null;
+  /**
+   * Stage 2C: receipt-derived focused player id. Roster cards matching
+   * this id render a non-mutating "just changed" outline.
+   */
+  highlightPlayerId?: string | null;
 };
 
-const RosterSection = ({ teamCapSheet, playersMap, teamId }: RosterSectionProps) => (
+const RosterSection = ({
+  teamCapSheet,
+  playersMap,
+  teamId,
+  onOpenPlayerContractModal,
+  highlightPlayerId = null,
+}: RosterSectionProps) => (
   <RosterVisual
     teamCapSheet={teamCapSheet}
     playersMap={playersMap}
     teamId={teamId}
+    onSelectPlayer={
+      onOpenPlayerContractModal
+        ? (player) => onOpenPlayerContractModal(player as RosterPlayerLike)
+        : null
+    }
+    highlightPlayerId={highlightPlayerId}
   />
 );
 

--- a/src/features/architect/capSheet/CapSheet/CapSheet.tsx
+++ b/src/features/architect/capSheet/CapSheet/CapSheet.tsx
@@ -31,6 +31,7 @@ import { getCapPercentage } from '@/features/architect/utils/basicArchitectUtils
 import { usePlayerRulesProfiles } from '@/features/architect/hooks/usePlayerRulesProfiles';
 import { ManageDeadMoneyModal } from '@/features/architect/capSheet/modals/ManageDeadMoneyModal';
 import { ManageExceptionsModal } from '@/features/architect/capSheet/modals/ManageExceptionsModal';
+import { playerMatchesFocus } from '@/features/architect/GMDashboard/postActionHandoff/playerFocus';
 
 type NumericLike = number | string | null | undefined;
 type RulesProfileLike = PlayerRulesProfile | null;
@@ -137,6 +138,12 @@ type CapSheetProps = {
   // Legacy alias kept temporarily so older tests/helpers do not silently break.
   onSelectPlayer?: ((player: CapSheetPlayerLike) => void) | null;
   manualCapSheetMutationAuthority?: ManualCapSheetMutationAuthority | null;
+  /**
+   * Stage 2C: receipt-derived focused player id. The matching player
+   * row renders a non-mutating "just changed" outline. Visual only —
+   * no cap totals impact, no row reordering, no action behavior change.
+   */
+  highlightPlayerId?: string | null;
 };
 
 const CAP_SHEET_SURFACE_LABELS = {
@@ -154,6 +161,7 @@ export const CapSheet = ({
   onOpenPlayerContractModal,
   onSelectPlayer,
   manualCapSheetMutationAuthority,
+  highlightPlayerId = null,
 }: CapSheetProps) => {
   const [internalSelectedYear, setInternalSelectedYear] = useState(currentYear);
   const [showCapHolds, setShowCapHolds] = useState(false);
@@ -495,11 +503,18 @@ export const CapSheet = ({
             // Use canonicalTotals.salaryCap (SSOT) for cap % to match totals display
             const capPct = getCapPercentage(capHit, canonicalTotals.salaryCap || 1);
             const capPctDisplay = capPct ? `${capPct}%` : '—';
+            const isHighlighted = playerMatchesFocus(player, highlightPlayerId);
+            const rowHighlightClass = isHighlighted
+              ? 'ring-1 ring-inset ring-green-400/40 bg-green-500/[0.04]'
+              : 'hover:bg-white/[0.02]';
 
             return (
               <div
                 key={`${player.name}-${idx}`}
-                className="grid grid-cols-[2fr,0.8fr,0.6fr,1.2fr,0.8fr,1.2fr,1.5fr] gap-2 px-4 py-2 items-center hover:bg-white/[0.02] transition-colors group"
+                className={`grid grid-cols-[2fr,0.8fr,0.6fr,1.2fr,0.8fr,1.2fr,1.5fr] gap-2 px-4 py-2 items-center transition-colors group ${rowHighlightClass}`}
+                data-testid={
+                  isHighlighted ? 'cap-sheet-player-row-highlighted' : undefined
+                }
               >
                 <div className="font-medium text-xs text-white/90 truncate">
                   <button

--- a/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
+++ b/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/features/architect/utils/contractUtils';
 import { computeTeamCapTotals } from '@/features/architect/utils/capTotals/computeTeamCapTotals';
 import { BirdRightsIcon } from '@/shared/components/BirdRightsIcon';
+import { playerMatchesFocus } from '@/features/architect/GMDashboard/postActionHandoff/playerFocus';
 
 type NumericLike = number | string | null | undefined;
 type RulesProfileLike = PlayerRulesProfile | null;
@@ -80,6 +81,12 @@ type CapSheetFullProps = {
   getRulesProfileForYear?:
     | ((player: CapSheetFullPlayerLike, year: number) => RulesProfileLike)
     | null;
+  /**
+   * Stage 2C: receipt-derived focused player id. The matching player
+   * row (sticky name column + year cells) renders a non-mutating
+   * "just changed" outline. Visual only.
+   */
+  highlightPlayerId?: string | null;
 };
 
 const CAP_SHEET_FULL_SURFACE_LABELS = {
@@ -171,6 +178,7 @@ export const CapSheetFull = ({
   onSelectPlayer,
   onActionClick,
   getRulesProfileForYear = null,
+  highlightPlayerId = null,
 }: CapSheetFullProps) => {
   const [showCapHolds, setShowCapHolds] = useState(false);
   const openPlayerContractModal =
@@ -332,10 +340,23 @@ export const CapSheetFull = ({
                     const extensionEligibleYear = getExtensionEligibleYear(
                       profileForCurrentYear
                     );
+                    const isRowHighlighted = playerMatchesFocus(
+                      player,
+                      highlightPlayerId
+                    );
                     return (
                       <div
                         key={idx}
-                        className={`grid grid-cols-[200px_repeat(7,minmax(100px,1fr))] hover:bg-white/[0.02] transition-colors group ${isTwoWay ? 'opacity-70' : ''}`}
+                        className={`grid grid-cols-[200px_repeat(7,minmax(100px,1fr))] transition-colors group ${
+                          isRowHighlighted
+                            ? 'ring-1 ring-inset ring-green-400/40 bg-green-500/[0.04]'
+                            : 'hover:bg-white/[0.02]'
+                        } ${isTwoWay ? 'opacity-70' : ''}`}
+                        data-testid={
+                          isRowHighlighted
+                            ? 'cap-sheet-full-player-row-highlighted'
+                            : undefined
+                        }
                       >
                         {/* Player Name (Sticky) */}
                         <div className="sticky left-0 z-10 bg-[#0f0f0f] group-hover:bg-[#131313] px-4 py-2 flex items-center gap-2 border-r border-white/5 shadow-[4px_0_24px_rgba(0,0,0,0.4)] transition-colors h-[36px]">

--- a/src/features/architect/shared/RosterVisual/RosterVisual.tsx
+++ b/src/features/architect/shared/RosterVisual/RosterVisual.tsx
@@ -13,6 +13,7 @@ import { getTeamColors } from '@/shared/utils/formatting/teamColors';
 import { getTeamLogoFilename } from '@/shared/utils/formatting/teamLogos';
 import { TeamMap } from '@/constants/teamList';
 import { useParams } from 'react-router-dom';
+import { playerMatchesFocus } from '@/features/architect/GMDashboard/postActionHandoff/playerFocus';
 
 type RosterBio = Record<string, unknown> & {
   displayName?: string | null;
@@ -66,6 +67,20 @@ type RosterVisualProps = {
   teamCapSheet: RosterVisualCapSheetInput | null | undefined;
   playersMap?: RosterVisualDetailsMap;
   teamId?: string | null;
+  /**
+   * Stage 2C navigation-only seam. When provided, clicking a roster
+   * card invokes this callback with the resolved (merged) roster
+   * member. The legacy `isExport: true` constant still suppresses the
+   * legacy add/remove mutation controls — this seam is additive and
+   * does not re-enable them.
+   */
+  onSelectPlayer?: ((player: RosterDisplayMember) => void) | null;
+  /**
+   * Stage 2C focus highlight. When this id matches one of the member's
+   * canonical identity keys, the matching card renders a non-mutating
+   * "just changed" outline. Visual only.
+   */
+  highlightPlayerId?: string | null;
 };
 
 const LEGACY_ROSTER_DISPLAY_ONLY_PROPS = {
@@ -221,6 +236,8 @@ export const RosterVisual = ({
   teamCapSheet,
   playersMap = {},
   teamId: propTeamId,
+  onSelectPlayer = null,
+  highlightPlayerId = null,
 }: RosterVisualProps) => {
   const { teamId: routeTeamId } = useParams();
   const id = String(
@@ -277,6 +294,21 @@ export const RosterVisual = ({
     return roster;
   }, [teamCapSheet, playersMap]);
 
+  const handleSectionSelect = useMemo(() => {
+    if (!onSelectPlayer) return undefined;
+    return (player: unknown) =>
+      onSelectPlayer((player ?? {}) as RosterDisplayMember);
+  }, [onSelectPlayer]);
+
+  const sectionHighlightMatcher = useMemo(() => {
+    if (!highlightPlayerId) return undefined;
+    return (player: unknown) =>
+      playerMatchesFocus(
+        player as Parameters<typeof playerMatchesFocus>[0],
+        highlightPlayerId
+      );
+  }, [highlightPlayerId]);
+
   if (!roster) return null;
 
   const displayName = String(
@@ -318,16 +350,22 @@ export const RosterVisual = ({
         players={roster.starters}
         section="starters"
         {...LEGACY_ROSTER_DISPLAY_ONLY_PROPS}
+        onSelectPlayer={handleSectionSelect}
+        isPlayerHighlighted={sectionHighlightMatcher}
       />
       <RosterSection
         players={roster.rotation}
         section="rotation"
         {...LEGACY_ROSTER_DISPLAY_ONLY_PROPS}
+        onSelectPlayer={handleSectionSelect}
+        isPlayerHighlighted={sectionHighlightMatcher}
       />
       <RosterSection
         players={roster.bench}
         section="bench"
         {...LEGACY_ROSTER_DISPLAY_ONLY_PROPS}
+        onSelectPlayer={handleSectionSelect}
+        isPlayerHighlighted={sectionHighlightMatcher}
       />
     </div>
   );

--- a/src/features/roster/RosterSection/BenchCard.tsx
+++ b/src/features/roster/RosterSection/BenchCard.tsx
@@ -15,6 +15,8 @@ type BenchCardProps = {
   onRemove?: (event: MouseEvent<HTMLElement>) => void;
   showRemove?: boolean;
   isExport?: boolean;
+  onSelect?: (event: MouseEvent<HTMLElement>) => void;
+  isHighlighted?: boolean;
 };
 
 export const BenchCard = ({
@@ -22,6 +24,8 @@ export const BenchCard = ({
   onRemove,
   showRemove = true,
   isExport = false,
+  onSelect,
+  isHighlighted = false,
 }: BenchCardProps) => {
   if (!player) return null;
 
@@ -30,7 +34,7 @@ export const BenchCard = ({
   const normalizedId = playerId
     ? String(playerId)
         .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[̀-ͯ]/g, '')
         .toLowerCase()
     : 'default';
   const headshot =
@@ -38,9 +42,33 @@ export const BenchCard = ({
     player.headshotUrl ||
     `/assets/headshots/${normalizedId}.png`;
 
+  const innerCardClass = `relative bg-gradient-to-br from-[#1e1e1e] to-[#111] border ${
+    isHighlighted ? 'border-green-400/70 ring-2 ring-green-400/40' : 'border-white/10'
+  } rounded-md overflow-hidden shadow-md flex flex-col w-[7.7rem] h-[11.55rem] text-xs hover:shadow-xl transition-all duration-200`;
+
+  const handleSelect = onSelect
+    ? (event: MouseEvent<HTMLElement>) => onSelect(event)
+    : undefined;
+  const handleKeyDown = onSelect
+    ? (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(event as unknown as MouseEvent<HTMLElement>);
+        }
+      }
+    : undefined;
+
   return (
     <div className="relative overflow-visible p-[2px]">
-      <div className="relative bg-gradient-to-br from-[#1e1e1e] to-[#111] border border-white/10 rounded-md overflow-hidden shadow-md flex flex-col w-[7.7rem] h-[11.55rem] text-xs hover:shadow-xl transition-all duration-200">
+      <div
+        className={`${innerCardClass} ${onSelect ? 'cursor-pointer' : ''}`}
+        onClick={handleSelect}
+        onKeyDown={handleKeyDown}
+        role={onSelect ? 'button' : undefined}
+        tabIndex={onSelect ? 0 : undefined}
+        data-roster-card-highlighted={isHighlighted ? 'true' : undefined}
+        data-testid="roster-card-bench"
+      >
         <div className="flex-1 relative">
           <img
             src={headshot}
@@ -52,7 +80,10 @@ export const BenchCard = ({
           />
           {showRemove && (
             <button
-              onClick={onRemove}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove?.(e);
+              }}
               className="absolute top-1 right-1 text-white/10 hover:text-white text-xs bg-black/10 rounded-sm px-[4px]"
             >
               ✕

--- a/src/features/roster/RosterSection/RotationCard.tsx
+++ b/src/features/roster/RosterSection/RotationCard.tsx
@@ -15,6 +15,8 @@ type RotationCardProps = {
   onRemove?: (event: MouseEvent<HTMLElement>) => void;
   showRemove?: boolean;
   isExport?: boolean;
+  onSelect?: (event: MouseEvent<HTMLElement>) => void;
+  isHighlighted?: boolean;
 };
 
 export const RotationCard = ({
@@ -22,6 +24,8 @@ export const RotationCard = ({
   onRemove,
   showRemove = true,
   isExport = false,
+  onSelect,
+  isHighlighted = false,
 }: RotationCardProps) => {
   if (!player) return null;
 
@@ -30,7 +34,7 @@ export const RotationCard = ({
   const normalizedId = playerId
     ? String(playerId)
         .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[̀-ͯ]/g, '')
         .toLowerCase()
     : 'default';
   const headshot =
@@ -38,9 +42,33 @@ export const RotationCard = ({
     player.headshotUrl ||
     `/assets/headshots/${normalizedId}.png`;
 
+  const innerCardClass = `relative bg-gradient-to-br from-[#1e1e1e] to-[#111] border ${
+    isHighlighted ? 'border-green-400/70 ring-2 ring-green-400/40' : 'border-white/10'
+  } rounded-md overflow-hidden shadow-md flex flex-col w-[8.7rem] h-[13.05rem] text-sm hover:shadow-xl transition-all duration-200`;
+
+  const handleSelect = onSelect
+    ? (event: MouseEvent<HTMLElement>) => onSelect(event)
+    : undefined;
+  const handleKeyDown = onSelect
+    ? (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(event as unknown as MouseEvent<HTMLElement>);
+        }
+      }
+    : undefined;
+
   return (
     <div className="relative overflow-visible p-[2px]">
-      <div className="relative bg-gradient-to-br from-[#1e1e1e] to-[#111] border border-white/10 rounded-md overflow-hidden shadow-md flex flex-col w-[8.7rem] h-[13.05rem] text-sm hover:shadow-xl transition-all duration-200">
+      <div
+        className={`${innerCardClass} ${onSelect ? 'cursor-pointer' : ''}`}
+        onClick={handleSelect}
+        onKeyDown={handleKeyDown}
+        role={onSelect ? 'button' : undefined}
+        tabIndex={onSelect ? 0 : undefined}
+        data-roster-card-highlighted={isHighlighted ? 'true' : undefined}
+        data-testid="roster-card-rotation"
+      >
         <div className="flex-1 relative">
           <img
             src={headshot}
@@ -52,7 +80,10 @@ export const RotationCard = ({
           />
           {showRemove && (
             <button
-              onClick={onRemove}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove?.(e);
+              }}
               className="absolute top-1 right-1 text-white/10 hover:text-white text-xs bg-black/10 rounded-sm px-[4px]"
             >
               ✕

--- a/src/features/roster/RosterSection/StarterCard.tsx
+++ b/src/features/roster/RosterSection/StarterCard.tsx
@@ -15,6 +15,8 @@ type StarterCardProps = {
   onRemove?: (event: MouseEvent<HTMLElement>) => void;
   showRemove?: boolean;
   isExport?: boolean;
+  onSelect?: (event: MouseEvent<HTMLElement>) => void;
+  isHighlighted?: boolean;
 };
 
 export const StarterCard = ({
@@ -22,6 +24,8 @@ export const StarterCard = ({
   onRemove,
   showRemove = true,
   isExport = false,
+  onSelect,
+  isHighlighted = false,
 }: StarterCardProps) => {
   if (!player) return null;
 
@@ -30,7 +34,7 @@ export const StarterCard = ({
   const normalizedId = playerId
     ? String(playerId)
         .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[̀-ͯ]/g, '')
         .toLowerCase()
     : 'default';
   const headshot =
@@ -38,9 +42,33 @@ export const StarterCard = ({
     player.headshotUrl ||
     `/assets/headshots/${normalizedId}.png`;
 
+  const innerCardClass = `relative bg-gradient-to-br from-[#1e1e1e] to-[#111] border ${
+    isHighlighted ? 'border-green-400/70 ring-2 ring-green-400/40' : 'border-white/10'
+  } rounded-md overflow-hidden shadow-md flex flex-col w-40 h-60 text-base hover:shadow-xl transition-all duration-200`;
+
+  const handleSelect = onSelect
+    ? (event: MouseEvent<HTMLElement>) => onSelect(event)
+    : undefined;
+  const handleKeyDown = onSelect
+    ? (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(event as unknown as MouseEvent<HTMLElement>);
+        }
+      }
+    : undefined;
+
   return (
     <div className="relative overflow-visible p-[2px]">
-      <div className="relative bg-gradient-to-br from-[#1e1e1e] to-[#111] border border-white/10 rounded-md overflow-hidden shadow-md flex flex-col w-40 h-60 text-base hover:shadow-xl transition-all duration-200">
+      <div
+        className={`${innerCardClass} ${onSelect ? 'cursor-pointer' : ''}`}
+        onClick={handleSelect}
+        onKeyDown={handleKeyDown}
+        role={onSelect ? 'button' : undefined}
+        tabIndex={onSelect ? 0 : undefined}
+        data-roster-card-highlighted={isHighlighted ? 'true' : undefined}
+        data-testid="roster-card-starter"
+      >
         <div className="flex-1 relative">
           <img
             src={headshot}
@@ -52,7 +80,10 @@ export const StarterCard = ({
           />
           {showRemove && (
             <button
-              onClick={onRemove}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove?.(e);
+              }}
               className="absolute top-1 right-1 text-white/10 hover:text-white text-xs bg-black/10 rounded-sm px-[4px]"
             >
               ✕

--- a/src/features/roster/RosterSection/index.tsx
+++ b/src/features/roster/RosterSection/index.tsx
@@ -17,6 +17,8 @@ type RosterCardProps = {
   onRemove?: (event: MouseEvent<HTMLElement>) => void;
   showRemove?: boolean;
   isExport?: boolean;
+  onSelect?: (event: MouseEvent<HTMLElement>) => void;
+  isHighlighted?: boolean;
 };
 
 type RosterSectionProps = {
@@ -30,6 +32,19 @@ type RosterSectionProps = {
   onAdd?: (section: RosterSectionName, index: number) => void;
   isExport?: boolean;
   previewSpacing?: boolean;
+  /**
+   * Stage 2C navigation-only seam: clicking a player opens the existing
+   * contract modal through the dashboard-owned callback. Receives the
+   * player object so the upstream owner can route through
+   * `handleEditContract` exactly the way Cap Sheet rows already do.
+   */
+  onSelectPlayer?: (player: RosterSectionPlayer) => void;
+  /**
+   * Stage 2C focus highlight: when `isPlayerHighlighted(player)` returns
+   * true, the matching card renders a non-mutating "just changed"
+   * outline. Visual only.
+   */
+  isPlayerHighlighted?: (player: RosterSectionPlayer) => boolean;
 };
 
 const getSectionClass = (
@@ -72,6 +87,8 @@ export const RosterSection = ({
   onAdd,
   isExport = false,
   previewSpacing = false,
+  onSelectPlayer,
+  isPlayerHighlighted,
 }: RosterSectionProps) => {
   const CardComponent = cardMap[section];
   const sectionClass = getSectionClass(section, previewSpacing);
@@ -81,6 +98,10 @@ export const RosterSection = ({
     <div className={sectionClass} data-roster-section={section}>
       {players.map((player, idx) => {
         if (player) {
+          const handleSelect = onSelectPlayer
+            ? () => onSelectPlayer(player)
+            : undefined;
+          const highlighted = Boolean(isPlayerHighlighted?.(player));
           return (
             <CardComponent
               key={player.id}
@@ -92,6 +113,8 @@ export const RosterSection = ({
               }
               showRemove={showMutationControls}
               isExport={isExport}
+              onSelect={handleSelect}
+              isHighlighted={highlighted}
             />
           );
         }

--- a/src/tests/architect/stage2c.playerRosterContinuity.test.tsx
+++ b/src/tests/architect/stage2c.playerRosterContinuity.test.tsx
@@ -1,0 +1,403 @@
+/**
+ * FILE: src/tests/architect/stage2c.playerRosterContinuity.test.tsx
+ * PURPOSE: Targeted tests for Stage 2C player/roster continuity:
+ *          roster click → contract modal, focused-player highlight on
+ *          Roster, Cap Sheet, and Full Cap Table, and the receipt-driven
+ *          lifetime of that highlight.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Stage 1, 2A, and 2B tests live in their own files; this file only
+ * covers Stage 2C surface area. All highlight behavior is visual-only —
+ * no mutation, no Firestore reads/writes.
+ */
+
+import React from 'react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  collectPlayerFocusKeys,
+  playerMatchesFocus,
+} from '@/features/architect/GMDashboard/postActionHandoff/playerFocus';
+import { RosterSection as LegacyRosterSection } from '@/features/roster/RosterSection';
+import { RosterSection } from '@/features/architect/GMDashboard/sections/RosterSection';
+import { CapSheet } from '@/features/architect/capSheet/CapSheet';
+import { CapSheetFull } from '@/features/architect/capSheet/CapSheetFull';
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// playerMatchesFocus — pure derivation
+// ---------------------------------------------------------------------------
+
+describe('Stage 2C — playerMatchesFocus', () => {
+  it('matches on id', () => {
+    expect(
+      playerMatchesFocus({ id: 'player_42', name: 'Jane Doe' }, 'player_42')
+    ).toBe(true);
+  });
+
+  it('matches on player_id', () => {
+    expect(
+      playerMatchesFocus(
+        { player_id: 'player_42', name: 'Jane Doe' },
+        'player_42'
+      )
+    ).toBe(true);
+  });
+
+  it('matches on bio.playerId', () => {
+    expect(
+      playerMatchesFocus(
+        { bio: { playerId: 'player_42', displayName: 'Jane Doe' } },
+        'player_42'
+      )
+    ).toBe(true);
+  });
+
+  it('matches on a normalized name fallback', () => {
+    expect(
+      playerMatchesFocus({ name: 'Jané Doe' }, 'jane_doe')
+    ).toBe(true);
+  });
+
+  it('does not match a different player', () => {
+    expect(
+      playerMatchesFocus({ id: 'player_42', name: 'Jane Doe' }, 'player_99')
+    ).toBe(false);
+  });
+
+  it('returns false for a null focus id', () => {
+    expect(
+      playerMatchesFocus({ id: 'player_42', name: 'Jane Doe' }, null)
+    ).toBe(false);
+  });
+
+  it('returns false for a null player', () => {
+    expect(playerMatchesFocus(null, 'player_42')).toBe(false);
+  });
+
+  it('collectPlayerFocusKeys gathers id + name variants', () => {
+    const keys = collectPlayerFocusKeys({
+      id: 'player_42',
+      name: 'Jané Doe',
+      bio: { playerId: 'player_42', displayName: 'Jane Doe' },
+    });
+    expect(keys).toContain('player_42');
+    expect(keys).toContain('Jané Doe');
+    expect(keys).toContain('Jane Doe');
+    // Normalized name fallback should also be present (lowercase, no marks).
+    expect(keys).toContain('janedoe');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy roster RosterSection — onSelectPlayer + isPlayerHighlighted
+// ---------------------------------------------------------------------------
+
+describe('Stage 2C — legacy roster RosterSection', () => {
+  const STARTER = {
+    id: 'player_42',
+    name: 'Jane Doe',
+    bio: { playerId: 'player_42', displayName: 'Jane Doe', position: 'G' },
+  } as const;
+
+  it('calls onSelectPlayer when a card is clicked', () => {
+    const onSelectPlayer = vi.fn();
+    render(
+      <LegacyRosterSection
+        players={[STARTER, null, null, null, null]}
+        section="starters"
+        isExport
+        onSelectPlayer={onSelectPlayer}
+      />
+    );
+    fireEvent.click(screen.getByTestId('roster-card-starter'));
+    expect(onSelectPlayer).toHaveBeenCalledTimes(1);
+    expect(onSelectPlayer).toHaveBeenCalledWith(STARTER);
+  });
+
+  it('does not throw when onSelectPlayer is absent', () => {
+    expect(() =>
+      render(
+        <LegacyRosterSection
+          players={[STARTER, null, null, null, null]}
+          section="starters"
+          isExport
+        />
+      )
+    ).not.toThrow();
+    // No click handler attached, so clicking is a no-op
+    fireEvent.click(screen.getByTestId('roster-card-starter'));
+  });
+
+  it('renders the highlight outline only on matching cards', () => {
+    const MATCH = { id: 'player_42', name: 'Jane Doe', bio: { playerId: 'player_42', displayName: 'Jane Doe' } };
+    const OTHER = { id: 'player_99', name: 'John Q', bio: { playerId: 'player_99', displayName: 'John Q' } };
+    render(
+      <LegacyRosterSection
+        players={[MATCH, OTHER, null, null, null]}
+        section="starters"
+        isExport
+        isPlayerHighlighted={(p) => p?.id === 'player_42'}
+      />
+    );
+    const cards = screen.getAllByTestId('roster-card-starter');
+    expect(cards[0]).toHaveAttribute('data-roster-card-highlighted', 'true');
+    expect(cards[1]).not.toHaveAttribute('data-roster-card-highlighted');
+  });
+
+  it('does not re-enable legacy add/remove controls when onSelectPlayer is provided', () => {
+    // Even with onSelectPlayer + isExport, the legacy onRemove/onAdd
+    // mutation controls remain suppressed (showRemove is gated by !isExport).
+    render(
+      <LegacyRosterSection
+        players={[STARTER, null, null, null, null]}
+        section="starters"
+        isExport
+        onRemove={vi.fn()}
+        onAdd={vi.fn()}
+        onSelectPlayer={vi.fn()}
+      />
+    );
+    // The remove "✕" button should not be present in export mode.
+    expect(screen.queryByText('✕')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dashboard RosterSection wrapper — forwards Stage 2C props into RosterVisual
+// ---------------------------------------------------------------------------
+
+describe('Stage 2C — dashboard RosterSection wrapper', () => {
+  const teamCapSheet = {
+    teamId: 'LAL',
+    teamName: 'Lakers',
+    players: [
+      {
+        id: 'player_42',
+        name: 'Jane Doe',
+        bio: {
+          playerId: 'player_42',
+          displayName: 'Jane Doe',
+          position: 'G',
+        },
+        MIN: 30,
+      },
+      {
+        id: 'player_99',
+        name: 'John Q',
+        bio: {
+          playerId: 'player_99',
+          displayName: 'John Q',
+          position: 'F',
+        },
+        MIN: 20,
+      },
+    ],
+  };
+
+  it('opens the contract modal when a roster card is clicked', () => {
+    const onOpenPlayerContractModal = vi.fn();
+    render(
+      <MemoryRouter>
+        <RosterSection
+          teamCapSheet={teamCapSheet}
+          teamId="LAL"
+          onOpenPlayerContractModal={onOpenPlayerContractModal}
+        />
+      </MemoryRouter>
+    );
+    const starters = screen.getAllByTestId('roster-card-starter');
+    expect(starters.length).toBeGreaterThan(0);
+    fireEvent.click(starters[0]);
+    expect(onOpenPlayerContractModal).toHaveBeenCalledTimes(1);
+    const arg = onOpenPlayerContractModal.mock.calls[0][0] as {
+      id?: string;
+      name?: string;
+    };
+    expect(['player_42', 'player_99']).toContain(arg.id);
+  });
+
+  it('does not throw when onOpenPlayerContractModal is omitted', () => {
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <RosterSection teamCapSheet={teamCapSheet} teamId="LAL" />
+        </MemoryRouter>
+      )
+    ).not.toThrow();
+  });
+
+  it('highlights only the focused player card', () => {
+    render(
+      <MemoryRouter>
+        <RosterSection
+          teamCapSheet={teamCapSheet}
+          teamId="LAL"
+          highlightPlayerId="player_42"
+        />
+      </MemoryRouter>
+    );
+    const highlighted = screen
+      .getAllByTestId('roster-card-starter')
+      .filter((el) => el.getAttribute('data-roster-card-highlighted') === 'true');
+    expect(highlighted.length).toBe(1);
+  });
+
+  it('clears the highlight when highlightPlayerId is null (receipt dismissed)', () => {
+    render(
+      <MemoryRouter>
+        <RosterSection
+          teamCapSheet={teamCapSheet}
+          teamId="LAL"
+          highlightPlayerId={null}
+        />
+      </MemoryRouter>
+    );
+    const highlighted = screen
+      .getAllByTestId('roster-card-starter')
+      .filter((el) => el.getAttribute('data-roster-card-highlighted') === 'true');
+    expect(highlighted.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CapSheet — focused player row highlight
+// ---------------------------------------------------------------------------
+
+describe('Stage 2C — CapSheet row highlight', () => {
+  const teamCapSheet = {
+    teamId: 'LAL',
+    teamCode: 'LAL',
+    players: [
+      {
+        id: 'player_42',
+        name: 'Jane Doe',
+        displayName: 'Jane Doe',
+        bio: { playerId: 'player_42', displayName: 'Jane Doe' },
+        contract: {
+          salariesByYear: [
+            { year: 2026, season: '2025-26', salary: 30_000_000, capHit: 30_000_000 },
+          ],
+        },
+      },
+      {
+        id: 'player_99',
+        name: 'John Q',
+        displayName: 'John Q',
+        bio: { playerId: 'player_99', displayName: 'John Q' },
+        contract: {
+          salariesByYear: [
+            { year: 2026, season: '2025-26', salary: 5_000_000, capHit: 5_000_000 },
+          ],
+        },
+      },
+    ],
+  } as never;
+
+  it('renders the highlighted row only for the matching player', () => {
+    render(
+      <CapSheet
+        teamCapSheet={teamCapSheet}
+        currentYear={2026}
+        highlightPlayerId="player_42"
+      />
+    );
+    const highlighted = screen.queryAllByTestId(
+      'cap-sheet-player-row-highlighted'
+    );
+    expect(highlighted.length).toBe(1);
+  });
+
+  it('renders no highlight when highlightPlayerId is null', () => {
+    render(
+      <CapSheet
+        teamCapSheet={teamCapSheet}
+        currentYear={2026}
+        highlightPlayerId={null}
+      />
+    );
+    expect(
+      screen.queryAllByTestId('cap-sheet-player-row-highlighted').length
+    ).toBe(0);
+  });
+
+  it('renders no highlight when no row matches the focus id', () => {
+    render(
+      <CapSheet
+        teamCapSheet={teamCapSheet}
+        currentYear={2026}
+        highlightPlayerId="player_does_not_exist"
+      />
+    );
+    expect(
+      screen.queryAllByTestId('cap-sheet-player-row-highlighted').length
+    ).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CapSheetFull — focused player row highlight
+// ---------------------------------------------------------------------------
+
+describe('Stage 2C — CapSheetFull row highlight', () => {
+  const teamCapSheet = {
+    teamId: 'LAL',
+    teamCode: 'LAL',
+    players: [
+      {
+        id: 'player_42',
+        name: 'Jane Doe',
+        displayName: 'Jane Doe',
+        bio: { playerId: 'player_42', displayName: 'Jane Doe' },
+        contract: {
+          salariesByYear: [
+            { year: 2026, season: '2025-26', salary: 30_000_000, capHit: 30_000_000 },
+            { year: 2027, season: '2026-27', salary: 32_000_000, capHit: 32_000_000 },
+          ],
+        },
+      },
+      {
+        id: 'player_99',
+        name: 'John Q',
+        displayName: 'John Q',
+        bio: { playerId: 'player_99', displayName: 'John Q' },
+        contract: {
+          salariesByYear: [
+            { year: 2026, season: '2025-26', salary: 5_000_000, capHit: 5_000_000 },
+          ],
+        },
+      },
+    ],
+  } as never;
+
+  it('renders the highlighted row only for the matching player', () => {
+    render(
+      <CapSheetFull
+        teamCapSheet={teamCapSheet}
+        currentYear={2026}
+        highlightPlayerId="player_42"
+      />
+    );
+    expect(
+      screen.queryAllByTestId('cap-sheet-full-player-row-highlighted').length
+    ).toBe(1);
+  });
+
+  it('renders no highlight when highlightPlayerId is null', () => {
+    render(
+      <CapSheetFull
+        teamCapSheet={teamCapSheet}
+        currentYear={2026}
+        highlightPlayerId={null}
+      />
+    );
+    expect(
+      screen.queryAllByTestId('cap-sheet-full-player-row-highlighted').length
+    ).toBe(0);
+  });
+});

--- a/src/tests/architect/stage2c.playerRosterContinuity.test.tsx
+++ b/src/tests/architect/stage2c.playerRosterContinuity.test.tsx
@@ -80,6 +80,35 @@ describe('Stage 2C — playerMatchesFocus', () => {
     expect(playerMatchesFocus(null, 'player_42')).toBe(false);
   });
 
+  it('treats empty-string and whitespace focus ids as no-match', () => {
+    expect(
+      playerMatchesFocus({ id: 'player_42', name: 'Jane Doe' }, '')
+    ).toBe(false);
+    expect(
+      playerMatchesFocus({ id: 'player_42', name: 'Jane Doe' }, '   ')
+    ).toBe(false);
+  });
+
+  it('does not substring-match short tokens against longer names', () => {
+    // 'doe' should not match 'janedoe' — equality on normalized keys only.
+    expect(
+      playerMatchesFocus({ name: 'Jane Doe' }, 'doe')
+    ).toBe(false);
+    expect(
+      playerMatchesFocus({ name: 'Jane Doe' }, 'jane')
+    ).toBe(false);
+  });
+
+  it('matches numeric ids against string focus tokens', () => {
+    expect(
+      playerMatchesFocus({ id: 42 }, '42')
+    ).toBe(true);
+  });
+
+  it('does not match a player without any identifying fields', () => {
+    expect(playerMatchesFocus({}, 'player_42')).toBe(false);
+  });
+
   it('collectPlayerFocusKeys gathers id + name variants', () => {
     const keys = collectPlayerFocusKeys({
       id: 'player_42',
@@ -102,6 +131,8 @@ describe('Stage 2C — legacy roster RosterSection', () => {
   const STARTER = {
     id: 'player_42',
     name: 'Jane Doe',
+    displayName: 'Jane Doe',
+    headshot: '/assets/headshots/player_42.png',
     bio: { playerId: 'player_42', displayName: 'Jane Doe', position: 'G' },
   } as const;
 
@@ -135,8 +166,20 @@ describe('Stage 2C — legacy roster RosterSection', () => {
   });
 
   it('renders the highlight outline only on matching cards', () => {
-    const MATCH = { id: 'player_42', name: 'Jane Doe', bio: { playerId: 'player_42', displayName: 'Jane Doe' } };
-    const OTHER = { id: 'player_99', name: 'John Q', bio: { playerId: 'player_99', displayName: 'John Q' } };
+    const MATCH = {
+      id: 'player_42',
+      name: 'Jane Doe',
+      displayName: 'Jane Doe',
+      headshot: '/assets/headshots/player_42.png',
+      bio: { playerId: 'player_42', displayName: 'Jane Doe', position: 'G' },
+    };
+    const OTHER = {
+      id: 'player_99',
+      name: 'John Q',
+      displayName: 'John Q',
+      headshot: '/assets/headshots/player_99.png',
+      bio: { playerId: 'player_99', displayName: 'John Q', position: 'F' },
+    };
     render(
       <LegacyRosterSection
         players={[MATCH, OTHER, null, null, null]}
@@ -165,6 +208,67 @@ describe('Stage 2C — legacy roster RosterSection', () => {
     );
     // The remove "✕" button should not be present in export mode.
     expect(screen.queryByText('✕')).toBeNull();
+  });
+
+  it('activates onSelectPlayer via Enter and Space keys', () => {
+    const onSelectPlayer = vi.fn();
+    render(
+      <LegacyRosterSection
+        players={[STARTER, null, null, null, null]}
+        section="starters"
+        isExport
+        onSelectPlayer={onSelectPlayer}
+      />
+    );
+    const card = screen.getByTestId('roster-card-starter');
+    fireEvent.keyDown(card, { key: 'Enter' });
+    expect(onSelectPlayer).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(card, { key: ' ' });
+    expect(onSelectPlayer).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores unrelated keys (no Tab/Shift/Escape activation)', () => {
+    const onSelectPlayer = vi.fn();
+    render(
+      <LegacyRosterSection
+        players={[STARTER, null, null, null, null]}
+        section="starters"
+        isExport
+        onSelectPlayer={onSelectPlayer}
+      />
+    );
+    const card = screen.getByTestId('roster-card-starter');
+    fireEvent.keyDown(card, { key: 'Tab' });
+    fireEvent.keyDown(card, { key: 'Escape' });
+    fireEvent.keyDown(card, { key: 'a' });
+    expect(onSelectPlayer).not.toHaveBeenCalled();
+  });
+
+  it('renders interactive cards with role=button and tabIndex=0', () => {
+    render(
+      <LegacyRosterSection
+        players={[STARTER, null, null, null, null]}
+        section="starters"
+        isExport
+        onSelectPlayer={vi.fn()}
+      />
+    );
+    const card = screen.getByTestId('roster-card-starter');
+    expect(card).toHaveAttribute('role', 'button');
+    expect(card).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('renders non-interactive cards without role=button or tabIndex', () => {
+    render(
+      <LegacyRosterSection
+        players={[STARTER, null, null, null, null]}
+        section="starters"
+        isExport
+      />
+    );
+    const card = screen.getByTestId('roster-card-starter');
+    expect(card).not.toHaveAttribute('role');
+    expect(card).not.toHaveAttribute('tabIndex');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds Stage 2C player/roster continuity for Architect Operating Experience.

Stage 1 made Architect visually continuous. Stage 2A made it navigationally continuous. Stage 2B added post-action consequence handoffs. Stage 2C now makes player/roster objects inspectable and visually continuous across Roster, Cap Sheet, and Full Cap Table.

## Added

- Roster player cards can open the existing contract modal through existing `handleEditContract` routing.
- Receipt-derived `focusedPlayerId` is threaded from `GMDashboard` into Roster, Cap Sheet, and Full Cap Table.
- Matching players render a non-mutating visual highlight across those surfaces.
- New pure player focus helpers: `playerMatchesFocus` and `collectPlayerFocusKeys`.
- Roster card click/keyboard support for safe player selection while preserving legacy `isExport` display-only control suppression.

## Guardrails

- No new mutation authority
- No Firestore reads or writes
- No schema changes
- No Trade Machine player prefill
- No History-to-player deep-links
- No baseline deltas
- No scenario comparison
- No direct roster mutations
- Existing legacy roster add/remove controls remain suppressed

## Validation Reported

- `npm run typecheck`: passed
- `npm run build`: passed
- Stage 2C targeted tests: 21/21 passed
- Stage 2A regression: 11/11 passed
- Stage 2B regression: 24/24 passed
- Stage 1 regression: 35/35 passed

`npm run test:diff` widened the impact set because CapSheet/CapSheetFull/RosterVisual changed and surfaced pre-existing unrelated guardrail failures. The agent verified this by stashing Stage 2C changes and re-running the diff selection.

## Deferred

- Trade Machine player prefill
- History event → player deep-link
- Manual focus publication outside receipt-derived focus
- Full Cap Table → Roster jump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual player highlighting across the dashboard (cap sheet, roster, and cap table sections). Selected players are now visually emphasized with a green highlight after actions are performed, improving visibility of the active player.

* **Documentation**
  * Updated component hierarchy documentation to reflect latest architecture.

* **Tests**
  * Added comprehensive test coverage for player focus and roster continuity behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bet-Zero/scoutzero/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->