### PR TITLE
Polish Architect operating experience

### DIFF
--- a/docs/architect/ARCHITECT_STAGE_5_FINAL_VERIFICATION.md
+++ b/docs/architect/ARCHITECT_STAGE_5_FINAL_VERIFICATION.md
@@ -1,0 +1,374 @@
+# Architect Stage 5 — Final Verification Report
+
+**Stage:** 5B (Final Verification)
+**Branch:** `feature/architect-operating-experience-stage-5-polish`
+**Base:** Stage 4 verified on `main` (commit `adf0c12f`)
+**Stage 5A commit:** `95e2d33f` — "Polish Architect operating experience"
+**Date:** 2026-05-22
+**Verifier:** Claude Code (automated verification pass)
+
+---
+
+## Executive Summary
+
+Stage 5 polishes the Architect operating experience built across Stages 1–4
+so it feels more professional, consistent, readable, and intentional without
+adding new product behavior. Stage 5A landed the polish; Stage 5B (this
+report) verifies that the polish met its scope and broke nothing.
+
+This verification pass confirms that all 35 acceptance criteria are met,
+that the Stage 5 polish test suite passes in full (19/19 tests), and that
+all targeted Stage 1, Stage 2, Stage 3, and Stage 4 test suites continue to
+pass with no new failures (258/258 targeted tests across Stages 1–5). The
+build, typecheck, and `validate:project` are clean.
+
+No corrections were required during verification. No Stage 6 audit/fix
+work was added. No new features, tabs, mutations, Firestore writes/reads,
+event sources, validators, comparison derivations, or guided-answer
+derivations were introduced. The polish layer sits entirely on top of
+existing Stage 1/2/3/4 seams.
+
+---
+
+## Completed Stage 5 Scope
+
+| Sub-stage | Scope | Key Artifacts |
+|-----------|-------|---------------|
+| **5A** | Tab bar extraction + `type="button"` / tablist semantics / focus rings; copy standardization across the workspace header, activity rail, post-action handoff, Compare tab, and Guide tab; loading/empty/error/unavailable state normalization; Compare and Guide section titles + read-only qualifiers; accessibility refinements (aria-labels, navigation-only intent reinforcement) | `src/features/architect/GMDashboard/components/ArchitectTabBar.tsx` (new), `src/features/architect/GMDashboard/GMDashboard.tsx`, `src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx`, `src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx`, `src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx`, `src/features/architect/GMDashboard/sections/ComparisonSection.tsx`, `src/features/architect/GMDashboard/sections/GuideSection.tsx`, `docs/architect/ARCHITECT_STAGE_5_POLISH_NOTES.md` |
+| **5A tests** | 19 targeted polish tests covering tab bar a11y, copy normalization, Compare/Guide navigation-only invariant, loading/error ARIA roles, and the GuideSection no-input invariant | `src/tests/architect/stage5.polish.test.tsx` |
+| **5B** | This final verification — guardrail confirmations, acceptance results, integration findings | `docs/architect/ARCHITECT_STAGE_5_FINAL_VERIFICATION.md` |
+
+---
+
+## Acceptance Checklist Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Stage 5 polish notes exist | ✅ PASS | `docs/architect/ARCHITECT_STAGE_5_POLISH_NOTES.md` present on branch |
+| 2 | `ArchitectTabBar` exists and replaces the inline dashboard tab bar | ✅ PASS | `src/features/architect/GMDashboard/components/ArchitectTabBar.tsx` exports `ArchitectTabBar` + `ArchitectTabDescriptor`; `GMDashboard.tsx` imports it and renders `<ArchitectTabBar activeTab={activeTab} tabs={dashboardTabs} />` (no inline tab buttons remain) |
+| 3 | All nine existing tabs remain present | ✅ PASS | `GMDashboard.tsx:504–551` defines a 9-entry `dashboardTabs` array — `roster`, `cap`, `capfull`, `trade`, `fa`, `offseason`, `history`, `compare`, `guide` — matching the Stage 4 set exactly |
+| 4 | No new tabs were added | ✅ PASS | Diff shows zero additions to `ActiveTab` union; descriptor array length is 9 (was 9) |
+| 5 | Existing `activeTab` behavior remains unchanged | ✅ PASS | Tab `onActivate` callbacks delegate to the same `setActiveTab` / `openHistoryRoot` handlers as Stage 4; no new state, no new side effect |
+| 6 | Tab buttons use `type="button"` | ✅ PASS | `ArchitectTabBar.tsx:52` sets `type="button"` on every rendered button; Stage 5 test "renders one button per descriptor with type=\"button\" and role=\"tab\"" asserts on all nine |
+| 7 | Tab bar uses tablist/tab semantics | ✅ PASS | `ArchitectTabBar.tsx:43–53` — container has `role="tablist"` + `aria-label`; each button has `role="tab"`, `aria-pressed`, `aria-selected`; Stage 5 tests "container has role=\"tablist\" and an aria-label" and "marks the active tab with aria-pressed=true and aria-selected=true" both pass |
+| 8 | Tab buttons remain keyboard-focusable with visible focus rings | ✅ PASS | `ArchitectTabBar.tsx:29–32` — `focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-1`; buttons are native `<button>` elements, so default tabbable; Stage 4/5 test "clicking every button only triggers navigation events" exercises every button via `getAllByRole('button')` |
+| 9 | Existing data-testids preserved | ✅ PASS | `dashboardTabs` carries `tab-cap-sheet`, `tab-full-cap-table`, `tab-compare`, `tab-guide`; Stage 4 test `screen.getByTestId('tab-guide')` and Stage 3C test `screen.getByTestId('tab-compare')` would still resolve (rendered through `ArchitectTabBar`'s `data-testid={tab.testId}`) |
+| 10 | Season select has an `aria-label` and focus ring | ✅ PASS | `GMDashboard.tsx:583–597` — `aria-label="Viewing season"` + `focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40` |
+| 11 | Workspace header copy is standardized without changing authority meaning | ✅ PASS | `ArchitectWorkspaceHeader.tsx:253–256` — row 3 indicators now read `Exceptions · See Cap Sheet`, `Draft picks · See Trade`, `Activity · See History`; authority chips (`mode.shortLabel`, `CapSummary`, `ExceptionLine`) and mode tone classes are unchanged |
+| 12 | Workspace header navigation remains navigation-only | ✅ PASS | The exceptions / cap-posture / season-mismatch buttons still call only `onNavigateToCapSheet` or `onNavigateToOffseason`; no validator or mutation hook is imported by `ArchitectWorkspaceHeader.tsx` |
+| 13 | Post-action handoff behavior is unchanged; buttons only gained polish/focus treatment | ✅ PASS | `ArchitectPostActionHandoff.tsx` diff: `+ focus-visible:ring-1 focus-visible:ring-white/40` on each `className`; no copy or callback wiring changes; chip text remains `"Committed world"`; Stage 2B test `expect(getByTestId('post-action-handoff-status-chip')).toHaveTextContent('Committed world')` continues to pass |
+| 14 | `ScenarioMoveRail` behavior is unchanged; copy/accessibility only | ✅ PASS | Diff: wrapper gained `aria-label="Recent committed activity"`; `Full History →` → `Open History →`; history button gained focus ring; rail-state hook and entry rendering identical to Stage 2D; Stage 2D test "keeps the Full History button as History-root navigation" passes (it asserts on the testid, not the label) |
+| 15 | `ComparisonSection` remains read-only and navigation-only | ✅ PASS | `ComparisonSection.tsx` imports no validators, no mutations, no Firestore APIs; nav buttons (`type="button"`) only call `onNavigateToHistory` / `onNavigateToCapSheet` / `onNavigateToRoster` callbacks; Stage 5 test "navigation buttons still call only their navigation callback" exercises each |
+| 16 | `ComparisonSection` loading/error/unavailable states remain present and accessible | ✅ PASS | All four states render with explicit `data-testid` (`comparison-sandbox-state`, `comparison-loading-state`, `comparison-error-state`, `comparison-empty-state`, `comparison-unavailable-summary`); loading state gained `role="status"` + `aria-live="polite"`; error state gained `role="alert"`; Stage 3C tests + Stage 5 tests cover each |
+| 17 | `GuideSection` remains read-only and navigation-only | ✅ PASS | `GuideSection.tsx` accepts only `viewModel: Stage4GuidedAnswersViewModel` + `onNavigate: (id) => void`; Stage 4 test "every click should have been a navigation event" + Stage 5 test "clicking every button only triggers navigation events" both pass |
+| 18 | `GuideSection` contains no input, textarea, contentEditable, or chatbot/freeform prompt UI | ✅ PASS | Grep on file returns zero `<input`, `<textarea`, or `contentEditable` matches; Stage 4 test `container.querySelectorAll('input').length === 0` + Stage 5 test "still does not render any input, textarea, or contentEditable element" both pass |
+| 19 | Guide navigation buttons announce navigation-only intent | ✅ PASS | `GuideSection.tsx:147–157` — each `NavigationButton` carries `title="Navigation only — opens the existing surface"` + `aria-label={`${target.label} (navigation only)`}`; Stage 5 test "navigation buttons carry a navigation-only accessible name" asserts on `aria-label` and `title` |
+| 20 | Authority labels remain visible | ✅ PASS | `AuthorityChip` rendering is unchanged in `GuideSection.tsx` and `ComparisonSection.tsx`; only the scope-card label string normalized from `"Committed World"` to `"Committed world"` for consistency; Stage 4 test "shows authority labels on evidence chips" passes; Stage 3C tests asserting `getByText(/committed world/i)` pass |
+| 21 | Deferred/unavailable summaries remain visible | ✅ PASS | `ComparisonSection.tsx:407–416` still renders `comparison-unavailable-summary` with `SectionHeading "Deferred / Unavailable"` plus a new clarifying intro line; `GuideSection.tsx` still renders `guide-deferred-reasons` list per answer; Stage 3C and Stage 4 tests pass |
+| 22 | No comparison derivation behavior changed | ✅ PASS | `src/features/architect/comparison/` and `useArchitectComparisonViewModel.ts` are untouched on Stage 5 (verified via `git diff main..HEAD --stat` showing zero changes in those paths) |
+| 23 | No guided-answer derivation behavior changed | ✅ PASS | `src/features/architect/guidedQuestions/` and `useArchitectGuidedAnswers.ts` are untouched on Stage 5; all 39 Stage 4B tests pass unchanged |
+| 24 | No mutation behavior changed | ✅ PASS | `useArchitectActions*`, `mutationPipeline*`, `seasonManager*`, `worldManager*` files are unmodified by Stage 5 (verified via diff) |
+| 25 | No validation behavior changed | ✅ PASS | No validator imports were added to any polished file; Trade Machine and Free Agency validators are untouched |
+| 26 | No Firestore reads were added | ✅ PASS | Grep for `getDoc/getDocs/onSnapshot/collection(/query(` on Stage 5 files returns zero hits |
+| 27 | No Firestore writes were added | ✅ PASS | Grep for `setDoc/addDoc/updateDoc/deleteDoc/writeBatch/runTransaction` on Stage 5 files returns zero hits |
+| 28 | No new event source was added | ✅ PASS | No new Firestore subscription, no new hook calls, no new collection or query helpers; the existing Stage 1/2/3/4 seams (`useArchitectWorkspaceContext`, `useArchitectComparisonViewModel`, `useScenarioActivityRail`, `useArchitectPostActionReceipt`, `useArchitectGuidedAnswers`) are consumed unchanged |
+| 29 | No move generation or planning logic was added | ✅ PASS | No trade composer, no signing planner, no offseason path generator; only one new presentational component (`ArchitectTabBar`) was introduced |
+| 30 | No branching/scenario creation UI was added | ✅ PASS | No `createWorld`, no `worldManager.*`, no branch creation control in any Stage 5 file |
+| 31 | No world-vs-world or parent-world comparison was added | ✅ PASS | `ComparisonSection.tsx` continues to render only the Stage 3 `ComparisonViewModelStatus` view model; no second-world dropdown, no parent-world toggle |
+| 32 | No Stage 6 audit/fix work was added | ✅ PASS | No new lint config, no new perf instrumentation, no new test infra, no broad refactor; one new component + targeted tests + polish edits only |
+| 33 | Existing Stage 1/2/3/4 targeted suites still pass | ✅ PASS | Stage 1A 17/17, Stage 1D 18/18, Stage 2A 11/11, Stage 2B 24/24, Stage 2C 29/29, Stage 2D 11/11, Stage 3 foundation 57/57, Stage 3C 33/33, Stage 4 39/39 — total 239/239 |
+| 34 | Stage 5 polish tests pass | ✅ PASS | `stage5.polish.test.tsx` — 19/19 |
+| 35 | Docs hierarchy is updated if repo tooling requires it | ✅ PASS | Stage 5A commit included the pre-commit hook's regenerated `docs/ArchitectHierarchy.md` covering the new `ArchitectTabBar.tsx`; Stage 5B run produced no further hierarchy delta |
+
+**All 35 acceptance criteria: PASS**
+
+---
+
+## Integration Findings
+
+### Positive Findings
+
+- **Polish layer is genuinely additive.** Stage 5's only new module is
+  `ArchitectTabBar.tsx`. Every other change is a small in-place edit that
+  either added an attribute (`type="button"`, `aria-label`, `role`,
+  `focus-visible:ring-*`), normalized a literal string (`"Committed World"`
+  → `"Committed world"`, `"Full History →"` → `"Open History →"`,
+  `Label: see …` → `Label · See …`), or introduced a section-level title +
+  qualifier in `ComparisonSection` and `GuideSection`. No behavior moved.
+
+- **Authority meaning is preserved.** Authority chip text is the only
+  reading the user has of "is this committed world truth?" Stage 5
+  normalized the visible casing (`Committed world`) but did **not** modify
+  the underlying `mode.kind`, `mode.tone`, or `scope.authority` values. The
+  Stage 1A `mode.label` fixture remains `"Committed World"`; only the
+  user-facing chip string was lowercased to match the post-action handoff
+  vocabulary.
+
+- **Composition shell remains a composition shell.** `GMDashboard.tsx`'s
+  only structural change is replacing nine inline `<button>` elements with
+  one `<ArchitectTabBar>` invocation backed by a `useMemo`-ed descriptor
+  list. No new mutation logic, no new state, no new hook calls.
+
+- **Tab semantics enrich without breaking.** Adding `role="tablist"` /
+  `role="tab"` / `aria-selected` to the tab bar gives screen-reader users
+  a clearer mental model. Because the buttons remain native `<button>`
+  elements and continue to call `setActiveTab` / `openHistoryRoot`,
+  keyboard activation (Enter/Space) and mouse activation both still work
+  identically. The legacy `data-testid` values are preserved through the
+  descriptor's `testId` field.
+
+- **Compare / Guide titling clarifies intent.** Before Stage 5, both tabs
+  opened directly into chip+card content with no header explaining what
+  the tab was. The new "Committed Scenario Comparison" / "Front Office
+  Guide" titles plus their `Read-only · …` qualifier strip immediately
+  reinforce that neither tab is interactive in the mutation sense.
+
+- **Loading / error / unavailable parity.** The Compare tab now matches
+  the Activity Rail's discipline of always rendering a card-shaped state
+  with explicit ARIA role for assistive tech (`role="status"` /
+  `aria-live="polite"` for loading, `role="alert"` for error). The Guide
+  tab's `guide-unavailable-state` was already card-shaped.
+
+- **No nested interactive controls.** Every navigation button in the
+  Guide and Compare panes remains a single `<button>`. The
+  `ArchitectWorkspaceHeader`'s exceptions / cap-posture / season-mismatch
+  affordances remain single buttons. No `<button>` is rendered inside
+  another `<button>`.
+
+### Risk Notes (Confirmed Mitigated)
+
+- **`role="tab"` without `role="tabpanel"`.** Strict WAI-ARIA recommends
+  pairing tabs with tabpanels and `aria-controls`. The Stage 5 polish
+  intentionally stops short of that — the existing dashboard panel
+  structure uses `activeTab` to conditionally render one of nine
+  section components, none of which is wrapped in a `role="tabpanel"`
+  container. This is an intentional Stage 6 deferral: introducing
+  tabpanel semantics correctly would require touching every section
+  shell and threading id/aria-controls through, which is broader than
+  Stage 5's "polish-only" scope. Current behavior is harmless — screen
+  readers will announce "tab" on each button and "selected" on the
+  active one. Stage 5 chose the strictly-additive minimum.
+
+- **Redundant `aria-pressed` + `aria-selected`.** Strictly, `aria-pressed`
+  is for toggle buttons and `aria-selected` is for tabs/options. Setting
+  both on a `role="tab"` element is slightly redundant. It does not
+  conflict with any screen reader's behavior — `aria-selected` is the
+  one that announces, and `aria-pressed` is harmless. Keeping both
+  preserves backward compatibility for any future audit that expects
+  toggle semantics.
+
+- **Copy changes might alter authority meaning.** The Stage 5 polish
+  changed only one authority-bearing string: the Comparison / Guide
+  scope chip text from `"Committed World"` to `"Committed world"` —
+  identical meaning, identical authority. The underlying
+  `scope.authority` field and chip-rendering CSS class are untouched.
+  The "event-derived", "navigation-only", "committed-world", and
+  "sandbox" authority labels on evidence chips, blocking constraints,
+  and deferred reasons are unchanged.
+
+- **Guide could be perceived as a chatbot after wording polish.** The
+  added "Front Office Guide" title + `Read-only · Deterministic ·
+  Navigation only` qualifier and the per-button `(navigation only)`
+  aria-label collectively *reduce* chatbot perception. Stage 5 tests
+  re-enforce the no-`<input>`/`<textarea>`/contentEditable invariant.
+
+- **Polish could accidentally touch derivation/action logic.** Diff
+  inspection confirms zero edits in `src/features/architect/comparison/`,
+  `src/features/architect/guidedQuestions/`, any `useArchitect*.ts`
+  hook, any `mutationPipeline*`, any `worldManager*`, any
+  `seasonManager*`, or any validator file. Stage 5 changes are
+  presentation-only.
+
+- **Docs hierarchy could go stale.** The pre-commit hook regenerated
+  `docs/ArchitectHierarchy.md` to reflect the new `ArchitectTabBar.tsx`
+  file. Stage 5B re-ran the hook; no further delta was produced.
+
+---
+
+## Known Pre-Existing Failures
+
+All failures below pre-date Stage 5 and exist on `main`. Stage 5
+introduced **zero** new test failures.
+
+The Stage 5B verification did not run the full `test:architect` suite
+(per "do not run broad tests" policy). The Stage 3 final verification
+report documented 39 files / 177 tests as pre-existing failures on `main`
+prior to Stage 4; Stage 4 did not affect them; Stage 5 likewise does not
+touch any of those code paths.
+
+`test:diff` was not run as a separate broad gate. The targeted Stage
+1/2/3/4/5 suites that *are* the relevant gate for Stage 5 all pass
+cleanly (258/258).
+
+Notable pre-existing failure categories (carried forward from the Stage
+3 / Stage 4 verifications, unchanged by Stage 5):
+
+| Category | Notes |
+|----------|-------|
+| `capSheet_closure.gate.test.ts` | Reference to removed canonicalize helpers |
+| `offerSheets_closure.gate.test.ts` | Pre-existing offer-sheet gate failures |
+| `phase67/68/69/70_*.test.ts` | Pre-existing migration scan gates |
+| `useArchitectState.worldFreeAgency.test.ts` | Pre-existing `useArchitectPlayerData` mock gap |
+| Various guardrail/compatibility tests | Pre-existing guardrail reference failures |
+
+---
+
+## Guardrail Confirmations
+
+| Guardrail | Status |
+|-----------|--------|
+| No new features | ✅ Confirmed — only presentation polish |
+| No new tabs | ✅ Confirmed — nine-tab set is identical to Stage 4 |
+| No move generation | ✅ Confirmed — no trade composer / signing planner / offseason path generator |
+| No trade-package generation | ✅ Confirmed |
+| No cap-room optimization | ✅ Confirmed |
+| No branching/scenario creation UI | ✅ Confirmed |
+| No world A vs world B comparison | ✅ Confirmed |
+| No parent-world comparison | ✅ Confirmed |
+| No new Firestore reads | ✅ Confirmed by grep on Stage 5 files |
+| No Firestore writes | ✅ Confirmed by grep on Stage 5 files |
+| No new event source | ✅ Confirmed — only existing Stage 1/2/3/4 seams consumed |
+| No mutation authority changes | ✅ Confirmed — `useArchitectActions`, `mutationPipeline`, `seasonManager`, `worldManager` untouched |
+| No validation behavior changes | ✅ Confirmed — Trade Machine / Free Agency / cap legality validators untouched |
+| No comparison derivation changes | ✅ Confirmed — `src/features/architect/comparison/` and `useArchitectComparisonViewModel.ts` untouched |
+| No guided-answer derivation changes | ✅ Confirmed — `src/features/architect/guidedQuestions/` and `useArchitectGuidedAnswers.ts` untouched |
+| No new event source | ✅ Confirmed — no new Firestore subscription / query helper / hook |
+| Authority labels preserved | ✅ Confirmed — `event-derived`, `navigation-only`, `committed-world`, `sandbox` unchanged |
+| Existing data-testids preserved | ✅ Confirmed — `tab-cap-sheet`, `tab-full-cap-table`, `tab-compare`, `tab-guide`, comparison-/guide-/rail testids all unchanged |
+| Guide remains read-only | ✅ Confirmed — no `<input>`, `<textarea>`, or `contentEditable`; navigation buttons announce "navigation only" |
+| Compare remains navigation-only | ✅ Confirmed — nav buttons gained `type="button"` but still call only `onNavigateTo…` callbacks |
+| GMDashboard remains a composition shell | ✅ Confirmed — Stage 5 adds one `useMemo` for tab descriptors and one component invocation; no new mutation logic |
+| Active-tab behavior unchanged | ✅ Confirmed — `setActiveTab` / `openHistoryRoot` callbacks are the same as Stage 4 |
+| Tab order unchanged | ✅ Confirmed — `Roster, Cap Sheet, Full Cap Table, Trade Machine, Free Agency, Offseason, Team History, Compare, Guide` |
+| No Stage 6 audit/fix work | ✅ Confirmed — no lint config / no perf instrumentation / no broad refactor |
+
+---
+
+## Deferred Items Moving to Stage 6
+
+The following are out of Stage 5's polish-only scope and remain Stage 6
+candidates per the master plan:
+
+- **Full `role="tabpanel"` / `aria-controls` pairing.** The tab buttons
+  use `role="tab"` semantics, but the active section render slots are
+  not wrapped in `role="tabpanel"` containers. Stage 6 ship-readiness
+  audit can decide whether to wire tabpanel semantics through every
+  section shell (broader refactor) or drop `role="tab"` back to plain
+  `<button>` semantics (smaller change).
+- **`aria-pressed` redundancy.** `role="tab"` only needs
+  `aria-selected`; the redundant `aria-pressed` was retained for
+  backward compatibility. Stage 6 audit can decide whether to drop it.
+- **Move-feasibility answers** (Stage 4 deferral) — still deferred.
+- **Apron-duck and max-cap-room questions** — still deferred.
+- **Hard-cap activation answer** — still deferred.
+- **World A vs World B comparison** — still deferred.
+- **Parent-world vs child-world comparison** — still deferred.
+- **Multi-season comparison** — Stage 3 deferred; the multi-season
+  warning is surfaced when applicable.
+- **Draft asset / pick delta** — still deferred.
+- **Exception / TPE future-year delta** — still deferred.
+- **Baseline collection roster comparison** — still deferred.
+- **Manual focus publication** — Stage 2C Slice 4 carryover.
+- **Cap Sheet ⇄ Full Cap Table same-player scroll sync** — Stage 2/3
+  carryover.
+- **Recommendation of which player to waive/trade** — out of scope;
+  optimization/recommendation work.
+- **Recommendation of an offseason path** — out of scope; multi-step
+  planning.
+- **Bundle-size code-splitting** — pre-existing chunk-size warning;
+  Stage 6 perf audit territory.
+- **`browserslist` data refresh** — pre-existing build warning; Stage 6
+  housekeeping.
+
+---
+
+## Recommended Next Stage
+
+**Stage 5 is complete and ready to PR.**
+
+All 35 acceptance criteria pass. The build, typecheck, and
+`validate:project` are clean. 19 Stage 5 polish tests pass. All 239
+Stage 1/2/3/4 targeted tests pass. Zero pre-existing failures worsened.
+No corrections were required during 5B.
+
+Per the Stage 5 workflow, the user will have ChatGPT open the single
+final Stage 5 PR after Stage 5B.
+
+After the PR merges, Stage 6 (per the master plan) is the
+"Full Architect Ship-Ready Audit": state authority, mutation
+boundaries, world/base/sandbox/preview truth presentation, validation
+and legality behavior, route and navigation continuity, Firestore
+read/write boundaries, performance, accessibility (including the
+deferred tabpanel/`aria-controls` work above), docs and test coverage.
+Stage 6 is intentionally last so it audits a stable operating model
+rather than chasing surfaces that are still changing.
+
+---
+
+## Files Inspected
+
+| File | Purpose |
+|------|---------|
+| `docs/architect/ARCHITECT_STAGE_5_POLISH_NOTES.md` | Stage 5A scope, what was/wasn't changed, guardrail confirmations |
+| `docs/architect/ARCHITECT_STAGE_4_FINAL_VERIFICATION.md` | Stage 4 baseline acceptance results and pre-existing failure list |
+| `docs/architect/ARCHITECT_STAGE_3_FINAL_VERIFICATION.md` | Stage 3 baseline + pre-existing failure category list |
+| `docs/architect/ARCHITECT_STAGE_2_FINAL_VERIFICATION.md` | Stage 2 baseline acceptance results |
+| `docs/architect/ARCHITECT_NEXT_ERA_MASTER_PLAN.md` | Stage 5 / Stage 6 scope definitions |
+| `src/features/architect/GMDashboard/GMDashboard.tsx` | Composition shell — tab descriptor `useMemo`, `ArchitectTabBar` wiring, Season select a11y |
+| `src/features/architect/GMDashboard/components/ArchitectTabBar.tsx` | New tab bar component — tablist/tab semantics, focus rings, type="button" |
+| `src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx` | Row-3 indicator copy + exceptions-button focus ring/aria-label |
+| `src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx` | Focus ring + dismiss aria-label (no copy / no behavior change) |
+| `src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx` | Wrapper aria-label, "Open History →" wording, focus ring |
+| `src/features/architect/GMDashboard/sections/ComparisonSection.tsx` | Section title + qualifier, standardized loading/error/empty layouts, nav button `View …` labels + focus rings, scope chip "Committed world", deferred intro line |
+| `src/features/architect/GMDashboard/sections/GuideSection.tsx` | Section title + qualifier, scope chip "Committed world", nav-button title + aria-label "(navigation only)" + focus ring |
+| `src/tests/architect/stage5.polish.test.tsx` | 19 targeted Stage 5 polish tests |
+
+---
+
+## Validation Commands and Results
+
+| Command | Result |
+|---------|--------|
+| `npm run typecheck` | ✅ PASS — zero TypeScript errors |
+| `npm run validate:project` | ✅ PASS — all structural validations pass |
+| `npm run build` | ✅ PASS — built in ~26.5s, no new errors (pre-existing chunk-size + browserslist warnings unrelated to Stage 5) |
+| Stage 5A: `stage5.polish.test.tsx` | ✅ PASS — 19/19 |
+| Stage 4B: `stage4.guidedQuestions.test.tsx` | ✅ PASS — 39/39 |
+| Stage 3 foundation: `stage3.comparisonFoundation.test.ts` | ✅ PASS — 57/57 |
+| Stage 3C: `stage3c.comparisonUI.test.tsx` | ✅ PASS — 33/33 |
+| Stage 2A: `stage2a.navigationContinuity.test.tsx` | ✅ PASS — 11/11 |
+| Stage 2B: `stage2b.postActionHandoff.test.tsx` | ✅ PASS — 24/24 |
+| Stage 2C: `stage2c.playerRosterContinuity.test.tsx` | ✅ PASS — 29/29 |
+| Stage 2D: `stage2d.historyActivityDeeplink.test.tsx` | ✅ PASS — 11/11 |
+| Stage 1A: `architectWorkspaceContext.stage1a.test.ts` | ✅ PASS — 17/17 |
+| Stage 1D: `architectActivityRail.stage1d.test.ts` | ✅ PASS — 18/18 |
+| **Combined Stage 1/2/3/4/5 targeted scope** | **✅ 258/258** |
+
+`test:diff` was not run as a separate broad gate per the "do not run
+broad tests" policy. The targeted Stage 1/2/3/4/5 suites above are the
+relevant gate for Stage 5.
+
+---
+
+## Corrections Made
+
+None. Stage 5 was verified in its current state with no corrections
+required. All polish edits met scope; no behavior or authority drift was
+detected during verification.
+
+---
+
+## Unrelated Files Left Untouched
+
+The working tree was clean at the start of this verification pass. Only
+`docs/architect/ARCHITECT_STAGE_5_FINAL_VERIFICATION.md` (this file) was
+staged and committed for Stage 5B. No files in
+`src/features/architect/guidedQuestions/`,
+`src/features/architect/comparison/`,
+`src/features/architect/hooks/`,
+`src/features/architect/utils/`,
+`src/features/architect/capSheet/`,
+`src/features/architect/history/`, any actions / hooks under
+`src/features/architect/GMDashboard/hooks/`, or any test file other than
+Stage 5's own `stage5.polish.test.tsx` were modified across Stages 5A
+and 5B.

--- a/docs/architect/ARCHITECT_STAGE_5_POLISH_NOTES.md
+++ b/docs/architect/ARCHITECT_STAGE_5_POLISH_NOTES.md
@@ -1,0 +1,287 @@
+# Architect Stage 5A — Product Polish Notes
+
+**Stage:** 5A (Product polish / professionalization)
+**Branch:** `feature/architect-operating-experience-stage-5-polish`
+**Base:** Stage 4 verified on `main` (commit `adf0c12f`)
+**Date:** 2026-05-21
+
+---
+
+## Purpose
+
+Stage 5A polishes the Architect operating experience built across Stages 1–4
+so it feels more professional, consistent, readable, and intentional —
+*without* adding new product behavior.
+
+This stage is **presentation-only**. No new features, tabs, mutations, event
+sources, Firestore writes, validators, comparison derivations, or guided-answer
+derivations were added. The polish layer sits entirely on top of existing
+Stage 1/2/3/4 seams.
+
+---
+
+## What Was Polished
+
+### 1. Tab navigation
+
+- Extracted the inline tab bar into a small reusable component:
+  [`src/features/architect/GMDashboard/components/ArchitectTabBar.tsx`](../../src/features/architect/GMDashboard/components/ArchitectTabBar.tsx).
+- All tab buttons now carry `type="button"` (previously missing, all nine
+  buttons defaulted to `type="submit"`).
+- Each tab button now carries `role="tab"`, `aria-pressed`, and
+  `aria-selected`. The container carries `role="tablist"` and an
+  `aria-label="Architect dashboard sections"`.
+- Tab buttons now get a visible keyboard focus ring
+  (`focus-visible:ring-2 ring-white/40`).
+- Spacing tightened slightly (`gap-x-2 gap-y-2`) so the row wraps cleanly
+  with nine tabs without changing tab order or behavior.
+- All existing tabs (`Roster`, `Cap Sheet`, `Full Cap Table`, `Trade Machine`,
+  `Free Agency`, `Offseason`, `Team History`, `Compare`, `Guide`) and all
+  existing `data-testid` values (`tab-cap-sheet`, `tab-full-cap-table`,
+  `tab-compare`, `tab-guide`) are preserved.
+- New testid `architect-tab-bar` added for the wrapper.
+
+### 2. Standardized copy
+
+- [`ArchitectWorkspaceHeader.tsx`](../../src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx)
+  bottom row separator standardized from `"Label: see Surface"` to
+  `"Label · See Surface"` for the three indicator slots
+  (Exceptions / Draft picks / Activity). "See" capitalized; "Trade & History"
+  shortened to "Trade" to match the actual deep-link target.
+- [`ComparisonSection.tsx`](../../src/features/architect/GMDashboard/sections/ComparisonSection.tsx)
+  navigation buttons standardized to `View History` / `View Cap Sheet` /
+  `View Roster` (previously `View History` / `Cap Sheet` / `Roster`).
+- [`ComparisonSection.tsx`](../../src/features/architect/GMDashboard/sections/ComparisonSection.tsx)
+  scope authority chip label normalized from `"Committed World"` to
+  `"Committed world"` for consistency with the post-action handoff chip.
+- [`GuideSection.tsx`](../../src/features/architect/GMDashboard/sections/GuideSection.tsx)
+  scope authority chip label normalized from `"Committed World"` to
+  `"Committed world"` for the same reason.
+- [`ScenarioMoveRail.tsx`](../../src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx)
+  navigation link wording standardized from `"Full History →"` to
+  `"Open History →"` to mirror the post-action handoff vocabulary.
+- Authority labels (`event-derived`, `navigation-only`, `committed-world`,
+  `sandbox`) and Stage 3/4 deferred-reason strings remain **verbatim** — no
+  authority meaning was changed.
+
+### 3. Section titles for Compare and Guide
+
+- [`ComparisonSection.tsx`](../../src/features/architect/GMDashboard/sections/ComparisonSection.tsx)
+  scope card now displays an `h2` "Committed Scenario Comparison" title with a
+  small `Read-only · Event-derived` qualifier underneath, making the tab's
+  intent clear before any cards render.
+- [`GuideSection.tsx`](../../src/features/architect/GMDashboard/sections/GuideSection.tsx)
+  scope card now displays an `h2` "Front Office Guide" title with a small
+  `Read-only · Deterministic · Navigation only` qualifier, reinforcing that
+  the Guide is not a chatbot or analyst — it surfaces fixed deterministic
+  answers and offers navigation only.
+
+### 4. Loading / empty / error / unavailable states
+
+- [`ComparisonSection.tsx`](../../src/features/architect/GMDashboard/sections/ComparisonSection.tsx)
+  - Loading state: now uses the same card + center-aligned italic body as the
+    sandbox state; gains `role="status"` and `aria-live="polite"` for
+    assistive tech.
+  - Error state: gains `role="alert"`; message normalized from `"Error
+    loading comparison data"` to `"Unable to load comparison data"` to match
+    `ScenarioMoveRail` ("Unable to load recent activity.").
+  - Empty (no view-model fallback): now uses the same card layout as the
+    other empty/sandbox states.
+  - Deferred / unavailable summary: gained a small intro line explaining
+    that these deltas are not surfaced in this read-only comparison.
+- [`ScenarioMoveRail.tsx`](../../src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx)
+  remains the canonical pattern for these states; no behavioral changes here.
+
+### 5. Visual hierarchy
+
+- Tab bar wrapping uses both `gap-x-2` and `gap-y-2` so a wrapped row keeps
+  uniform vertical spacing instead of collapsing.
+- The workspace header's row 3 (`Exceptions · …`, `Draft picks · …`,
+  `Activity · …`) now uses `gap-x-3 gap-y-1` so wrapped indicators don't
+  pile up.
+- Comparison and Guide section titles are `text-sm font-semibold` — present
+  but subordinate to the surrounding dashboard heading.
+- Authority chips, evidence chips, and severity colors remain unchanged from
+  Stages 3/4 (they were already subordinate to the body text).
+- No card colors or border treatments were changed for the actual answer /
+  delta cards — those already match the dark theme.
+
+### 6. Accessibility
+
+- `type="button"` added to every tab bar button (was missing).
+- `type="button"` added to ComparisonSection navigation buttons (was
+  missing).
+- The dashboard `Season` `<select>` gained an explicit `aria-label="Viewing
+  season"` and a visible focus ring.
+- Existing per-section buttons (workspace-header nav buttons, post-action
+  handoff buttons, scenario rail history button, guide navigation buttons)
+  all gained `focus-visible:ring-1 ring-white/40` for keyboard users.
+- Guide navigation buttons gained `title="Navigation only — opens the
+  existing surface"` and an `aria-label="<Label> (navigation only)"` to
+  reinforce that the click only switches tabs — it does not commit, validate,
+  or simulate anything.
+- The workspace-header `Exceptions: see Cap Sheet` button gained an
+  `aria-label="Open Cap Sheet to review active exceptions"`.
+- `ScenarioMoveRail` wrapper gained `aria-label="Recent committed activity"`.
+- `ArchitectPostActionHandoff` already had `role="status"` and
+  `aria-live="polite"` — preserved.
+- No nested interactive controls were introduced. Keyboard tab order
+  remains intact.
+
+### 7. Compare / Guide readability
+
+- Compare now reads as `Committed Scenario Comparison` (title) with
+  `Read-only · Event-derived` qualifier + `Committed world` authority chip +
+  team/season context + a short deferred-list intro. The navigation buttons
+  are clearly labeled `View …`.
+- Guide now reads as `Front Office Guide` (title) with
+  `Read-only · Deterministic · Navigation only` qualifier + `Committed
+  world` / `Sandbox` authority chip + team/season context. The 15 answers
+  are unchanged; navigation buttons are explicitly labeled with the
+  `(navigation only)` accessible-name suffix.
+
+---
+
+## What Was Intentionally Not Changed
+
+The following were considered and *intentionally* left alone, per the
+Stage 5 scope:
+
+- **No new tabs.** Tab count remains nine, ids remain the same, order
+  remains the same.
+- **No new product features.** No move generation, no trade packaging, no
+  cap-room optimizer, no branching UI, no world-vs-world comparison, no
+  parent-vs-child comparison.
+- **No new Firestore reads or writes.** No new collections, no new
+  subscriptions, no new query helpers.
+- **No new event source.** The Stage 4 `recent-committed-event` answer
+  still reuses the Stage 3 event references via the existing
+  `useArchitectComparisonViewModel`.
+- **No mutation authority changes.** `mutationPipeline`,
+  `useArchitectActions`, `seasonManager`, and `worldManager` were not
+  touched.
+- **No validation behavior changes.** The Trade Machine and Free Agency
+  validators are unchanged. Cap legality, signing legality, and offseason
+  resolution all behave identically.
+- **No comparison derivation changes.** `useArchitectComparisonViewModel`
+  and the Stage 3 derivation helpers are unchanged; Stage 5 only retitles
+  and re-skins the section.
+- **No guided-answer derivation changes.** The 15 Stage 4 answer ids,
+  catalog, status logic, authority labels, and deferred reasons are
+  unchanged. Stage 5 only retitles the scope card and adds nav-button
+  accessible names.
+- **No design-system rewrite.** Only one small local component
+  (`ArchitectTabBar`) was introduced, and only because the inline tab bar
+  had grown to nine buttons with duplicated styling and was the cleanest
+  place to fix the missing `type="button"` issue.
+- **No broad visual redesign.** Cards, borders, dark theme, and chip
+  treatments are unchanged. Color tokens for severities and authorities
+  match Stages 1–4.
+- **No Stage 6 audit work.** Performance audits, accessibility audits,
+  Firestore read/write boundary audits, and ship-readiness audits are
+  explicitly Stage 6 work.
+
+---
+
+## Guardrail Confirmations
+
+| Guardrail | Status |
+|-----------|--------|
+| No new features | ✅ Polish-only |
+| No new tabs | ✅ Nine tabs unchanged |
+| No move generation | ✅ Not introduced |
+| No trade package generation | ✅ Not introduced |
+| No cap-room optimization | ✅ Not introduced |
+| No branching / scenario creation UI | ✅ Not introduced |
+| No world A vs world B comparison | ✅ Not introduced |
+| No parent-world comparison | ✅ Not introduced |
+| No new Firestore reads | ✅ Confirmed by grep on Stage 5 files |
+| No Firestore writes | ✅ Confirmed by grep on Stage 5 files |
+| No new event source | ✅ Confirmed — only the existing Stage 1/2/3/4 seams are consumed |
+| No mutation authority changes | ✅ `useArchitectActions`, `mutationPipeline`, `seasonManager`, `worldManager` untouched |
+| No validation behavior changes | ✅ Validators untouched |
+| No comparison derivation changes | ✅ `useArchitectComparisonViewModel` + Stage 3 helpers untouched |
+| No guided-answer derivation changes | ✅ `guidedQuestions/` module untouched |
+| Authority labels preserved | ✅ `event-derived`, `navigation-only`, `committed-world`, `sandbox` unchanged |
+| Existing data-testids preserved | ✅ `tab-cap-sheet`, `tab-full-cap-table`, `tab-compare`, `tab-guide`, comparison-/guide-/scenario-rail testids all unchanged |
+| Guide remains read-only | ✅ Still no `<input>`, `<textarea>`, or `contentEditable`; navigation-only buttons gained title/aria-label clarifying intent |
+| Compare remains navigation-only | ✅ Nav buttons gained `type="button"` but still call only `onNavigateTo…` callbacks |
+| GMDashboard remains a composition shell | ✅ Only one additional `useMemo` for tab descriptors; no new mutation logic |
+
+---
+
+## Files Created / Changed
+
+### Created
+
+| File | Purpose |
+|------|---------|
+| `src/features/architect/GMDashboard/components/ArchitectTabBar.tsx` | Small reusable tab bar — adds `type="button"`, tab/tablist semantics, focus rings, and a consistent active-state style |
+| `docs/architect/ARCHITECT_STAGE_5_POLISH_NOTES.md` | This document |
+| `src/tests/architect/stage5.polish.test.tsx` | Targeted Stage 5A tests — tab bar a11y, copy normalization, navigation-only Compare/Guide buttons, no-input invariant |
+
+### Changed
+
+| File | Change |
+|------|--------|
+| `src/features/architect/GMDashboard/GMDashboard.tsx` | Replaced inline tab bar with `<ArchitectTabBar>`; added `aria-label` + focus ring to the Season `<select>` |
+| `src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx` | Row-3 indicator copy standardized (`Label · See Surface`); exceptions nav button got focus ring + aria-label |
+| `src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx` | Buttons gained `focus-visible` rings (no copy or behavior change) |
+| `src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx` | Wrapper got `aria-label`; "Full History →" → "Open History →"; history button got focus ring |
+| `src/features/architect/GMDashboard/sections/ComparisonSection.tsx` | Added section title + `Read-only · Event-derived` qualifier; standardized loading/error/empty layouts; nav buttons gained `type="button"`, focus rings, and `View …` prefix; deferred list gained intro line; scope authority chip → "Committed world" |
+| `src/features/architect/GMDashboard/sections/GuideSection.tsx` | Added section title + `Read-only · Deterministic · Navigation only` qualifier; scope authority chip → "Committed world"; nav buttons gained `title` + `aria-label` reinforcing navigation-only intent + focus ring |
+
+---
+
+## Validation Commands and Results
+
+| Command | Result |
+|---------|--------|
+| `npm run typecheck` | ✅ PASS |
+| `npm run validate:project` | ✅ PASS |
+| `npm run build` | ✅ PASS |
+| Stage 5A: `stage5.polish.test.tsx` | ✅ PASS |
+| Stage 4B: `stage4.guidedQuestions.test.tsx` | ✅ PASS |
+| Stage 3C: `stage3c.comparisonUI.test.tsx` | ✅ PASS |
+| Stage 3 foundation: `stage3.comparisonFoundation.test.ts` | ✅ PASS |
+| Stage 2A: `stage2a.navigationContinuity.test.tsx` | ✅ PASS |
+| Stage 2B: `stage2b.postActionHandoff.test.tsx` | ✅ PASS |
+| Stage 2D: `stage2d.historyActivityDeeplink.test.tsx` | ✅ PASS |
+| Stage 1A: `architectWorkspaceContext.stage1a.test.ts` | ✅ PASS |
+
+The Stage 2C `playerRosterContinuity` suite was not re-run (Stage 5 did
+not touch roster / focused-player code paths).
+
+`test:diff` was not run as a separate broad gate per the "do not run full
+suite unless authorized" policy. The targeted Stage 1/2/3/4/5 suites
+above are the relevant gate.
+
+---
+
+## Unrelated Files Left Untouched
+
+The working tree was clean at the start of Stage 5A. No unrelated tracked
+files were modified. No files in `src/features/architect/guidedQuestions/`,
+`src/features/architect/comparison/`, `src/features/architect/hooks/`,
+`src/features/architect/utils/`, `src/features/architect/capSheet/`,
+`src/features/architect/history/`, or any actions / hooks under
+`src/features/architect/GMDashboard/hooks/` were touched by Stage 5A.
+
+---
+
+## Recommended Next Stage
+
+**Stage 5A is complete and ready to be followed by Stage 5B final
+verification on the same branch.**
+
+Stage 5B (final verification) should:
+
+1. Re-run the targeted Stage 1/2/3/4/5 test suites end-to-end.
+2. Confirm no Stage 5A change altered authority meaning anywhere.
+3. Confirm no new Firestore / mutation / validation surface was introduced.
+4. Produce `ARCHITECT_STAGE_5_FINAL_VERIFICATION.md` with the same
+   acceptance-criteria-table layout used by Stages 2/3/4.
+5. After verification passes, open the single Stage 5 PR.
+
+Stage 6 (full ship-readiness audit) remains the next major stage per the
+master plan.

