### PR TITLE
Add Architect history activity deeplinks

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -41,6 +41,7 @@ GMDashboard/
     useArchitectState.worldLoader.ts
     useArchitectState.worldTracker.ts
     useArchitectWorkspaceContext.ts
+    useHistoryEventDetailRequest.ts
     useScenarioActivityRail.ts
   offerSheetTypes.ts
   postActionHandoff/
@@ -490,5 +491,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-05-21T03:15:58.671Z*
+*Generated on: 2026-05-21T05:23:30.365Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -34,6 +34,7 @@ import { ArchitectWorkspaceHeader } from '@/features/architect/GMDashboard/compo
 import { ScenarioMoveRail } from '@/features/architect/GMDashboard/components/ScenarioMoveRail';
 import { ArchitectPostActionHandoff } from '@/features/architect/GMDashboard/components/ArchitectPostActionHandoff';
 import { useArchitectPostActionReceipt } from './hooks/useArchitectPostActionReceipt';
+import { useHistoryEventDetailRequest } from './hooks/useHistoryEventDetailRequest';
 import { deriveSeasonAdvanceReceipt } from './postActionHandoff/types';
 import { useArchitectState } from './hooks/useArchitectState';
 import { useArchitectWorkspaceContext } from './hooks/useArchitectWorkspaceContext';
