### PR TITLE
Verify Architect operating experience stage two

### DIFF
--- a/docs/architect/ARCHITECT_STAGE_2_FINAL_VERIFICATION.md
+++ b/docs/architect/ARCHITECT_STAGE_2_FINAL_VERIFICATION.md
@@ -1,0 +1,231 @@
+# Architect Stage 2 — Final Verification Report
+
+**Stage:** 2E (Final Verification)
+**Branch:** `feature/architect-operating-experience-stage-2e-verification`
+**Base:** `main` (commit `2e7b499b`)
+**Date:** 2026-05-21
+**Verifier:** Claude Code (automated verification pass)
+
+---
+
+## Executive Summary
+
+Stage 2 delivered a complete operational continuity layer on top of the Stage 1
+visual continuity cockpit. Four sub-stages connected action lifecycles across
+all Architect surfaces without adding mutation authority, Firestore writes, new
+event sources, or changes to the mutation pipeline, season manager, or world
+manager.
+
+This verification pass confirms that all 30 acceptance criteria are met, that
+the Stage 1 and Stage 2A–2D test suites pass in full, and that the build and
+typecheck are clean. No corrections were required. No Stage 3 features, no
+Firestore writes, no synthetic history entries, no mutation callbacks, and no
+local/pending committed rows were found.
+
+---
+
+## Completed Stage 2 Scope
+
+| Sub-stage | Scope | Key Files Added or Changed |
+|-----------|-------|---------------------------|
+| **2A** | Navigation continuity — post-action tab routing, cockpit chip deep links, offseason close-and-navigate | `GMDashboard.tsx`, `ArchitectWorkspaceHeader.tsx`, `TradeSection.tsx`, `FreeAgencySection.tsx` |
+| **2B** | Post-action handoff receipts — committed receipt strip, rail refresh seam, history deep-link foundation | `ArchitectPostActionHandoff.tsx`, `useArchitectPostActionReceipt.ts`, `postActionHandoff/types.ts`, `ScenarioMoveRail.tsx`, `useScenarioActivityRail.ts` |
+| **2C** | Player/roster continuity — Roster card modal opener, receipt-derived focused player highlight on Roster / Cap Sheet / Full Cap Table | `RosterSection.tsx`, `postActionHandoff/playerFocus.ts`, `GMDashboard.tsx` (focusedPlayerId seam) |
+| **2D** | History/activity deep-linking — rail row → History detail, handoff View History → matched detail, missing-event fallback | `useHistoryEventDetailRequest.ts`, `ScenarioMoveRail.tsx`, `HistorySection.tsx`, `TeamHistoryTab.tsx`, `WorldEventsTimeline.tsx`, `history/TeamHistoryTab/types.ts` |
+
+---
+
+## Acceptance Checklist Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Successful trade apply routes to Cap Sheet | ✅ PASS | `GMDashboard.tsx:385` `onAfterTradeApplied: () => setActiveTab('cap')` |
+| 2 | Successful FA signing routes to Cap Sheet | ✅ PASS | `GMDashboard.tsx:401` `onAfterSigningComplete: () => setActiveTab('cap')`; `FreeAgencySection.tsx:57-63` wraps `signFreeAgent` and calls only on `result?.success` |
+| 3 | Header cap/exception affordances route to Cap Sheet | ✅ PASS | `ArchitectWorkspaceHeader.tsx:207-218` cap posture button; `:232-243` exceptions button; both wired to `onNavigateToCapSheet` |
+| 4 | Header season mismatch routes to Offseason | ✅ PASS | `ArchitectWorkspaceHeader.tsx:152-162` season-mismatch chip renders as a `<button>` calling `onNavigateToOffseason` |
+| 5 | Offseason summary close routes to Cap Sheet | ✅ PASS | `GMDashboard.tsx:724-727` `onClick`: `closeOffseasonModal(); setActiveTab('cap')` |
+| 6 | Successful committed actions produce receipts when authoritative data exists | ✅ PASS | `postActionHandoff/types.ts:134-167` `deriveReceiptFromMutationResult` returns non-null only when `result.success === true && !result.skipped && result.persistedToWorld !== false && result.appliedToLocalState !== false` |
+| 7 | Failed/thrown/skipped/non-applied mutations do not produce receipts | ✅ PASS | Same function returns `null` for all failure conditions; `authority: 'committed-world'` is set only on the success path |
+| 8 | Receipt state is session-scoped and clears on world/team scope change | ✅ PASS | `useArchitectPostActionReceipt.ts:33-42` effect clears receipt when `scopeKey` (= `worldId:teamCode`) changes |
+| 9 | Post-action handoff buttons are navigation-only | ✅ PASS | `ArchitectPostActionHandoff.tsx` has only `onNavigateToCapSheet`, `onNavigateToRoster`, `onNavigateToHistory`, `onDismiss` — no mutation callbacks |
+| 10 | Activity rail refreshes after committed receipt generation | ✅ PASS | `GMDashboard.tsx:504` `refreshKey={postActionReceipt.generation}` threaded through `ScenarioMoveRail` → `useScenarioActivityRail` → `useWorldTeamEvents` |
+| 11 | Activity rail preserves existing committed entries while refetching | ✅ PASS | `deriveActivityRailState` returns `'loading'` only when `normalizedEvents.length === 0`; stale entries are retained during refetch |
+| 12 | Activity rail never synthesizes local/pending/optimistic committed rows | ✅ PASS | `useScenarioActivityRail.ts:142` `localPendingDeferred: true` hardcoded; all entries tagged `authority: 'committed-world'` |
+| 13 | Roster player click opens existing contract modal route | ✅ PASS | `RosterSection.tsx:55-60` forwards `onOpenPlayerContractModal` as `onSelectPlayer`; `GMDashboard.tsx:600-606` wires to `actions.handleEditContract` |
+| 14 | Roster player click does not directly mutate anything | ✅ PASS | `handleEditContract` opens `EditContractModal`; the modal owns mutation authority through `useArchitectActions` |
+| 15 | Legacy roster add/remove controls remain suppressed | ✅ PASS | `RosterVisual` continues to pass `LEGACY_ROSTER_DISPLAY_ONLY_PROPS = { isExport: true }` — `onRemove`/`onAdd` remain silenced |
+| 16 | Receipt-derived focused player highlights Roster / Cap Sheet / Full Cap Table | ✅ PASS | `GMDashboard.tsx:244` `focusedPlayerId = receipt?.primaryPlayerIds?.[0] ?? null`; passed as `highlightPlayerId` to `RosterSection:607`, `CapSheetSection:375`, `CapTableSection:629` |
+| 17 | Focused player clears with receipt dismissal/scope clearing | ✅ PASS | `focusedPlayerId` is derived from `postActionReceipt.receipt`; clears automatically when receipt is dismissed or scope changes |
+| 18 | Handoff View History opens matching committed History detail when eventId exists | ✅ PASS | `GMDashboard.tsx:489-494` calls `requestHistoryEventDetail(receipt?.eventId, 'post-action-handoff')`; `WorldEventsTimeline.tsx:64-73` matches by `entry.eventId` or `entry.id` and calls `onSelectEntry` |
+| 19 | Handoff View History falls back to History root when eventId is null | ✅ PASS | `useHistoryEventDetailRequest.ts:62-64`: when `!requestedSelectedEntryId`, calls `openHistoryRoot()` which clears pending request and navigates to history tab root |
+| 20 | Activity rail row opens matching committed History detail | ✅ PASS | `ScenarioMoveRail.tsx:134-136` each entry renders a `<button>` calling `onOpenHistoryEntry?.(entry.id)`; `GMDashboard.tsx:501-503` wires to `requestHistoryEventDetail` |
+| 21 | Full History button still opens History root | ✅ PASS | `ScenarioMoveRail.tsx:63-70` "Full History →" button calls `onOpenHistory` which is bound to `openHistoryRoot` in `GMDashboard.tsx:500` |
+| 22 | Missing requested History event does not synthesize a row or open a fake modal | ✅ PASS | `WorldEventsTimeline.tsx:65-74`: if no match found, acknowledges the request key and returns without calling `onSelectEntry`; timeline root remains visible |
+| 23 | History selectedEntry and HistoryDetailModal ownership remain inside History | ✅ PASS | `TeamHistoryTab.tsx:31` `selectedEntry` is local state; `HistoryDetailModal` at line 264 is rendered inside `TeamHistoryTab`; deep-link only calls the same `onSelectEntry` used by manual clicks |
+| 24 | No Trade Machine player prefill was added | ✅ PASS | `TradeSection.tsx` forwards only existing props; no `initialPlayerTokens`, `prefillPlayer`, or equivalent prop added |
+| 25 | No History-to-player deep-links were added | ✅ PASS | `HistoryDetailModal.tsx` has no navigation callbacks; `TeamHistoryTab.tsx` has no `onNavigateToPlayer` or equivalent |
+| 26 | No baseline deltas or scenario comparison were added | ✅ PASS | No comparison view, no base-vs-world diff, no new delta computation surface introduced |
+| 27 | No Firestore writes were added | ✅ PASS | All Stage 2 hooks (`useHistoryEventDetailRequest`, `useArchitectPostActionReceipt`) and helpers (`postActionHandoff/types.ts`, `postActionHandoff/playerFocus.ts`) are pure React state — confirmed by grep: zero Firestore write calls (`setDoc`, `addDoc`, `updateDoc`, `deleteDoc`, `writeBatch`, `runTransaction`) |
+| 28 | No new event source was added | ✅ PASS | All committed-event reads still flow through `useWorldTeamEvents`; no new Firestore collection, subscription, or query contract added |
+| 29 | No mutationPipeline, seasonManager, or worldManager changes were made | ✅ PASS | Grep confirms Stage 2 files do not import or call these utilities; the pre-existing references in `SeasonAdvanceModal.tsx` and `WorldSelector.tsx` are unchanged |
+| 30 | GMDashboard remains a composition shell | ✅ PASS | `GMDashboard.tsx` delegates mutations to `useArchitectActions`, state to `useArchitectState`, navigation to `setActiveTab`; no mutation logic was introduced |
+
+**All 30 acceptance criteria: PASS**
+
+---
+
+## Integration Findings
+
+### Positive Findings
+
+- **Receipt lifetime is authority-correct.** `deriveReceiptFromMutationResult` rejects results unless `success === true`, `skipped !== true`, `persistedToWorld !== false`, and `appliedToLocalState !== false`. This means only genuinely committed world writes produce a receipt strip.
+
+- **Rail refresh is safe.** The `refreshKey` counter increments on receipt publication (i.e., after a committed write), not on local mutations or pending state. `deriveActivityRailState` preserves stale entries during the refetch by only entering `'loading'` state when the entries array is empty.
+
+- **Deep-link request is one-shot and scoped.** `requestKey` is a monotonically increasing session counter; `worldId` + `teamCode` scope filtering ensures stale requests from prior team/world contexts are silently ignored by `WorldEventsTimeline`.
+
+- **focusedPlayerId matching is identity-tolerant.** `playerMatchesFocus` in `playerFocus.ts` attempts matching across `id`, `player_id`, `bio.playerId`, and normalized name keys. This correctly handles the case where a receipt carries a player id token that doesn't match the cap sheet's primary `id` field.
+
+- **Missing event falls back cleanly.** When `WorldEventsTimeline` resolves the first loaded page and finds no matching entry, it acknowledges the request key (clearing the one-shot state in GMDashboard) and leaves the timeline root visible — no synthetic row, no fake modal.
+
+### Risk Notes (Confirmed Mitigated)
+
+- **Route slug vs resolved team code:** `GMDashboard` derives `resolvedHistoryTeamCode` from `teamCapSheet?.teamCode` with a fallback to `resolveTeamCode(normalizedTeamId)`. This ensures the History request is scoped to the same code used by the committed world events feed, not the raw URL slug.
+
+- **Stale receipt not leaking across worlds/teams:** `postActionReceiptScopeKey` is `worldId:teamCode`. The effect in `useArchitectPostActionReceipt` clears the receipt on any key change.
+
+- **Local preview not shown as committed truth:** `TradeReceiptPanel` (a DEV diagnostic for the pre-apply draft) is not connected to `ArchitectPostActionHandoff`. The handoff strip only renders when `postActionReceipt.receipt` is non-null, which requires a successful pipeline commit.
+
+---
+
+## Known Pre-Existing Failures
+
+The following test files failed in the full `test:architect` run. All failures pre-date Stage 2 and are unrelated to this verification pass. None of the Stage 2 specific test files are in this list.
+
+| Test File | Failures | Category |
+|-----------|----------|----------|
+| `capSheet_closure.gate.test.ts` | 2 | Reference to removed canonicalize helpers |
+| `offerSheets_closure.gate.test.ts` | 9 | Pre-existing offer-sheet gate failures |
+| `phase68_verify_only_empty_scan_must_fail_guardrails.test.ts` | 27 | Pre-existing migration scan gate |
+| `phase69_seeded_verify_only_nonempty_proof_guardrails.test.ts` | 28 | Pre-existing migration scan gate |
+| `phase67_migration_execution_guardrails.test.ts` | 14 | Pre-existing migration execution gate |
+| `phase70_ci_proof_and_prod_write_safety_guardrails.test.ts` | 16 | Pre-existing CI proof gate |
+| `useArchitectState.worldFreeAgency.test.ts` | 18 | TypeError from pre-existing `useArchitectPlayerData` mock gap |
+| Various guardrail/compatibility tests | ~42 | Pre-existing guardrail/compatibility reference failures |
+
+**Total pre-existing failures: 178 tests across 39 files.**
+
+These failures are present on `main` before this branch was created and are unrelated to Stage 2 operating experience work.
+
+---
+
+## Guardrail Confirmations
+
+| Guardrail | Status |
+|-----------|--------|
+| No Stage 3 features added | ✅ Confirmed — no scenario comparison, no cross-surface delta computation, no new guided workflow |
+| No Firestore writes added | ✅ Confirmed — grep: zero write calls in Stage 2 files |
+| No new event source added | ✅ Confirmed — all committed events still read from `useWorldTeamEvents` |
+| No synthetic History entries | ✅ Confirmed — missing requests fall back silently; no fake row constructed |
+| No local/pending committed rows in rail | ✅ Confirmed — `localPendingDeferred: true` hardcoded; all entries require `useWorldTeamEvents` materialization |
+| No mutation callbacks in rail/header/history | ✅ Confirmed — all callbacks in these components are `setActiveTab` or receipt dismiss only |
+| No Trade Machine player prefill | ✅ Confirmed — `useTradeMachine` init is unchanged |
+| No History-to-player deep-links | ✅ Confirmed — `HistoryDetailModal` has no outbound navigation |
+| No baseline deltas or scenario comparison | ✅ Confirmed — no comparison surface or new delta util introduced |
+| No mutationPipeline/seasonManager/worldManager changes | ✅ Confirmed — grep: zero imports/calls in Stage 2 files |
+| GMDashboard remains a composition shell | ✅ Confirmed — no mutation logic in dashboard |
+| History selectedEntry ownership inside History | ✅ Confirmed — `TeamHistoryTab` owns `selectedEntry` local state; modal renders there |
+
+---
+
+## Deferred Items Moving to Stage 3+
+
+These items were explicitly deferred by the Stage 2 discovery documents and remain out of scope:
+
+- **History event → affected player on Roster / Cap Sheet** — requires player-keyed navigation from `HistoryDetailModal`; depends on Stage 3 authority model.
+- **History event → contract modal** — mutation-aware detail linking; deferred to Stage 4.
+- **History event → entitlement / pick / exception / cap-hold deep-link** — requires typed navigation targets not yet present on normalized rows.
+- **Trade Machine player prefill from external context** — requires `useTradeMachine` init contract expansion; deferred.
+- **Season advance History detail** — `WorldAdvanceAftermath` does not expose the committed event id; `deriveSeasonAdvanceReceipt` correctly uses `eventId: null` and falls back to History root.
+- **Manual focus publication** (Slice 4 of Stage 2C) — `focusedPlayerId` is currently receipt-derived only; manual player selection focus deferred.
+- **Cap Sheet ⇄ Full Cap Table same-player scroll sync** — same-player continuity across cap tabs deferred.
+- **Offseason aftermath sticky badge** — persistent badge showing "Season Advanced — N expired, M declined" deferred to Stage 2C follow-up.
+- **Scenario comparison / baseline deltas** — Stage 3 scope.
+- **Full Stage 6 ship-readiness audit** — after Stage 5 polish pass.
+
+---
+
+## Recommended Next Stage
+
+**Stage 3: Scenario Comparison and Branching**
+
+Stage 2 is complete and integration-verified. The operating experience layer is stable:
+- Cockpit navigation is wired (2A)
+- Committed receipt truth is surfaced (2B)
+- Player identity is continuous across surfaces (2C)
+- History deep-links are live (2D)
+
+Stage 3 may now begin with confidence that the Stage 1/2 continuity foundation is solid and all mutation/authority boundaries are respected.
+
+---
+
+## Files Inspected
+
+| File | Purpose |
+|------|---------|
+| `docs/architect/ARCHITECT_NEXT_ERA_MASTER_PLAN.md` | Staged roadmap and Stage 2 framing |
+| `docs/architect/ARCHITECT_STAGE_2_ACTION_CONTINUITY_DISCOVERY.md` | Stage 2A discovery |
+| `docs/architect/ARCHITECT_STAGE_2B_POST_ACTION_HANDOFF_DISCOVERY.md` | Stage 2B discovery |
+| `docs/architect/ARCHITECT_STAGE_2C_PLAYER_ROSTER_CONTINUITY_DISCOVERY.md` | Stage 2C discovery |
+| `docs/architect/ARCHITECT_STAGE_2D_HISTORY_ACTIVITY_DEEPLINK_DISCOVERY.md` | Stage 2D discovery |
+| `src/features/architect/GMDashboard/GMDashboard.tsx` | Composition shell — all Stage 2 wiring |
+| `src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx` | Stage 2A cockpit navigation chips |
+| `src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx` | Stage 2B receipt strip — navigation-only |
+| `src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx` | Stage 2B/2D activity rail |
+| `src/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext.ts` | Stage 1A workspace context |
+| `src/features/architect/GMDashboard/hooks/useScenarioActivityRail.ts` | Stage 1D/2B rail hook |
+| `src/features/architect/GMDashboard/hooks/useArchitectPostActionReceipt.ts` | Stage 2B receipt store |
+| `src/features/architect/GMDashboard/hooks/useHistoryEventDetailRequest.ts` | Stage 2D one-shot request |
+| `src/features/architect/GMDashboard/postActionHandoff/types.ts` | Stage 2B receipt model |
+| `src/features/architect/GMDashboard/postActionHandoff/playerFocus.ts` | Stage 2C focus matching |
+| `src/features/architect/GMDashboard/sections/RosterSection.tsx` | Stage 2C roster modal seam |
+| `src/features/architect/GMDashboard/sections/CapSheetSection.tsx` | Stage 2C highlight forwarding |
+| `src/features/architect/GMDashboard/sections/CapTableSection.tsx` | Stage 2C highlight forwarding |
+| `src/features/architect/GMDashboard/sections/TradeSection.tsx` | Stage 2A trade post-apply nav |
+| `src/features/architect/GMDashboard/sections/FreeAgencySection.tsx` | Stage 2A signing post-apply nav |
+| `src/features/architect/GMDashboard/sections/HistorySection.tsx` | Stage 2D request prop pass-through |
+| `src/features/architect/history/TeamHistoryTab/TeamHistoryTab.tsx` | Stage 2D request consumption, selectedEntry ownership |
+| `src/features/architect/history/TeamHistoryTab/WorldEventsTimeline.tsx` | Stage 2D entry matching effect |
+| `src/features/architect/history/TeamHistoryTab/HistoryDetailModal.tsx` | History detail display — read-only |
+
+---
+
+## Validation Commands and Results
+
+| Command | Result |
+|---------|--------|
+| `npm run typecheck` | ✅ PASS — zero TypeScript errors |
+| `npm run validate:project` | ✅ PASS — all structural validations pass |
+| `npm run build` | ✅ PASS — built in ~1m 18s, no new errors (pre-existing chunk-size warning unrelated to Stage 2) |
+| Stage 1 tests (node config): `architectWorkspaceContext.stage1a` + `architectActivityRail.stage1d` | ✅ PASS — 35/35 |
+| Stage 2A: `stage2a.navigationContinuity.test.tsx` | ✅ PASS — 11/11 |
+| Stage 2B: `stage2b.postActionHandoff.test.tsx` | ✅ PASS — 24/24 |
+| Stage 2C: `stage2c.playerRosterContinuity.test.tsx` | ✅ PASS — 29/29 |
+| Stage 2D: `stage2d.historyActivityDeeplink.test.tsx` | ✅ PASS — 11/11 |
+| `npm run test:architect` (full scope) | 39 files failed / 246 passed — all failures are pre-existing; zero new failures introduced by Stage 2 |
+
+---
+
+## Corrections Made
+
+None. Stage 2 was verified in its current state with no corrections required.
+
+---
+
+## Unrelated Files Left Untouched
+
+The following files were present in the working tree but were not staged or modified:
+
+- `work/architect-split/WAVE10_PLAN.md`
+- `work/architect-split/WAVE11_PLAN.md`
+- `work/architect-split/WAVE12_PLAN.md`