--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -6,6 +6,7 @@ GMDashboard/
   GMDashboard.tsx
   components/
     ArchitectPostActionHandoff.tsx
+    ArchitectTabBar.tsx
     ArchitectWorkspaceHeader.tsx
     CapAuditDebugPanel.tsx
     DeleteWorldModal.tsx
@@ -512,5 +513,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-05-22T02:32:03.227Z*
+*Generated on: 2026-05-22T04:02:41.735Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -38,6 +38,10 @@ import { CapAuditDebugPanel } from '@/features/architect/GMDashboard/components/
 import { ArchitectWorkspaceHeader } from '@/features/architect/GMDashboard/components/ArchitectWorkspaceHeader';
 import { ScenarioMoveRail } from '@/features/architect/GMDashboard/components/ScenarioMoveRail';
 import { ArchitectPostActionHandoff } from '@/features/architect/GMDashboard/components/ArchitectPostActionHandoff';
+import {
+  ArchitectTabBar,
+  type ArchitectTabDescriptor,
+} from '@/features/architect/GMDashboard/components/ArchitectTabBar';
 import { useArchitectPostActionReceipt } from './hooks/useArchitectPostActionReceipt';
 import { useHistoryEventDetailRequest } from './hooks/useHistoryEventDetailRequest';
 import { deriveSeasonAdvanceReceipt } from './postActionHandoff/types';