@@ -212,6 +213,16 @@ export const GMDashboard = () => {
   const postActionReceipt = useArchitectPostActionReceipt(
     postActionReceiptScopeKey
   );
+  const {
+    requestedHistoryEventDetail,
+    openHistoryRoot,
+    requestHistoryEventDetail,
+    handleHistoryEventDetailHandled,
+  } = useHistoryEventDetailRequest({
+    worldId,
+    teamCode: normalizedTeamId,
+    onOpenHistory: () => setActiveTab('history'),
+  });
   // Stage 2C: derive a session-scoped focused player id from the most recent
   // committed post-action receipt. Visual-only — receipt dismiss/clear
   // automatically clears the highlight. Multi-player receipts (trades) use
@@ -462,14 +473,22 @@ export const GMDashboard = () => {
         receipt={postActionReceipt.receipt}
         onNavigateToCapSheet={() => setActiveTab('cap')}
         onNavigateToRoster={() => setActiveTab('roster')}
-        onNavigateToHistory={() => setActiveTab('history')}
+        onNavigateToHistory={() =>
+          requestHistoryEventDetail(
+            postActionReceipt.receipt?.eventId ?? null,
+            'post-action-handoff'
+          )
+        }
         onDismiss={postActionReceipt.dismiss}
       />
 
       <ScenarioMoveRail
         worldId={worldId}
         teamCode={normalizedTeamId}
-        onOpenHistory={() => setActiveTab('history')}
+        onOpenHistory={openHistoryRoot}
+        onOpenHistoryEntry={(eventId) =>
+          requestHistoryEventDetail(eventId, 'activity-rail')
+        }
         refreshKey={postActionReceipt.generation}
         highlightEventId={postActionReceipt.receipt?.eventId ?? null}
       />
@@ -550,7 +569,7 @@ export const GMDashboard = () => {
           Offseason
         </button>
         <button
-          onClick={() => setActiveTab('history')}
+          onClick={openHistoryRoot}
           className={`px-4 py-2 rounded-md text-sm font-semibold ${
             activeTab === 'history'
               ? 'bg-lakers/90 text-black'
@@ -621,6 +640,10 @@ export const GMDashboard = () => {
             onClearTeamHistoryFixtures={actions.teamHistoryDevTools.clearFixtures}
             hasInjectedTeamHistoryFixtures={
               actions.teamHistoryDevTools.hasInjectedFixtures
+            }
+            requestedHistoryEventDetail={requestedHistoryEventDetail}
+            onRequestedHistoryEventDetailHandled={
+              handleHistoryEventDetailHandled
             }
           />
         )}

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -41,6 +41,7 @@ import { useArchitectWorkspaceContext } from './hooks/useArchitectWorkspaceConte
 import { useArchitectActions } from './hooks/useArchitectActions';
 import { useArchitectModals } from './hooks/useArchitectModals';
 import { usePlayerRulesProfiles } from '@/features/architect/hooks/usePlayerRulesProfiles';
+import { resolveTeamCode } from '@/features/architect/utils/worldTeamData';
 import { useAuth } from '@/shared/hooks/useAuth';
 import {
   FIREBASE_TARGET_MODE,
@@ -167,6 +168,14 @@ export const GMDashboard = () => {
     error,
     worldModeBoundary,
   });
+  const resolvedHistoryTeamCode = useMemo(() => {
+    const capSheetTeamCode = String(teamCapSheet?.teamCode ?? '').trim();
+    return (
+      capSheetTeamCode ||
+      resolveTeamCode(normalizedTeamId) ||
+      normalizedTeamId
+    );
+  }, [normalizedTeamId, teamCapSheet?.teamCode]);
 
   const isEmulatorMode = FIREBASE_TARGET_MODE === 'EMULATOR';
   const showEmulatorUnavailableBanner =
@@ -209,7 +218,10 @@ export const GMDashboard = () => {
     (selectedRulesYear && leagueContextByYear?.get(selectedRulesYear)) ||
     rulesLeagueContext;
 
-  const postActionReceiptScopeKey = `${worldId ?? 'sandbox'}:${normalizedTeamId}`;
+  const postActionReceiptScopeKey = [
+    worldId ?? 'sandbox',
+    resolvedHistoryTeamCode,
+  ].join(':');
   const postActionReceipt = useArchitectPostActionReceipt(
     postActionReceiptScopeKey
   );
@@ -220,7 +232,7 @@ export const GMDashboard = () => {
     handleHistoryEventDetailHandled,
   } = useHistoryEventDetailRequest({
     worldId,
-    teamCode: normalizedTeamId,
+    teamCode: resolvedHistoryTeamCode,
     onOpenHistory: () => setActiveTab('history'),
   });
   // Stage 2C: derive a session-scoped focused player id from the most recent
@@ -484,7 +496,7 @@ export const GMDashboard = () => {
 
       <ScenarioMoveRail
         worldId={worldId}
-        teamCode={normalizedTeamId}
+        teamCode={resolvedHistoryTeamCode}
         onOpenHistory={openHistoryRoot}
         onOpenHistoryEntry={(eventId) =>
           requestHistoryEventDetail(eventId, 'activity-rail')

--- a/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
+++ b/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
@@ -14,6 +14,7 @@ interface ScenarioMoveRailProps {
   worldId: string | null | undefined;
   teamCode: string | null | undefined;
   onOpenHistory: () => void;
+  onOpenHistoryEntry?: (eventId: string) => void;
   /**
    * Stage 2B refresh seam. Increment to trigger a re-read of committed
    * world events after a successful committed mutation. Sandbox/no-world
@@ -42,6 +43,7 @@ export const ScenarioMoveRail = ({
   worldId,
   teamCode,
   onOpenHistory,
+  onOpenHistoryEntry,
   refreshKey = 0,
   highlightEventId = null,
 }: ScenarioMoveRailProps) => {
@@ -116,38 +118,43 @@ export const ScenarioMoveRail = ({
               const isJustCommitted = Boolean(
                 highlightEventId && entry.id === highlightEventId
               );
+              const entryClassName = isJustCommitted
+                ? 'flex items-baseline gap-2 text-white/80 rounded bg-green-500/[0.06] -mx-1 px-1'
+                : 'flex items-baseline gap-2 text-white/50';
               return (
                 <li
                   key={entry.id}
-                  className={
-                    isJustCommitted
-                      ? 'flex items-baseline gap-2 text-white/80 rounded bg-green-500/[0.06] -mx-1 px-1'
-                      : 'flex items-baseline gap-2 text-white/50'
-                  }
                   data-testid={
                     isJustCommitted
                       ? 'scenario-move-rail-entry-just-committed'
                       : undefined
                   }
                 >
-                  <span className="shrink-0 rounded border border-green-500/20 bg-green-500/10 px-1 text-green-400/60 text-[10px] leading-4">
-                    {isJustCommitted ? 'Just now' : 'World'}
-                  </span>
-                  <span className="shrink-0">{entry.typeLabel}</span>
-                  <span
-                    className={
-                      isJustCommitted
-                        ? 'text-white/70 min-w-0 truncate'
-                        : 'text-white/35 min-w-0 truncate'
-                    }
+                  <button
+                    type="button"
+                    onClick={() => onOpenHistoryEntry?.(entry.id)}
+                    className={`${entryClassName} w-full text-left hover:bg-white/[0.04] focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30`}
+                    data-testid="scenario-move-rail-entry-button"
                   >
-                    {entry.summary}
-                  </span>
-                  {entry.occurredAt && (
-                    <span className="shrink-0 ml-auto pl-2 text-white/25">
-                      {formatRailDate(entry.occurredAt)}
+                    <span className="shrink-0 rounded border border-green-500/20 bg-green-500/10 px-1 text-green-400/60 text-[10px] leading-4">
+                      {isJustCommitted ? 'Just now' : 'World'}
                     </span>
-                  )}
+                    <span className="shrink-0">{entry.typeLabel}</span>
+                    <span
+                      className={
+                        isJustCommitted
+                          ? 'text-white/70 min-w-0 truncate'
+                          : 'text-white/35 min-w-0 truncate'
+                      }
+                    >
+                      {entry.summary}
+                    </span>
+                    {entry.occurredAt && (
+                      <span className="shrink-0 ml-auto pl-2 text-white/25">
+                        {formatRailDate(entry.occurredAt)}
+                      </span>
+                    )}
+                  </button>
                 </li>
               );
             })}

--- a/src/features/architect/GMDashboard/hooks/useHistoryEventDetailRequest.ts
+++ b/src/features/architect/GMDashboard/hooks/useHistoryEventDetailRequest.ts
@@ -1,0 +1,93 @@
+/**
+ * FILE: src/features/architect/GMDashboard/hooks/useHistoryEventDetailRequest.ts
+ * PURPOSE: Dashboard-owned one-shot History event detail request state.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Stores read-only navigation/detail-selection requests only. It never creates
+ * history truth, never writes to Firestore, and clears when world/team scope
+ * changes or when History acknowledges the request.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  RequestedHistoryEventDetail,
+  RequestedHistoryEventDetailSource,
+} from '@/features/architect/history/TeamHistoryTab/types';
+
+type UseHistoryEventDetailRequestArgs = {
+  worldId: string | null | undefined;
+  teamCode: string | null | undefined;
+  onOpenHistory: () => void;
+};
+
+type UseHistoryEventDetailRequestResult = {
+  requestedHistoryEventDetail: RequestedHistoryEventDetail | null;
+  openHistoryRoot: () => void;
+  requestHistoryEventDetail: (
+    eventId: string | null | undefined,
+    source: RequestedHistoryEventDetailSource
+  ) => void;
+  handleHistoryEventDetailHandled: (requestKey: number) => void;
+};
+
+const normalizeToken = (value: string | null | undefined): string | null => {
+  const normalized = String(value ?? '').trim();
+  return normalized || null;
+};
+
+export function useHistoryEventDetailRequest({
+  worldId,
+  teamCode,
+  onOpenHistory,
+}: UseHistoryEventDetailRequestArgs): UseHistoryEventDetailRequestResult {
+  const [requestedHistoryEventDetail, setRequestedHistoryEventDetail] =
+    useState<RequestedHistoryEventDetail | null>(null);
+  const requestKeyRef = useRef(0);
+  const normalizedWorldId = normalizeToken(worldId);
+  const normalizedTeamCode = normalizeToken(teamCode);
+
+  useEffect(() => {
+    setRequestedHistoryEventDetail(null);
+  }, [normalizedWorldId, normalizedTeamCode]);
+
+  const openHistoryRoot = useCallback(() => {
+    setRequestedHistoryEventDetail(null);
+    onOpenHistory();
+  }, [onOpenHistory]);
+
+  const requestHistoryEventDetail = useCallback(
+    (
+      eventId: string | null | undefined,
+      source: RequestedHistoryEventDetailSource
+    ) => {
+      const requestedSelectedEntryId = normalizeToken(eventId);
+      if (!requestedSelectedEntryId || !normalizedWorldId || !normalizedTeamCode) {
+        openHistoryRoot();
+        return;
+      }
+
+      requestKeyRef.current += 1;
+      setRequestedHistoryEventDetail({
+        requestKey: requestKeyRef.current,
+        requestedSelectedEntryId,
+        worldId: normalizedWorldId,
+        teamCode: normalizedTeamCode,
+        source,
+      });
+      onOpenHistory();
+    },
+    [normalizedWorldId, normalizedTeamCode, onOpenHistory, openHistoryRoot]
+  );
+
+  const handleHistoryEventDetailHandled = useCallback((requestKey: number) => {
+    setRequestedHistoryEventDetail((current) =>
+      current?.requestKey === requestKey ? null : current
+    );
+  }, []);
+
+  return {
+    requestedHistoryEventDetail,
+    openHistoryRoot,
+    requestHistoryEventDetail,
+    handleHistoryEventDetailHandled,
+  };
+}

--- a/src/features/architect/GMDashboard/sections/HistorySection.tsx
+++ b/src/features/architect/GMDashboard/sections/HistorySection.tsx
@@ -11,11 +11,16 @@
  *  - Latest Chunk: N/A
  */
 import { TeamHistoryTab } from '@/features/architect/history/TeamHistoryTab';
-import type { TeamHistoryCapSheetLike } from '@/features/architect/history/TeamHistoryTab/types';
+import type {
+  RequestedHistoryEventDetail,
+  TeamHistoryCapSheetLike,
+} from '@/features/architect/history/TeamHistoryTab/types';
 
 type HistorySectionProps = {
   teamCapSheet: TeamHistoryCapSheetLike | null | undefined;
   worldId?: string | null;
+  requestedHistoryEventDetail?: RequestedHistoryEventDetail | null;
+  onRequestedHistoryEventDetailHandled?: ((requestKey: number) => void) | null;
   onInjectTeamHistoryFixtures?: (() => void) | null;
   onClearTeamHistoryFixtures?: (() => void) | null;
   hasInjectedTeamHistoryFixtures?: boolean;
@@ -24,6 +29,8 @@ type HistorySectionProps = {
 const HistorySection = ({
   teamCapSheet,
   worldId,
+  requestedHistoryEventDetail,
+  onRequestedHistoryEventDetailHandled,
   onInjectTeamHistoryFixtures,
   onClearTeamHistoryFixtures,
   hasInjectedTeamHistoryFixtures,
@@ -31,6 +38,10 @@ const HistorySection = ({
   <TeamHistoryTab
     teamCapSheet={teamCapSheet!}
     worldId={worldId}
+    requestedHistoryEventDetail={requestedHistoryEventDetail}
+    onRequestedHistoryEventDetailHandled={
+      onRequestedHistoryEventDetailHandled
+    }
     onInjectTeamHistoryFixtures={onInjectTeamHistoryFixtures}
     onClearTeamHistoryFixtures={onClearTeamHistoryFixtures}
     hasInjectedTeamHistoryFixtures={hasInjectedTeamHistoryFixtures}

--- a/src/features/architect/history/TeamHistoryTab/TeamHistoryTab.tsx
+++ b/src/features/architect/history/TeamHistoryTab/TeamHistoryTab.tsx
@@ -21,6 +21,8 @@ import { WorldEventsTimeline } from './WorldEventsTimeline';
 export const TeamHistoryTab = ({
   teamCapSheet,
   worldId,
+  requestedHistoryEventDetail = null,
+  onRequestedHistoryEventDetailHandled = null,
   onInjectTeamHistoryFixtures = null,
   onClearTeamHistoryFixtures = null,
   hasInjectedTeamHistoryFixtures = false,
@@ -155,6 +157,10 @@ export const TeamHistoryTab = ({
           <WorldEventsTimeline
             worldId={worldId || ''}
             teamCode={teamCapSheet?.teamCode || null}
+            requestedHistoryEventDetail={requestedHistoryEventDetail}
+            onRequestedHistoryEventDetailHandled={
+              onRequestedHistoryEventDetailHandled
+            }
             onSelectEntry={(entry) =>
               setSelectedEntry(
                 buildSelectedHistoryEntry({

--- a/src/features/architect/history/TeamHistoryTab/WorldEventsTimeline.tsx
+++ b/src/features/architect/history/TeamHistoryTab/WorldEventsTimeline.tsx
@@ -1,21 +1,27 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useWorldTeamEvents } from '@/features/architect/history/hooks/useWorldTeamEvents';
 import {
   normalizeWorldEventsForTeamHistory,
   type TeamHistoryWorldEventRow,
 } from '@/features/architect/history/utils/normalizeWorldEventsForTeamHistory';
+import type { RequestedHistoryEventDetail } from './types';
 
 type WorldEventsTimelineProps = {
   worldId: string;
   teamCode: string | null;
   onSelectEntry: (entry: TeamHistoryWorldEventRow) => void;
+  requestedHistoryEventDetail?: RequestedHistoryEventDetail | null;
+  onRequestedHistoryEventDetailHandled?: ((requestKey: number) => void) | null;
 };
 
 export const WorldEventsTimeline = ({
   worldId,
   teamCode,
   onSelectEntry,
+  requestedHistoryEventDetail = null,
+  onRequestedHistoryEventDetailHandled = null,
 }: WorldEventsTimelineProps) => {
+  const handledRequestKeyRef = useRef<number | null>(null);
   const {
     events,
     loading,
@@ -35,6 +41,47 @@ export const WorldEventsTimeline = ({
     () => normalizeWorldEventsForTeamHistory(events, teamCode),
     [events, teamCode]
   );
+
+  useEffect(() => {
+    if (!requestedHistoryEventDetail) {
+      return;
+    }
+    if (
+      handledRequestKeyRef.current === requestedHistoryEventDetail.requestKey
+    ) {
+      return;
+    }
+    if (
+      requestedHistoryEventDetail.worldId !== worldId ||
+      requestedHistoryEventDetail.teamCode !== teamCode
+    ) {
+      return;
+    }
+    if (loading) {
+      return;
+    }
+
+    const requestedId = requestedHistoryEventDetail.requestedSelectedEntryId;
+    const matchedEntry = timelineRows.find(
+      (entry) => entry.eventId === requestedId || entry.id === requestedId
+    );
+
+    handledRequestKeyRef.current = requestedHistoryEventDetail.requestKey;
+    if (matchedEntry) {
+      onSelectEntry(matchedEntry);
+    }
+    onRequestedHistoryEventDetailHandled?.(
+      requestedHistoryEventDetail.requestKey
+    );
+  }, [
+    requestedHistoryEventDetail,
+    worldId,
+    teamCode,
+    loading,
+    timelineRows,
+    onSelectEntry,
+    onRequestedHistoryEventDetailHandled,
+  ]);
 
   if (loading && timelineRows.length === 0) {
     return (

--- a/src/features/architect/history/TeamHistoryTab/types.ts
+++ b/src/features/architect/history/TeamHistoryTab/types.ts
@@ -52,6 +52,18 @@ export type TeamHistorySelectedEntry = {
   truthKind: TeamHistorySelectedEntryTruthKind;
 };
 
+export type RequestedHistoryEventDetailSource =
+  | 'post-action-handoff'
+  | 'activity-rail';
+
+export type RequestedHistoryEventDetail = {
+  requestKey: number;
+  requestedSelectedEntryId: string;
+  worldId: string;
+  teamCode: string;
+  source: RequestedHistoryEventDetailSource;
+};
+
 export type TeamHistoryWaivedContractEntry = {
   id?: string | null;
   name?: string | null;
@@ -122,6 +134,8 @@ export type TeamHistoryCapSheetLike = {
 export type TeamHistoryTabProps = {
   teamCapSheet: TeamHistoryCapSheetLike;
   worldId?: string | null;
+  requestedHistoryEventDetail?: RequestedHistoryEventDetail | null;
+  onRequestedHistoryEventDetailHandled?: ((requestKey: number) => void) | null;
   onInjectTeamHistoryFixtures?: (() => void) | null;
   onClearTeamHistoryFixtures?: (() => void) | null;
   hasInjectedTeamHistoryFixtures?: boolean;

--- a/src/tests/architect/stage2d.historyActivityDeeplink.test.tsx
+++ b/src/tests/architect/stage2d.historyActivityDeeplink.test.tsx
@@ -8,6 +8,8 @@
  */
 
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import React, { useState } from 'react';
 import '@testing-library/jest-dom/vitest';
 import {
@@ -275,6 +277,58 @@ describe('Stage 2D — History / Activity deep-linking', () => {
     });
   });
 
+  it('waits for committed timeline rows before acknowledging a request', async () => {
+    const onSelectEntry = vi.fn();
+    const onHandled = vi.fn();
+    const request: RequestedHistoryEventDetail = {
+      requestKey: 2,
+      requestedSelectedEntryId: 'evt_trade_1',
+      worldId: 'world_lal',
+      teamCode: 'LAL',
+      source: 'activity-rail',
+    };
+
+    useWorldTeamEventsMock.mockReturnValueOnce({
+      events: [],
+      loading: true,
+      loadingMore: false,
+      error: null,
+      hasMore: false,
+      resolution: 'authoritative',
+      loadMore: null,
+      refetch: vi.fn(),
+    });
+
+    const { rerender } = render(
+      <WorldEventsTimeline
+        worldId="world_lal"
+        teamCode="LAL"
+        onSelectEntry={onSelectEntry}
+        requestedHistoryEventDetail={request}
+        onRequestedHistoryEventDetailHandled={onHandled}
+      />
+    );
+
+    expect(onSelectEntry).not.toHaveBeenCalled();
+    expect(onHandled).not.toHaveBeenCalled();
+
+    mockWorldEvents([makeTradeEvent()]);
+    rerender(
+      <WorldEventsTimeline
+        worldId="world_lal"
+        teamCode="LAL"
+        onSelectEntry={onSelectEntry}
+        requestedHistoryEventDetail={request}
+        onRequestedHistoryEventDetailHandled={onHandled}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onSelectEntry).toHaveBeenCalledTimes(1);
+      expect(onHandled).toHaveBeenCalledWith(2);
+    });
+  });
+
   it('acknowledges a missing requested id without selecting or synthesizing a row', async () => {
     const onSelectEntry = vi.fn();
     const onHandled = vi.fn();
@@ -351,5 +405,30 @@ describe('Stage 2D — History / Activity deep-linking', () => {
       Number(firstKey) + 1
     );
     expect(onOpenHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('wires dashboard History requests and rail reads through resolved team codes', () => {
+    const source = readFileSync(
+      resolve(
+        process.cwd(),
+        'src/features/architect/GMDashboard/GMDashboard.tsx'
+      ),
+      'utf8'
+    );
+
+    expect(source).toContain('const resolvedHistoryTeamCode = useMemo');
+    expect(source).toContain('resolveTeamCode(normalizedTeamId)');
+    expect(source).toMatch(
+      /useHistoryEventDetailRequest\(\{\s*worldId,\s*teamCode: resolvedHistoryTeamCode,/
+    );
+    expect(source).not.toMatch(
+      /useHistoryEventDetailRequest\(\{\s*worldId,\s*teamCode: normalizedTeamId,/
+    );
+    expect(source).toMatch(
+      /<ScenarioMoveRail[\s\S]*?teamCode=\{resolvedHistoryTeamCode\}/
+    );
+    expect(source).not.toMatch(
+      /<ScenarioMoveRail[\s\S]*?teamCode=\{normalizedTeamId\}/
+    );
   });
 });

--- a/src/tests/architect/stage2d.historyActivityDeeplink.test.tsx
+++ b/src/tests/architect/stage2d.historyActivityDeeplink.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * FILE: src/tests/architect/stage2d.historyActivityDeeplink.test.tsx
+ * PURPOSE: Targeted tests for Stage 2D History / Activity deep-linking.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Covers committed-event detail requests from post-action handoff and the
+ * activity rail. Deep-linking remains read-only navigation/detail selection.
+ */
+
+// @vitest-environment jsdom
+import React, { useState } from 'react';
+import '@testing-library/jest-dom/vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+  act,
+} from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArchitectPostActionHandoff } from '@/features/architect/GMDashboard/components/ArchitectPostActionHandoff';
+import { ScenarioMoveRail } from '@/features/architect/GMDashboard/components/ScenarioMoveRail';
+import { useHistoryEventDetailRequest } from '@/features/architect/GMDashboard/hooks/useHistoryEventDetailRequest';
+import { TeamHistoryTab } from '@/features/architect/history/TeamHistoryTab';
+import { WorldEventsTimeline } from '@/features/architect/history/TeamHistoryTab/WorldEventsTimeline';
+import type { ArchitectPostActionReceipt } from '@/features/architect/GMDashboard/postActionHandoff/types';
+import type {
+  RequestedHistoryEventDetail,
+  TeamHistoryCapSheetLike,
+} from '@/features/architect/history/TeamHistoryTab/types';
+import type { WorldEventRecord } from '@/features/architect/history/hooks/useWorldTeamEvents';
+
+const useWorldTeamEventsMock = vi.fn();
+
+vi.mock('@/features/architect/history/hooks/useWorldTeamEvents', () => ({
+  useWorldTeamEvents: (...args: unknown[]) => useWorldTeamEventsMock(...args),
+}));
+
+const teamCapSheet: TeamHistoryCapSheetLike = {
+  teamCode: 'LAL',
+  waivedContracts: [],
+  exceptionHistory: [],
+  mleHistory: [],
+  pickLog: [],
+  currentPicks: {},
+  historyTimeline: [],
+};
+
+const makeReceipt = (
+  overrides: Partial<ArchitectPostActionReceipt> = {}
+): ArchitectPostActionReceipt => ({
+  kind: 'trade',
+  eventId: 'evt_trade_1',
+  occurredAt: '2026-05-01T00:00:00.000Z',
+  headline: 'Trade applied',
+  changedTeamCodes: ['LAL', 'BOS'],
+  primaryTeamCode: 'LAL',
+  primaryPlayerIds: ['player_1'],
+  authority: 'committed-world',
+  ...overrides,
+});
+
+const makeTradeEvent = (
+  overrides: Partial<WorldEventRecord> = {}
+): WorldEventRecord => ({
+  id: 'evt_trade_1',
+  eventId: 'evt_trade_1',
+  mutationType: 'executeTrade',
+  occurredAt: '2026-05-01T00:00:00.000Z',
+  teamCodes: ['LAL', 'BOS'],
+  playerIds: ['player_1'],
+  operationId: 'op_trade_1',
+  beforeTotalsByTeam: {
+    LAL: { totalCapAllocations: 150000000 },
+  },
+  afterTotalsByTeam: {
+    LAL: { totalCapAllocations: 149000000 },
+  },
+  ...overrides,
+});
+
+const mockWorldEvents = (events: WorldEventRecord[]) => {
+  useWorldTeamEventsMock.mockReturnValue({
+    events,
+    loading: false,
+    loadingMore: false,
+    error: null,
+    hasMore: false,
+    resolution: 'authoritative',
+    loadMore: null,
+    refetch: vi.fn(),
+  });
+};
+
+type Stage2DHarnessProps = {
+  receipt?: ArchitectPostActionReceipt | null;
+  worldId?: string;
+  teamCode?: string;
+};
+
+const Stage2DHarness = ({
+  receipt = makeReceipt(),
+  worldId = 'world_lal',
+  teamCode = 'LAL',
+}: Stage2DHarnessProps) => {
+  const [activeTab, setActiveTab] = useState<'home' | 'history'>('home');
+  const {
+    requestedHistoryEventDetail,
+    openHistoryRoot,
+    requestHistoryEventDetail,
+    handleHistoryEventDetailHandled,
+  } = useHistoryEventDetailRequest({
+    worldId,
+    teamCode,
+    onOpenHistory: () => setActiveTab('history'),
+  });
+
+  return (
+    <div>
+      <ArchitectPostActionHandoff
+        receipt={receipt}
+        onNavigateToCapSheet={vi.fn()}
+        onNavigateToRoster={vi.fn()}
+        onNavigateToHistory={() =>
+          requestHistoryEventDetail(
+            receipt?.eventId ?? null,
+            'post-action-handoff'
+          )
+        }
+        onDismiss={vi.fn()}
+      />
+      <ScenarioMoveRail
+        worldId={worldId}
+        teamCode={teamCode}
+        onOpenHistory={openHistoryRoot}
+        onOpenHistoryEntry={(eventId) =>
+          requestHistoryEventDetail(eventId, 'activity-rail')
+        }
+        highlightEventId={receipt?.eventId ?? null}
+      />
+      {activeTab === 'history' ? (
+        <TeamHistoryTab
+          teamCapSheet={{ ...teamCapSheet, teamCode }}
+          worldId={worldId}
+          requestedHistoryEventDetail={requestedHistoryEventDetail}
+          onRequestedHistoryEventDetailHandled={
+            handleHistoryEventDetailHandled
+          }
+        />
+      ) : (
+        <div data-testid="stage2d-home">Home</div>
+      )}
+    </div>
+  );
+};
+
+describe('Stage 2D — History / Activity deep-linking', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockWorldEvents([makeTradeEvent()]);
+  });
+
+  it('opens the matching History detail from post-action handoff View History when eventId exists', async () => {
+    render(<Stage2DHarness />);
+
+    fireEvent.click(screen.getByTestId('post-action-handoff-nav-history'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-detail-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('team-history-detail-event-id')).toHaveTextContent(
+        'evt_trade_1'
+      );
+    });
+    expect(screen.getByTestId('team-history-detail-truth-note')).toHaveTextContent(
+      'Authoritative world-event row'
+    );
+  });
+
+  it('falls back to History root from post-action handoff View History when eventId is null', async () => {
+    render(
+      <Stage2DHarness receipt={makeReceipt({ eventId: null })} />
+    );
+
+    fireEvent.click(screen.getByTestId('post-action-handoff-nav-history'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-section-timeline')).toBeInTheDocument();
+      expect(screen.getByTestId('team-history-row-0')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId('team-history-detail-modal')
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the matching History detail from an activity rail committed row click', async () => {
+    render(<Stage2DHarness />);
+
+    fireEvent.click(screen.getByTestId('scenario-move-rail-entry-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-detail-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('team-history-detail-event-id')).toHaveTextContent(
+        'evt_trade_1'
+      );
+    });
+    expect(screen.getByTestId('scenario-move-rail-entry-just-committed')).toBeInTheDocument();
+    expect(screen.getByText('Local and pending activity not shown.')).toBeInTheDocument();
+    expect(screen.getAllByTestId('scenario-move-rail-entry-button')).toHaveLength(1);
+  });
+
+  it('keeps the Full History button as History-root navigation', async () => {
+    render(<Stage2DHarness />);
+
+    fireEvent.click(screen.getByTestId('scenario-move-rail-open-history'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-section-timeline')).toBeInTheDocument();
+      expect(screen.getByTestId('team-history-row-0')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId('team-history-detail-modal')
+    ).not.toBeInTheDocument();
+  });
+
+  it('reopens the same event when repeated clicks create a new requestKey', async () => {
+    render(<Stage2DHarness />);
+
+    fireEvent.click(screen.getByTestId('post-action-handoff-nav-history'));
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-detail-modal')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('team-history-detail-close'));
+    expect(
+      screen.queryByTestId('team-history-detail-modal')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('post-action-handoff-nav-history'));
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-detail-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('team-history-detail-event-id')).toHaveTextContent(
+        'evt_trade_1'
+      );
+    });
+  });
+
+  it('WorldEventsTimeline consumes a matching request and calls onSelectEntry', async () => {
+    const onSelectEntry = vi.fn();
+    const onHandled = vi.fn();
+    const request: RequestedHistoryEventDetail = {
+      requestKey: 1,
+      requestedSelectedEntryId: 'evt_trade_1',
+      worldId: 'world_lal',
+      teamCode: 'LAL',
+      source: 'post-action-handoff',
+    };
+
+    render(
+      <WorldEventsTimeline
+        worldId="world_lal"
+        teamCode="LAL"
+        onSelectEntry={onSelectEntry}
+        requestedHistoryEventDetail={request}
+        onRequestedHistoryEventDetailHandled={onHandled}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onSelectEntry).toHaveBeenCalledTimes(1);
+      expect(onSelectEntry.mock.calls[0][0].eventId).toBe('evt_trade_1');
+      expect(onHandled).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('acknowledges a missing requested id without selecting or synthesizing a row', async () => {
+    const onSelectEntry = vi.fn();
+    const onHandled = vi.fn();
+    const request: RequestedHistoryEventDetail = {
+      requestKey: 7,
+      requestedSelectedEntryId: 'evt_missing',
+      worldId: 'world_lal',
+      teamCode: 'LAL',
+      source: 'activity-rail',
+    };
+
+    render(
+      <WorldEventsTimeline
+        worldId="world_lal"
+        teamCode="LAL"
+        onSelectEntry={onSelectEntry}
+        requestedHistoryEventDetail={request}
+        onRequestedHistoryEventDetailHandled={onHandled}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onHandled).toHaveBeenCalledWith(7);
+    });
+    expect(onSelectEntry).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId(/team-history-row-/)).toHaveLength(1);
+    expect(screen.queryByText('evt_missing')).not.toBeInTheDocument();
+  });
+
+  it('clears a pending request when world/team scope changes', async () => {
+    const onOpenHistory = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ worldId, teamCode }: { worldId: string; teamCode: string }) =>
+        useHistoryEventDetailRequest({
+          worldId,
+          teamCode,
+          onOpenHistory,
+        }),
+      { initialProps: { worldId: 'world_lal', teamCode: 'LAL' } }
+    );
+
+    act(() => {
+      result.current.requestHistoryEventDetail('evt_trade_1', 'activity-rail');
+    });
+    expect(result.current.requestedHistoryEventDetail?.worldId).toBe('world_lal');
+
+    rerender({ worldId: 'world_bos', teamCode: 'BOS' });
+
+    await waitFor(() => {
+      expect(result.current.requestedHistoryEventDetail).toBeNull();
+    });
+  });
+
+  it('increments requestKey for repeated same-event requests', () => {
+    const onOpenHistory = vi.fn();
+    const { result } = renderHook(() =>
+      useHistoryEventDetailRequest({
+        worldId: 'world_lal',
+        teamCode: 'LAL',
+        onOpenHistory,
+      })
+    );
+
+    act(() => {
+      result.current.requestHistoryEventDetail('evt_trade_1', 'activity-rail');
+    });
+    const firstKey = result.current.requestedHistoryEventDetail?.requestKey;
+
+    act(() => {
+      result.current.requestHistoryEventDetail('evt_trade_1', 'activity-rail');
+    });
+
+    expect(result.current.requestedHistoryEventDetail?.requestKey).toBe(
+      Number(firstKey) + 1
+    );
+    expect(onOpenHistory).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Stage 2D History / Activity deep-linking for Architect Operating Experience.

Stage 1 made Architect visually continuous. Stage 2A made it navigationally continuous. Stage 2B added post-action handoff receipts and activity rail refresh/highlight. Stage 2C added player/roster continuity. Stage 2D now lets committed activity and handoff history actions open the matching committed History detail when the event id is available.

## Added

- dashboard-owned one-shot History event detail request state
- post-action handoff `View History` → matching History detail when `receipt.eventId` exists
- post-action handoff `View History` → History root when `eventId` is null
- committed activity rail rows as accessible click targets
- activity rail row click → matching History detail
- request threading through `HistorySection`, `TeamHistoryTab`, and `WorldEventsTimeline`
- `WorldEventsTimeline` request consumption by committed row `eventId` / `id`
- missing requested ids acknowledge without synthetic rows or modal opening

## Review Corrections

- Fixed dashboard request/rail scoping to use resolved team codes such as `LAL` instead of route slugs such as `lakers`.
- Added coverage that request acknowledgement waits for committed rows.
- Added guard coverage for resolved team-code scoping.

## Guardrails

- No Firestore writes
- No new event source
- No synthetic History entries
- No local/pending rail entries
- No mutation callbacks from History, rail, or detail modal
- No player deep-links
- No Trade Machine reconstruction
- No baseline comparison
- No cap-delta recomputation
- History remains owner of `selectedEntry` and `HistoryDetailModal`

## Validation Reported

- Stage 2D targeted UI tests: 11 passed
- Stage 2A/2B/2C UI regression tests: 64 passed
- Stage 1 workspace/activity node tests: 35 passed
- `npm run typecheck`: passed
- `npm run build`: passed with existing Vite warnings
- `npm run validate:project`: passed
- `git diff --check`: passed

`npm run test:diff -- --reporter=dot` selected the broad Architect suite and hit unrelated pre-existing guardrail/source-scan/world-free-agency failures, so it was stopped. Full suite was not run because `RUN FULL SUITE` was not authorized.

## Deferred

- player/contract/Cap Sheet/Roster/Cap Table deep-links
- entitlement/pick/exception/cap-hold links
- Trade Machine reconstruction
- event-specific lookup
- broad pagination search
- baseline comparison
- cap-delta recomputation