### PR DESCRIPTION
## Summary

Adds the final Stage 2 verification report for Architect Operating Experience.

Stage 2 is now verified as an integrated operating-experience layer covering navigation continuity, post-action handoffs, player/roster continuity, and History/activity deep-linking.

## Added

- `docs/architect/ARCHITECT_STAGE_2_FINAL_VERIFICATION.md`

## Acceptance Result

All 30 Stage 2 acceptance criteria passed.

Covered areas:
- Stage 2A navigation routing
- Stage 2B receipt authority and post-action handoffs
- Stage 2C roster/player continuity and receipt-derived focus
- Stage 2D History/activity deep-linking
- authority and ownership guardrails

## Validation Reported

- `typecheck`: passed with zero errors
- `validate:project`: passed
- `build`: passed, with pre-existing chunk-size warning only
- Stage 1 tests: 35/35 passed
- Stage 2A tests: 11/11 passed
- Stage 2B tests: 24/24 passed
- Stage 2C tests: 29/29 passed
- Stage 2D tests: 11/11 passed

`test:architect` full scope still has 178 failures across 39 files, all reported as pre-existing and unrelated to Stage 2.

## Guardrails Confirmed

- No Stage 3 features
- No Firestore writes
- No new event source
- No synthetic History entries
- No local/pending committed rows
- No mutation callbacks in rail/header/history
- No Trade Machine prefill
- No baseline deltas
- No scenario comparison
- No owner changes
- `GMDashboard` remains a composition shell

## Next Recommended Stage

Stage 3: Scenario Comparison and Branching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Stage 2 Final Verification Report documenting completed verification scope, acceptance checklist with evidence, integration findings, test status, guardrails confirmation, and validation results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bet-Zero/scoutzero/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->