@@ -497,6 +501,55 @@ export const GMDashboard = () => {
     onAfterOffseasonAdvanceApplied: handleOffseasonAdvanceApplied,
   };
 
+  const dashboardTabs: ArchitectTabDescriptor[] = useMemo(
+    () => [
+      { id: 'roster', label: 'Roster', onActivate: () => setActiveTab('roster') },
+      {
+        id: 'cap',
+        label: 'Cap Sheet',
+        onActivate: () => setActiveTab('cap'),
+        testId: 'tab-cap-sheet',
+      },
+      {
+        id: 'capfull',
+        label: 'Full Cap Table',
+        onActivate: () => setActiveTab('capfull'),
+        testId: 'tab-full-cap-table',
+      },
+      {
+        id: 'trade',
+        label: 'Trade Machine',
+        onActivate: () => setActiveTab('trade'),
+      },
+      { id: 'fa', label: 'Free Agency', onActivate: () => setActiveTab('fa') },
+      {
+        id: 'offseason',
+        label: 'Offseason',
+        onActivate: () => setActiveTab('offseason'),
+      },
+      {
+        id: 'history',
+        label: 'Team History',
+        onActivate: openHistoryRoot,
+      },
+      {
+        id: 'compare',
+        label: 'Compare',
+        onActivate: () => setActiveTab('compare'),
+        testId: 'tab-compare',
+        title: 'Committed scenario comparison',
+      },
+      {
+        id: 'guide',
+        label: 'Guide',
+        onActivate: () => setActiveTab('guide'),
+        testId: 'tab-guide',
+        title: 'Front Office Guide',
+      },
+    ],
+    [setActiveTab, openHistoryRoot]
+  );
+
   if (authLoading || isLoading) return <p>Loading GM Dashboard...</p>;
   if (!teamCapSheet) return <p>No team data</p>;
 
@@ -536,13 +589,14 @@ export const GMDashboard = () => {
           )}
 
           <label className="flex items-center gap-2 text-sm font-medium">
-            Season
+            <span>Season</span>
             <select
               value={currentYear}
               onChange={(event) =>
                 setCurrentYear(parseInt(event.target.value, 10))
               }
-              className="bg-[#1a1a1a] text-white text-sm px-2 py-1 rounded border border-white/10"
+              aria-label="Viewing season"
+              className="bg-[#1a1a1a] text-white text-sm px-2 py-1 rounded border border-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
             >
               {seasonEndYearsFromCaps(capProjections).map((year) => (
                 <option key={year} value={year}>
@@ -596,102 +650,7 @@ export const GMDashboard = () => {
       {error && <p className="text-red-500 mb-2">{error}</p>}
       {isSaving && <p className="text-sm mb-2">Saving...</p>}
 
-      <div className="tab-bar flex flex-wrap gap-3 mb-6">
-        <button
-          onClick={() => setActiveTab('roster')}
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'roster'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Roster
-        </button>
-        <button
-          onClick={() => setActiveTab('cap')}
-          data-testid="tab-cap-sheet"
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'cap'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Cap Sheet
-        </button>
-        <button
-          onClick={() => setActiveTab('capfull')}
-          data-testid="tab-full-cap-table"
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'capfull'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Full Cap Table
-        </button>
-        <button
-          onClick={() => setActiveTab('trade')}
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'trade'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Trade Machine
-        </button>
-        <button
-          onClick={() => setActiveTab('fa')}
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'fa'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Free Agency
-        </button>
-        <button
-          onClick={() => setActiveTab('offseason')}
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'offseason'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Offseason
-        </button>
-        <button
-          onClick={openHistoryRoot}
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'history'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Team History
-        </button>
-        <button
-          onClick={() => setActiveTab('compare')}
-          data-testid="tab-compare"
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'compare'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Compare
-        </button>
-        <button
-          onClick={() => setActiveTab('guide')}
-          data-testid="tab-guide"
-          className={`px-4 py-2 rounded-md text-sm font-semibold ${
-            activeTab === 'guide'
-              ? 'bg-lakers/90 text-black'
-              : 'bg-white/10 hover:bg-white/20'
-          }`}
-        >
-          Guide
-        </button>
-      </div>
+      <ArchitectTabBar activeTab={activeTab} tabs={dashboardTabs} />
 
       <div className="tab-content space-y-6">
         {activeTab === 'roster' && (

--- a/src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectPostActionHandoff.tsx
@@ -111,7 +111,7 @@ export const ArchitectPostActionHandoff = ({
           <button
             type="button"
             onClick={onNavigateToCapSheet}
-            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90"
+            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
             data-testid="post-action-handoff-nav-cap"
           >
             View Cap Sheet
@@ -119,7 +119,7 @@ export const ArchitectPostActionHandoff = ({
           <button
             type="button"
             onClick={onNavigateToRoster}
-            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90"
+            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
             data-testid="post-action-handoff-nav-roster"
           >
             View Roster
@@ -127,7 +127,7 @@ export const ArchitectPostActionHandoff = ({
           <button
             type="button"
             onClick={onNavigateToHistory}
-            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90"
+            className="rounded border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] text-white/70 hover:bg-white/10 hover:text-white/90 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
             data-testid="post-action-handoff-nav-history"
           >
             View History
@@ -135,7 +135,7 @@ export const ArchitectPostActionHandoff = ({
           <button
             type="button"
             onClick={onDismiss}
-            className="rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[11px] text-white/40 hover:bg-white/10 hover:text-white/70"
+            className="rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[11px] text-white/40 hover:bg-white/10 hover:text-white/70 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
             data-testid="post-action-handoff-dismiss"
             aria-label="Dismiss post-action handoff"
           >

--- a/src/features/architect/GMDashboard/components/ArchitectTabBar.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectTabBar.tsx
@@ -1,0 +1,66 @@
+/**
+ * FILE: src/features/architect/GMDashboard/components/ArchitectTabBar.tsx
+ * PURPOSE: Stage 5A polish — small read-only tab bar for the Architect dashboard.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Renders the existing active-tab buttons with consistent styling, button
+ * semantics (`type="button"`), `aria-pressed`, `role="tab"` semantics, and
+ * keyboard focus rings. No mutation authority. No new tabs. No new state.
+ *
+ * Stage 5A only polishes presentation — the parent dashboard still owns
+ * `activeTab` and the click handlers.
+ */
+import type { ReactNode } from 'react';
+import type { ActiveTab } from '../hooks/useArchitectState.types';
+
+export interface ArchitectTabDescriptor {
+  id: ActiveTab;
+  label: string;
+  onActivate: () => void;
+  testId?: string;
+  title?: string;
+}
+
+interface ArchitectTabBarProps {
+  tabs: ArchitectTabDescriptor[];
+  activeTab: ActiveTab;
+}
+
+const baseClass =
+  'px-3.5 py-1.5 rounded-md text-sm font-semibold transition-colors ' +
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 ' +
+  'focus-visible:ring-offset-1 focus-visible:ring-offset-[#0d0d0d]';
+
+const activeClass = 'bg-lakers/90 text-black shadow-sm';
+const inactiveClass = 'bg-white/10 text-white/80 hover:bg-white/20 hover:text-white';
+
+export const ArchitectTabBar = ({
+  tabs,
+  activeTab,
+}: ArchitectTabBarProps): ReactNode => (
+  <div
+    className="tab-bar mb-6 flex flex-wrap items-center gap-x-2 gap-y-2"
+    role="tablist"
+    aria-label="Architect dashboard sections"
+    data-testid="architect-tab-bar"
+  >
+    {tabs.map((tab) => {
+      const isActive = activeTab === tab.id;
+      return (
+        <button
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-pressed={isActive}
+          aria-selected={isActive}
+          onClick={tab.onActivate}
+          data-testid={tab.testId}
+          title={tab.title}
+          className={`${baseClass} ${isActive ? activeClass : inactiveClass}`}
+        >
+          {tab.label}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
+++ b/src/features/architect/GMDashboard/components/ArchitectWorkspaceHeader.tsx
@@ -226,14 +226,15 @@ export const ArchitectWorkspaceHeader = ({ context, onNavigateToCapSheet, onNavi
       </div>
 
       {/* Row 3: Franchise summary indicators — exceptions, draft assets, activity */}
-      <div className="mt-1 flex flex-wrap items-center gap-3 border-t border-white/5 pt-1.5 text-white/30">
+      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-white/5 pt-1.5 text-white/30">
         {exceptions.status === 'available' && exceptions.hasAnyActive ? (
           onNavigateToCapSheet ? (
             <button
               type="button"
               onClick={onNavigateToCapSheet}
-              className="hover:text-white/60 cursor-pointer"
+              className="hover:text-white/60 cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30 rounded"
               data-testid="exceptions-nav-cap-sheet"
+              aria-label="Open Cap Sheet to review active exceptions"
             >
               <ExceptionLine
                 exc={exceptions}
@@ -249,10 +250,10 @@ export const ArchitectWorkspaceHeader = ({ context, onNavigateToCapSheet, onNavi
         ) : exceptions.status === 'loading' ? (
           <span className="italic">Exceptions loading…</span>
         ) : (
-          <span>Exceptions: see Cap Sheet</span>
+          <span>Exceptions · See Cap Sheet</span>
         )}
-        <span>Draft picks: see Trade & History</span>
-        <span>Activity: see History</span>
+        <span>Draft picks · See Trade</span>
+        <span>Activity · See History</span>
       </div>
     </div>
   );

--- a/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
+++ b/src/features/architect/GMDashboard/components/ScenarioMoveRail.tsx
@@ -57,16 +57,17 @@ export const ScenarioMoveRail = ({
     <div
       className="mb-4 rounded-md border border-white/10 bg-white/[0.015] px-3 py-2 text-xs"
       data-testid="scenario-move-rail"
+      aria-label="Recent committed activity"
     >
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-white/40 font-medium">Recent Activity</span>
         <button
           type="button"
           onClick={onOpenHistory}
-          className="text-white/25 hover:text-white/50 text-[11px] transition-colors"
+          className="text-white/25 hover:text-white/50 text-[11px] transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30 rounded px-1"
           data-testid="scenario-move-rail-open-history"
         >
-          Full History →
+          Open History →
         </button>
       </div>
 

--- a/src/features/architect/GMDashboard/sections/ComparisonSection.tsx
+++ b/src/features/architect/GMDashboard/sections/ComparisonSection.tsx
@@ -208,10 +208,14 @@ export const ComparisonSection = ({
   if (status === 'loading') {
     return (
       <div
-        className="text-sm text-white/40 py-4"
+        className="rounded-md border border-white/10 bg-white/[0.015] px-4 py-6 text-center"
         data-testid="comparison-loading-state"
+        role="status"
+        aria-live="polite"
       >
-        Loading comparison data…
+        <p className="text-sm text-white/50 italic">
+          Loading comparison data…
+        </p>
       </div>
     );
   }
@@ -221,8 +225,9 @@ export const ComparisonSection = ({
       <div
         className="rounded-md border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200"
         data-testid="comparison-error-state"
+        role="alert"
       >
-        Error loading comparison data{error ? `: ${error}` : '.'}
+        Unable to load comparison data{error ? `: ${error}` : '.'}
       </div>
     );
   }
@@ -230,8 +235,13 @@ export const ComparisonSection = ({
   // Available — viewModel must exist at this point
   if (!viewModel) {
     return (
-      <div className="text-sm text-white/40 py-4" data-testid="comparison-available">
-        No comparison data available.
+      <div
+        className="rounded-md border border-white/10 bg-white/[0.015] px-4 py-6 text-center"
+        data-testid="comparison-available"
+      >
+        <p className="text-sm text-white/40 italic">
+          No comparison data available.
+        </p>
       </div>
     );
   }
@@ -243,8 +253,16 @@ export const ComparisonSection = ({
     <div className="space-y-4" data-testid="comparison-available">
       {/* Scope header */}
       <SectionCard testId="comparison-scope">
+        <div className="flex flex-wrap items-baseline gap-2 mb-1">
+          <h2 className="text-sm font-semibold text-white/80">
+            Committed Scenario Comparison
+          </h2>
+          <span className="text-[11px] text-white/40">
+            Read-only · Event-derived
+          </span>
+        </div>
         <div className="flex flex-wrap items-center gap-2 mb-1">
-          <AuthorityChip label="Committed World" />
+          <AuthorityChip label="Committed world" />
           {scope.worldName && (
             <span className="text-sm font-semibold text-white/80">
               {scope.worldName}
@@ -283,12 +301,16 @@ export const ComparisonSection = ({
           )}
         </div>
 
-        {/* Navigation */}
-        <div className="flex flex-wrap gap-2 mt-2">
+        {/* Navigation — read-only deep links to existing surfaces */}
+        <div
+          className="flex flex-wrap gap-2 mt-2"
+          aria-label="Navigation only — opens existing surfaces"
+        >
           {onNavigateToHistory && (
             <button
+              type="button"
               onClick={onNavigateToHistory}
-              className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors"
+              className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
               data-testid="comparison-nav-history"
             >
               View History
@@ -296,20 +318,22 @@ export const ComparisonSection = ({
           )}
           {onNavigateToCapSheet && (
             <button
+              type="button"
               onClick={onNavigateToCapSheet}
-              className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors"
+              className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
               data-testid="comparison-nav-cap-sheet"
             >
-              Cap Sheet
+              View Cap Sheet
             </button>
           )}
           {onNavigateToRoster && (
             <button
+              type="button"
               onClick={onNavigateToRoster}
-              className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors"
+              className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
               data-testid="comparison-nav-roster"
             >
-              Roster
+              View Roster
             </button>
           )}
         </div>
@@ -400,6 +424,9 @@ export const ComparisonSection = ({
       {viewModel.unavailableSummary.length > 0 && (
         <SectionCard testId="comparison-unavailable-summary">
           <SectionHeading>Deferred / Unavailable</SectionHeading>
+          <p className="text-[11px] text-white/30 mb-1">
+            These deltas are not surfaced in this read-only comparison.
+          </p>
           <UnavailableList entries={viewModel.unavailableSummary} />
         </SectionCard>
       )}

--- a/src/features/architect/GMDashboard/sections/GuideSection.tsx
+++ b/src/features/architect/GMDashboard/sections/GuideSection.tsx
@@ -145,8 +145,10 @@ const NavigationButton = ({ target, onNavigate }: NavigationButtonProps) => (
   <button
     type="button"
     onClick={() => onNavigate(target.id)}
-    className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors"
+    className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
     data-testid={`guide-nav-${target.id}`}
+    title="Navigation only — opens the existing surface"
+    aria-label={`${target.label} (navigation only)`}
   >
     {target.label}
   </button>
@@ -290,27 +292,37 @@ export const GuideSection: React.FC<GuideSectionProps> = ({
 
   return (
     <div className="space-y-4" data-testid="guide-section">
-      <div
-        className="rounded-md border border-white/10 bg-white/[0.015] px-4 py-3 flex flex-wrap items-center gap-2"
+      <header
+        className="rounded-md border border-white/10 bg-white/[0.015] px-4 py-3 space-y-1"
         data-testid="guide-scope"
       >
-        <AuthorityChip
-          label={viewModel.scope.sandbox ? 'Sandbox' : 'Committed World'}
-        />
-        <span className="text-sm font-semibold text-white/80">
-          {viewModel.scope.teamCode}
-        </span>
-        {viewModel.scope.season && (
-          <span className="text-xs text-white/40">
-            Season {viewModel.scope.season}
+        <div className="flex flex-wrap items-baseline gap-2">
+          <h2 className="text-sm font-semibold text-white/80">
+            Front Office Guide
+          </h2>
+          <span className="text-[11px] text-white/40">
+            Read-only · Deterministic · Navigation only
           </span>
-        )}
-        {viewModel.scope.sandbox && (
-          <span className="text-xs text-white/40 italic">
-            Scenario answers require an active world.
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <AuthorityChip
+            label={viewModel.scope.sandbox ? 'Sandbox' : 'Committed world'}
+          />
+          <span className="text-sm font-semibold text-white/80">
+            {viewModel.scope.teamCode}
           </span>
-        )}
-      </div>
+          {viewModel.scope.season && (
+            <span className="text-xs text-white/40">
+              Season {viewModel.scope.season}
+            </span>
+          )}
+          {viewModel.scope.sandbox && (
+            <span className="text-xs text-white/40 italic">
+              Scenario answers require an active world.
+            </span>
+          )}
+        </div>
+      </header>
 
       {FAMILY_ORDER.map((family) => (
         <FamilyGroup

--- a/src/tests/architect/stage5.polish.test.tsx
+++ b/src/tests/architect/stage5.polish.test.tsx
@@ -1,0 +1,434 @@
+/**
+ * FILE: src/tests/architect/stage5.polish.test.tsx
+ * PURPOSE: Targeted tests for Stage 5A product polish.
+ * OWNERSHIP: Feature: architect/GMDashboard
+ *
+ * Covers the rendering / a11y changes introduced by Stage 5A:
+ * - ArchitectTabBar renders all nine tabs with correct semantics
+ * - Tab buttons use type="button", role="tab", aria-pressed/aria-selected
+ * - Tab bar exposes role="tablist" + aria-label
+ * - ComparisonSection navigation buttons use type="button"
+ * - ComparisonSection nav button labels are "View …"
+ * - ComparisonSection section title is present
+ * - ComparisonSection scope chip reads "Committed world"
+ * - ComparisonSection loading state has role=status / aria-live=polite
+ * - ComparisonSection error state has role=alert
+ * - GuideSection scope chip reads "Committed world"
+ * - GuideSection section title is present
+ * - GuideSection still renders no input, textarea, or contentEditable
+ * - GuideSection navigation buttons carry navigation-only intent labelling
+ * - ScenarioMoveRail history button label is "Open History →"
+ * - ArchitectWorkspaceHeader bottom row uses "·" separator copy
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { ArchitectTabBar } from '@/features/architect/GMDashboard/components/ArchitectTabBar';
+import { ComparisonSection } from '@/features/architect/GMDashboard/sections/ComparisonSection';
+import { GuideSection } from '@/features/architect/GMDashboard/sections/GuideSection';
+import { ArchitectWorkspaceHeader } from '@/features/architect/GMDashboard/components/ArchitectWorkspaceHeader';
+import { ScenarioMoveRail } from '@/features/architect/GMDashboard/components/ScenarioMoveRail';
+import { deriveGuidedAnswers } from '@/features/architect/guidedQuestions';
+import type { Stage3ComparisonViewModel } from '@/features/architect/comparison/types';
+import type { ArchitectWorkspaceContext } from '@/features/architect/GMDashboard/hooks/useArchitectWorkspaceContext';
+import type { ActiveTab } from '@/features/architect/GMDashboard/hooks/useArchitectState.types';
+
+// Mock the scenario activity rail data hook — Stage 5 does not change rail
+// data behavior, but we need a stable render to exercise the wrapper.
+vi.mock(
+  '@/features/architect/GMDashboard/hooks/useScenarioActivityRail',
+  () => ({
+    useScenarioActivityRail: () => ({
+      railState: { status: 'empty' },
+      localPendingDeferred: false,
+    }),
+  })
+);
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NINE_TABS: ActiveTab[] = [
+  'roster',
+  'cap',
+  'capfull',
+  'trade',
+  'fa',
+  'offseason',
+  'history',
+  'compare',
+  'guide',
+];
+
+const makeTabDescriptors = (onActivate: (id: ActiveTab) => void) =>
+  NINE_TABS.map((id) => ({
+    id,
+    label: id,
+    onActivate: () => onActivate(id),
+    testId: `polish-tab-${id}`,
+  }));
+
+const makeWorkspaceContext = (
+  overrides: Partial<ArchitectWorkspaceContext> = {}
+): ArchitectWorkspaceContext => ({
+  team: { status: 'available', id: 'LAL', label: 'Los Angeles Lakers' },
+  world: {
+    status: 'available',
+    id: 'world_test',
+    label: 'Test World',
+    labelSource: 'provided',
+  },
+  seasons: {
+    selectedViewingSeason: 2025,
+    selectedViewingSeasonLabel: '2025-26',
+    authoritativeWorldSeason: '2025-26',
+    authoritativeWorldSeasonLabel: '2025-26',
+    authoritativeWorldSeasonStatus: 'available',
+    viewingSeasonDiffersFromWorldSeason: false,
+  },
+  worldDate: {
+    status: 'available',
+    value: '2025-07-01',
+    label: '2025-07-01',
+  },
+  mode: {
+    kind: 'committed-world',
+    label: 'Committed World',
+    shortLabel: 'World',
+    detail: 'Committed world',
+    tone: 'success',
+    worldId: 'world_test',
+    isCommittedWorldTruth: true,
+  },
+  status: {
+    isLoading: false,
+    isSaving: false,
+    worldMetadataLoading: false,
+    hasError: false,
+    errorMessage: null,
+  },
+  roster: { status: 'available', count: 15, source: 'players' },
+  cap: {
+    status: 'unavailable',
+    reason: 'No cap snapshot available in this fixture.',
+  },
+  exceptions: {
+    status: 'unavailable',
+    deferralHint: 'see-cap-sheet',
+    reason: 'Exception detail is owned by the Cap Sheet surface.',
+  },
+  draftAssets: {
+    status: 'unavailable',
+    deferralHint: 'see-trade-history',
+    reason: 'Draft asset surfacing is deferred.',
+  },
+  recentActivity: {
+    status: 'deferred',
+    entryPoint: 'history-tab',
+  },
+  ...overrides,
+});
+
+const makeComparisonVm = (
+  overrides: Partial<Stage3ComparisonViewModel> = {}
+): Stage3ComparisonViewModel => ({
+  scope: {
+    teamCode: 'LAL',
+    worldId: 'world_test',
+    worldName: 'Test World',
+    baselineSeason: '2025-26',
+    currentSeason: '2025-26',
+    authority: 'committed-world',
+  },
+  rosterAdditions: [],
+  rosterRemovals: [],
+  rosterChangedPlayers: [],
+  capTotalDelta: null,
+  taxApronPostureDelta: null,
+  exceptionDelta: {
+    status: 'deferred',
+    reason: 'Exception delta is not reliably derivable.',
+  },
+  changedTeams: {
+    teamCodes: [],
+    authority: 'committed-world / event-derived',
+  },
+  changedPlayers: {
+    playerIds: [],
+    authority: 'committed-world / event-derived',
+  },
+  committedEventCount: 0,
+  committedEventReferences: [],
+  isMultiSeasonComparison: false,
+  unavailableSummary: [],
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// ArchitectTabBar
+// ---------------------------------------------------------------------------
+
+describe('ArchitectTabBar (Stage 5A)', () => {
+  it('renders one button per descriptor with type="button" and role="tab"', () => {
+    render(
+      <ArchitectTabBar
+        activeTab="cap"
+        tabs={makeTabDescriptors(() => undefined)}
+      />
+    );
+    const buttons = screen.getAllByRole('tab');
+    expect(buttons).toHaveLength(NINE_TABS.length);
+    for (const b of buttons) {
+      expect(b).toHaveAttribute('type', 'button');
+    }
+  });
+
+  it('container has role="tablist" and an aria-label', () => {
+    render(
+      <ArchitectTabBar
+        activeTab="cap"
+        tabs={makeTabDescriptors(() => undefined)}
+      />
+    );
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toHaveAttribute('aria-label');
+  });
+
+  it('marks the active tab with aria-pressed=true and aria-selected=true', () => {
+    render(
+      <ArchitectTabBar
+        activeTab="compare"
+        tabs={makeTabDescriptors(() => undefined)}
+      />
+    );
+    const compareTab = screen.getByTestId('polish-tab-compare');
+    expect(compareTab).toHaveAttribute('aria-pressed', 'true');
+    expect(compareTab).toHaveAttribute('aria-selected', 'true');
+    const rosterTab = screen.getByTestId('polish-tab-roster');
+    expect(rosterTab).toHaveAttribute('aria-pressed', 'false');
+    expect(rosterTab).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('invokes the descriptor onActivate when clicked', () => {
+    const onActivate = vi.fn();
+    render(
+      <ArchitectTabBar
+        activeTab="cap"
+        tabs={makeTabDescriptors(onActivate)}
+      />
+    );
+    fireEvent.click(screen.getByTestId('polish-tab-guide'));
+    expect(onActivate).toHaveBeenCalledWith('guide');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ComparisonSection polish
+// ---------------------------------------------------------------------------
+
+describe('ComparisonSection (Stage 5A polish)', () => {
+  it('renders the section title and read-only qualifier', () => {
+    render(
+      <ComparisonSection status="available" viewModel={makeComparisonVm()} />
+    );
+    expect(screen.getByText('Committed Scenario Comparison')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Read-only · Event-derived/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the scope authority chip as "Committed world"', () => {
+    render(
+      <ComparisonSection status="available" viewModel={makeComparisonVm()} />
+    );
+    const scope = screen.getByTestId('comparison-scope');
+    expect(scope).toHaveTextContent('Committed world');
+  });
+
+  it('navigation buttons use type="button" and "View …" labels', () => {
+    render(
+      <ComparisonSection
+        status="available"
+        viewModel={makeComparisonVm()}
+        onNavigateToHistory={() => undefined}
+        onNavigateToCapSheet={() => undefined}
+        onNavigateToRoster={() => undefined}
+      />
+    );
+    const history = screen.getByTestId('comparison-nav-history');
+    const cap = screen.getByTestId('comparison-nav-cap-sheet');
+    const roster = screen.getByTestId('comparison-nav-roster');
+    for (const b of [history, cap, roster]) {
+      expect(b).toHaveAttribute('type', 'button');
+    }
+    expect(history).toHaveTextContent('View History');
+    expect(cap).toHaveTextContent('View Cap Sheet');
+    expect(roster).toHaveTextContent('View Roster');
+  });
+
+  it('navigation buttons still call only their navigation callback', () => {
+    const onCap = vi.fn();
+    const onRoster = vi.fn();
+    const onHistory = vi.fn();
+    render(
+      <ComparisonSection
+        status="available"
+        viewModel={makeComparisonVm()}
+        onNavigateToHistory={onHistory}
+        onNavigateToCapSheet={onCap}
+        onNavigateToRoster={onRoster}
+      />
+    );
+    fireEvent.click(screen.getByTestId('comparison-nav-cap-sheet'));
+    fireEvent.click(screen.getByTestId('comparison-nav-roster'));
+    fireEvent.click(screen.getByTestId('comparison-nav-history'));
+    expect(onCap).toHaveBeenCalledTimes(1);
+    expect(onRoster).toHaveBeenCalledTimes(1);
+    expect(onHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('loading state exposes role="status" with aria-live="polite"', () => {
+    render(<ComparisonSection status="loading" viewModel={null} />);
+    const node = screen.getByTestId('comparison-loading-state');
+    expect(node).toHaveAttribute('role', 'status');
+    expect(node).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('error state exposes role="alert"', () => {
+    render(
+      <ComparisonSection
+        status="error"
+        viewModel={null}
+        error="Firestore read failed"
+      />
+    );
+    const node = screen.getByTestId('comparison-error-state');
+    expect(node).toHaveAttribute('role', 'alert');
+    expect(node).toHaveTextContent('Firestore read failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GuideSection polish
+// ---------------------------------------------------------------------------
+
+describe('GuideSection (Stage 5A polish)', () => {
+  const vm = deriveGuidedAnswers({
+    workspaceContext: makeWorkspaceContext(),
+    comparisonStatus: 'available',
+    comparisonViewModel: null,
+    comparisonError: null,
+    postActionReceipt: null,
+  });
+
+  it('renders the section title and qualifier', () => {
+    render(<GuideSection viewModel={vm} onNavigate={() => undefined} />);
+    expect(screen.getByText('Front Office Guide')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Read-only · Deterministic · Navigation only/i)
+    ).toBeInTheDocument();
+  });
+
+  it('scope chip reads "Committed world" in a committed-world context', () => {
+    render(<GuideSection viewModel={vm} onNavigate={() => undefined} />);
+    const scope = screen.getByTestId('guide-scope');
+    expect(scope).toHaveTextContent('Committed world');
+  });
+
+  it('still does not render any input, textarea, or contentEditable element', () => {
+    const { container } = render(
+      <GuideSection viewModel={vm} onNavigate={() => undefined} />
+    );
+    expect(container.querySelectorAll('input').length).toBe(0);
+    expect(container.querySelectorAll('textarea').length).toBe(0);
+    expect(container.querySelectorAll('[contenteditable]').length).toBe(0);
+  });
+
+  it('every visible button is a type="button" element', () => {
+    render(<GuideSection viewModel={vm} onNavigate={() => undefined} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const b of buttons) {
+      expect(b).toHaveAttribute('type', 'button');
+    }
+  });
+
+  it('navigation buttons carry a navigation-only accessible name', () => {
+    render(<GuideSection viewModel={vm} onNavigate={() => undefined} />);
+    const navCap = screen.getAllByTestId('guide-nav-cap')[0];
+    expect(navCap).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('navigation only')
+    );
+    expect(navCap).toHaveAttribute('title');
+  });
+
+  it('clicking every button only triggers navigation events', () => {
+    const onNavigate = vi.fn();
+    render(<GuideSection viewModel={vm} onNavigate={onNavigate} />);
+    const buttons = screen.getAllByRole('button');
+    for (const b of buttons) {
+      fireEvent.click(b);
+    }
+    // Every onNavigate call should have a string target id.
+    for (const call of onNavigate.mock.calls) {
+      expect(typeof call[0]).toBe('string');
+    }
+    // The number of calls equals the number of clicked buttons — i.e. no
+    // button did "nothing" or fired something other than navigation.
+    expect(onNavigate).toHaveBeenCalledTimes(buttons.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScenarioMoveRail polish
+// ---------------------------------------------------------------------------
+
+describe('ScenarioMoveRail (Stage 5A polish)', () => {
+  it('history button reads "Open History →"', () => {
+    render(
+      <ScenarioMoveRail
+        worldId={null}
+        teamCode={null}
+        onOpenHistory={() => undefined}
+      />
+    );
+    const button = screen.getByTestId('scenario-move-rail-open-history');
+    expect(button).toHaveTextContent('Open History');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('wrapper has an aria-label', () => {
+    render(
+      <ScenarioMoveRail
+        worldId={null}
+        teamCode={null}
+        onOpenHistory={() => undefined}
+      />
+    );
+    const rail = screen.getByTestId('scenario-move-rail');
+    expect(rail).toHaveAttribute('aria-label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ArchitectWorkspaceHeader copy polish
+// ---------------------------------------------------------------------------
+
+describe('ArchitectWorkspaceHeader (Stage 5A copy polish)', () => {
+  it('renders the new "·"-separated indicator copy when fallbacks apply', () => {
+    render(<ArchitectWorkspaceHeader context={makeWorkspaceContext()} />);
+    const header = screen.getByTestId('architect-workspace-header');
+    expect(header).toHaveTextContent('Exceptions · See Cap Sheet');
+    expect(header).toHaveTextContent('Draft picks · See Trade');
+    expect(header).toHaveTextContent('Activity · See History');
+  });
+});


### PR DESCRIPTION
## Summary

Adds Stage 5 Product Polish / Professionalization for Architect Operating Experience.

Stage 1 made Architect visually continuous. Stage 2 made Architect operationally continuous. Stage 3 added read-only committed scenario comparison. Stage 4 added the deterministic Front Office Guide. Stage 5 polishes the full operating layer without adding new product behavior.

## Included

- Stage 5A: operating-experience polish implementation
- Stage 5B: final Stage 5 verification report

## Added

- `src/features/architect/GMDashboard/components/ArchitectTabBar.tsx`
- `docs/architect/ARCHITECT_STAGE_5_POLISH_NOTES.md`
- `docs/architect/ARCHITECT_STAGE_5_FINAL_VERIFICATION.md`
- `src/tests/architect/stage5.polish.test.tsx`

## Polished

- Extracted the dashboard tab bar into `ArchitectTabBar`
- Preserved all nine existing tabs and active-tab behavior
- Added `type="button"`, tab/tablist semantics, focus rings, and preserved test IDs
- Standardized copy around `Committed world`, `View …`, `Open History`, and `Label · See Surface`
- Improved Compare and Guide titles/qualifiers
- Improved loading/error/unavailable state accessibility
- Added navigation-only accessible labels to Guide navigation buttons
- Added `aria-label` and focus treatment where useful

## Guardrails

- No new features
- No new tabs
- No Firestore reads or writes
- No new event source
- No mutation authority changes
- No validation behavior changes
- No comparison derivation changes
- No guided-answer derivation changes
- No move generation or planning logic
- No branching/scenario creation UI
- No world-vs-world or parent-world comparison
- No Stage 6 audit/fix work

## Validation Reported

- Stage 5 tests: 19/19 passed
- Stage 4 tests: 39/39 passed
- Stage 3 tests: 90/90 passed
- Stage 2A/2B/2C/2D tests: 75/75 passed
- Stage 1A + 1D tests: 35/35 passed
- Combined targeted scope: 258/258 passed
- `npm run typecheck`: passed
- `npm run validate:project`: passed
- `npm run build`: passed

Known broad-suite failures remain pre-existing and unrelated, as documented in prior final verification reports.

## Acceptance Result

Stage 5B verification passed all 35 acceptance criteria with no corrections required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned dashboard tab navigation with improved presentation and semantics.

* **Style**
  * Enhanced button accessibility with focus rings and semantic roles.
  * Standardized UI copy across comparison and guide sections.
  * Improved loading, error, and empty state presentations with accessibility attributes.
  * Updated navigation button labels and styling for consistency.

* **Documentation**
  * Added Stage 5A Polish Notes and Stage 5B Final Verification Report documenting presentation-layer improvements and verification results.

* **Tests**
  * Added comprehensive test suite verifying accessibility, semantics, and UI consistency across dashboard components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bet-Zero/scoutzero/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->