### PR TITLE
BZE-191 Build offer-sheet resolution: accept/decline moves the player

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -369,6 +369,7 @@ utils/
   leagueInvariants.ts
   loadArchitectBasePlayer.ts
   mutationPipeline.compute.offerSheets.initial.ts
+  mutationPipeline.compute.offerSheets.outcome.ts
   mutationPipeline.compute.offerSheets.ts
   mutationPipeline.compute.signings.playerOps.ts
   mutationPipeline.compute.signings.signing.ts
@@ -551,5 +552,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-06-20T00:37:42.115Z*
+*Generated on: 2026-06-27T03:53:52.453Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/GMDashboard/components/OfferSheetList.tsx
+++ b/src/features/architect/GMDashboard/components/OfferSheetList.tsx
@@ -43,10 +43,10 @@ type OfferSheetLifecycleSurfaceState =
     };
 
 const OFFER_SHEET_ACTION_LABELS: Record<OfferSheetLifecycleAction, string> = {
-  match: 'Match (Preview)',
-  decline: 'Decline (Preview)',
-  finalizeMatched: 'Finalize Match (Preview)',
-  finalizeDeclined: 'Finalize Signing (Preview)',
+  match: 'Match',
+  decline: 'Decline',
+  finalizeMatched: 'Finalize Match',
+  finalizeDeclined: 'Finalize Signing',
 };
 
 const OFFER_SHEET_ACTION_TONE_CLASSES: Record<
@@ -188,7 +188,9 @@ export const OfferSheetList = ({
                           })
                         }
                         disabled={actionsDisabled}
-                        data-action-exposure-classification="preview-only"
+                        data-action-exposure-classification={
+                          actionsDisabled ? 'preview-only' : 'V1 supported'
+                        }
                         title={
                           actionsDisabled ? actionsDisabledReason : undefined
                         }

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.offerSheetActions.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.offerSheetActions.ts
@@ -171,12 +171,12 @@ export function useOfferSheetActions({
   const runOfferSheetResolutionAction = useCallback(
     (
       action: OfferSheetResolutionAction,
-      offeringTeamCode: string,
-      offerSheetId: string
+      offerSheet: OfferSheet | null | undefined
     ): void => {
       const mutationType: OfferSheetResolutionMutationType =
         action === 'match' ? 'matchOfferSheet' : 'declineOfferSheet';
-      const actionLabel = action === 'match' ? 'match' : 'decline';
+      const offeringTeamCode = String(offerSheet?.offeringTeamCode || '');
+      const offerSheetId = String(offerSheet?.id || '');
 
       void (async () => {
         const worldRequiredMessage =
@@ -194,7 +194,7 @@ export function useOfferSheetActions({
 
         if (!offeringTeamCode || !offerSheetId) {
           reportMutationError(
-            `Cannot ${actionLabel} offer sheet: missing offering team or offer sheet ID.`,
+            `Cannot ${action} offer sheet: missing offering team or offer sheet ID.`,
             {
               offeringTeamCode,
               offerSheetId,
@@ -204,14 +204,22 @@ export function useOfferSheetActions({
           return;
         }
 
+        // BZE-191: one-click resolution removes the offer sheet from BOTH teams in
+        // a single atomic mutation (Match keeps the player on the home team;
+        // Decline moves player + cap to the offering team). The committed home-team
+        // snapshot therefore no longer carries the pending sheet — so we verify the
+        // sheet is ABSENT, and pass full identity so league-invariant and receipt
+        // derivation run at parity with the legacy finalize path.
         const expectation: OfferSheetLifecycleCommittedStateExpectation = {
           activeTeamArrayKey: 'incomingOfferSheets',
-          presence: 'present',
+          presence: 'absent',
           identity: {
             offerSheetId,
             offeringTeamCode,
             homeTeamCode: teamCode,
-            status: action === 'match' ? 'MATCHED' : 'DECLINED',
+            dedupKey: offerSheet?.dedupKey,
+            playerId: offerSheet?.playerId,
+            seasonKey: offerSheet?.seasonKey,
           },
         };
 
@@ -219,8 +227,13 @@ export function useOfferSheetActions({
           mutationType,
           {
             teamCode,
+            homeTeamCode: teamCode,
             offeringTeamCode,
             offerSheetId,
+            playerId: offerSheet?.playerId,
+            playerName: offerSheet?.playerName,
+            dedupKey: offerSheet?.dedupKey,
+            seasonKey: offerSheet?.seasonKey,
           },
           expectation
         );
@@ -301,15 +314,15 @@ export function useOfferSheetActions({
   );
 
   const handleMatchOfferSheet = useCallback(
-    (offeringTeamCode: string, offerSheetId: string): void => {
-      runOfferSheetResolutionAction('match', offeringTeamCode, offerSheetId);
+    (offerSheet: OfferSheet | null | undefined): void => {
+      runOfferSheetResolutionAction('match', offerSheet);
     },
     [runOfferSheetResolutionAction]
   );
 
   const handleDeclineOfferSheet = useCallback(
-    (offeringTeamCode: string, offerSheetId: string): void => {
-      runOfferSheetResolutionAction('decline', offeringTeamCode, offerSheetId);
+    (offerSheet: OfferSheet | null | undefined): void => {
+      runOfferSheetResolutionAction('decline', offerSheet);
     },
     [runOfferSheetResolutionAction]
   );

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.types.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.types.ts
@@ -409,6 +409,7 @@ export interface OfferSheet {
   homeTeamCode?: string;
   dedupKey?: string;
   playerId?: string;
+  playerName?: string;
   seasonKey?: string;
 }
 
@@ -725,8 +726,10 @@ export interface FreeAgencyWorldOnlyModalActionOwner {
  * The action layer owns these routes; section surfaces only forward UI intent.
  */
 export interface FreeAgencyOfferSheetLifecycleActionOwner {
-  matchOfferSheet: (offeringTeamCode: string, offerSheetId: string) => void;
-  declineOfferSheet: (offeringTeamCode: string, offerSheetId: string) => void;
+  // BZE-191: one-click resolution — Match keeps the player, Decline moves the
+  // player + cap to the offering team, both in a single atomic mutation.
+  matchOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
+  declineOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
   finalizeOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
 }
 
@@ -843,14 +846,8 @@ export interface UseArchitectActionsReturn {
     playerObj: ArchitectPlayer,
     contract: SigningDetails
   ) => Promise<MutationActionResult>;
-  handleMatchOfferSheet: (
-    offeringTeamCode: string,
-    offerSheetId: string
-  ) => void;
-  handleDeclineOfferSheet: (
-    offeringTeamCode: string,
-    offerSheetId: string
-  ) => void;
+  handleMatchOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
+  handleDeclineOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
   handleFinalizeOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
 
   // Trade actions

--- a/src/features/architect/GMDashboard/postActionHandoff/types.ts
+++ b/src/features/architect/GMDashboard/postActionHandoff/types.ts
@@ -178,8 +178,10 @@ const EFFECT_AREAS_BY_MUTATION_TYPE: Record<
   signFreeAgent: ['roster', 'cap', 'exceptions', 'contract'],
   signAndTrade: ['roster', 'cap', 'exceptions', 'contract'],
   storeOfferSheet: ['contract'],
-  matchOfferSheet: ['contract'],
-  declineOfferSheet: ['contract'],
+  // BZE-191: match/decline now resolve the offer sheet atomically (player +
+  // cap move), so they carry the same roster/cap effects as finalize.
+  matchOfferSheet: ['roster', 'cap', 'contract'],
+  declineOfferSheet: ['roster', 'cap', 'contract'],
   finalizeMatchedOfferSheet: ['roster', 'cap', 'contract'],
   finalizeDeclinedOfferSheet: ['roster', 'cap', 'contract'],
   extendPlayer: ['contract', 'cap'],

--- a/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
+++ b/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
@@ -75,12 +75,12 @@ const FreeAgencySection = ({
     freeAgentModalAvailability: actionOwner.freeAgentModalAvailability,
   } satisfies FreeAgentPoolActionOwner;
   const incomingOfferSheetSurface = {
-    title: 'Incoming Offer Sheets (Preview)',
+    title: 'Incoming Offer Sheets',
     offerSheets: incomingOfferSheets,
     surfaceRole: 'incoming' as const,
   };
   const outgoingOfferSheetSurface = {
-    title: 'My Offer Sheets (Parked)',
+    title: 'My Offer Sheets',
     offerSheets: outgoingOfferSheets,
     surfaceRole: 'outgoing' as const,
   };
@@ -93,14 +93,12 @@ const FreeAgencySection = ({
     switch (`${surfaceRole}:${action}`) {
       case 'incoming:match':
         offerSheetLifecycleActionOwner?.matchOfferSheet(
-          String(offerSheet.offeringTeamCode || ''),
-          String(offerSheet.id || '')
+          offerSheet as OfferSheetFinalizeArg
         );
         return;
       case 'incoming:decline':
         offerSheetLifecycleActionOwner?.declineOfferSheet(
-          String(offerSheet.offeringTeamCode || ''),
-          String(offerSheet.id || '')
+          offerSheet as OfferSheetFinalizeArg
         );
         return;
       case 'incoming:finalizeMatched':

--- a/src/features/architect/utils/leagueInvariants.playerInvariants.ts
+++ b/src/features/architect/utils/leagueInvariants.playerInvariants.ts
@@ -316,6 +316,9 @@ export function extractIncomingPlayers(
       break;
     }
 
+    // BZE-191: one-click declineOfferSheet now performs the player move directly
+    // (same incoming-player target as the legacy two-step finalizeDeclined).
+    case 'declineOfferSheet':
     case 'finalizeDeclinedOfferSheet': {
       const playerId = payload?.playerId;
       const targetTeamCode = payload?.offeringTeamCode || payload?.teamCode;

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
@@ -6,17 +6,18 @@
  * computeDeclineOfferSheetResult.
  */
 
-import {
-  getTeamSourceRecord,
-  requireOfferSheetTeamState,
-} from './mutationPipeline.helpers';
+import { getTeamSourceRecord } from './mutationPipeline.helpers';
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
 import { normalizeSalaryRow } from '@/features/architect/utils/contractNormalization';
+import {
+  computeMatchedOfferSheetOutcome,
+  computeDeclinedOfferSheetOutcome,
+} from './mutationPipeline.compute.offerSheets.outcome';
 import type {
   ArchitectMutationOfferSheet,
   ComputeMutationParamsWithCurrentState,
   ComputeResultLike,
-  MutationOfferSheetMirrorCurrentState,
+  MutationOfferSheetResolutionCurrentState,
   MutationOfferSheetTeamAndPlayerCurrentState,
   MutationPayloadInputByType,
   NormalizedMutationSalaryRow,
@@ -230,176 +231,51 @@ export function computeStoreOfferSheetResult({
 }
 
 /**
- * Compute match offer sheet result
+ * BZE-191: One-click MATCH. The home team keeps the player in a single atomic
+ * mutation — no separate finalize step. Reuses the shared matched outcome, which
+ * applies the offer-sheet contract to the home player and clears the sheet from
+ * both teams, accepting a PENDING_MATCH sheet directly.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- params required by ComputeMutationParamsWithCurrentState interface
 export function computeMatchOfferSheetResult({
-  payload: _payload, // eslint-disable-line @typescript-eslint/no-unused-vars
+  payload,
   currentState,
-  seasonId: _seasonId, // eslint-disable-line @typescript-eslint/no-unused-vars
+  seasonId,
   timestamp,
 }: ComputeMutationParamsWithCurrentState<
-  MutationOfferSheetMirrorCurrentState,
+  MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['matchOfferSheet']
 >): ComputeResultLike {
-  const { offeringTeam, homeTeam, offerSheetId } = requireOfferSheetTeamState(
+  return computeMatchedOfferSheetOutcome({
+    payload,
     currentState,
-    'matchOfferSheet'
-  );
-
-  // Find offer sheet on offering team
-  const offeringOfferSheets = offeringTeam.offerSheets ?? [];
-  const offerSheetIndex = offeringOfferSheets.findIndex(
-    (offerSheet) => offerSheet.id === offerSheetId
-  );
-  if (offerSheetIndex === -1) {
-    return {
-      success: false,
-      error: `Offer sheet ${offerSheetId} not found on team ${offeringTeam.teamCode}`,
-    };
-  }
-
-  const existingSheet = offeringOfferSheets[offerSheetIndex];
-
-  if (existingSheet.status !== 'PENDING_MATCH') {
-    return {
-      success: false,
-      error: `Offer sheet status is ${existingSheet.status}, expected PENDING_MATCH`,
-    };
-  }
-
-  // Update status
-  const updatedOfferSheet = {
-    ...existingSheet,
-    status: 'MATCHED',
-    matchedAt: new Date(timestamp).toISOString(),
-  };
-
-  const updatedOfferingTeam = { ...offeringTeam };
-  updatedOfferingTeam.offerSheets = [...offeringOfferSheets];
-  updatedOfferingTeam.offerSheets[offerSheetIndex] = updatedOfferSheet;
-  updatedOfferingTeam.source = {
-    ...getTeamSourceRecord(updatedOfferingTeam.source),
-    lastModifiedAt: new Date(timestamp).toISOString(),
-  };
-
-  const teamUpdates = [
-    { teamCode: offeringTeam.teamCode, team: updatedOfferingTeam },
-  ];
-
-  // MIRRORING: Update logic on home team
-  if (homeTeam && homeTeam.incomingOfferSheets) {
-    const homeIndex = homeTeam.incomingOfferSheets.findIndex(
-      (offerSheet) => offerSheet.id === offerSheetId
-    );
-    if (homeIndex !== -1) {
-    const updatedHomeTeam = { ...homeTeam };
-    const incomingOfferSheets = updatedHomeTeam.incomingOfferSheets ?? [];
-    updatedHomeTeam.incomingOfferSheets = [...incomingOfferSheets];
-    updatedHomeTeam.incomingOfferSheets[homeIndex] = updatedOfferSheet;
-      updatedHomeTeam.source = {
-        ...getTeamSourceRecord(updatedHomeTeam.source),
-        lastModifiedAt: new Date(timestamp).toISOString(),
-      };
-      teamUpdates.push({ teamCode: homeTeam.teamCode, team: updatedHomeTeam });
-    }
-  }
-
-  return {
-    success: true,
-    teamUpdates,
-    playerUpdates: [],
-    metadata: {
-      type: 'matchOfferSheet',
-      offeringTeamCode: offeringTeam.teamCode,
-      homeTeamCode: homeTeam.teamCode,
-      offerSheetId,
-      timestamp,
-    },
-  };
+    seasonId,
+    timestamp,
+    acceptedStatuses: ['PENDING_MATCH'],
+    metadataType: 'matchOfferSheet',
+  });
 }
 
 /**
- * Compute decline offer sheet result
+ * BZE-191: One-click DECLINE. The player + cap move to the offering team in a
+ * single atomic mutation — no separate finalize step. Reuses the shared declined
+ * outcome, which signs the player onto the offering team and removes them (and
+ * the sheet) from the home team, accepting a PENDING_MATCH sheet directly.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- params required by ComputeMutationParamsWithCurrentState interface
 export function computeDeclineOfferSheetResult({
-  payload: _payload, // eslint-disable-line @typescript-eslint/no-unused-vars
+  payload,
   currentState,
-  seasonId: _seasonId, // eslint-disable-line @typescript-eslint/no-unused-vars
+  seasonId,
   timestamp,
 }: ComputeMutationParamsWithCurrentState<
-  MutationOfferSheetMirrorCurrentState,
+  MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['declineOfferSheet']
 >): ComputeResultLike {
-  const { offeringTeam, homeTeam, offerSheetId } = requireOfferSheetTeamState(
+  return computeDeclinedOfferSheetOutcome({
+    payload,
     currentState,
-    'declineOfferSheet'
-  );
-
-  // Find offer sheet
-  const offeringOfferSheets = offeringTeam.offerSheets ?? [];
-  const offerSheetIndex = offeringOfferSheets.findIndex(
-    (offerSheet) => offerSheet.id === offerSheetId
-  );
-  if (offerSheetIndex === -1) {
-    return { success: false, error: `Offer sheet ${offerSheetId} not found` };
-  }
-
-  const existingSheet = offeringOfferSheets[offerSheetIndex];
-  if (existingSheet.status !== 'PENDING_MATCH') {
-    return {
-      success: false,
-      error: `Offer sheet status is ${existingSheet.status}, expected PENDING_MATCH`,
-    };
-  }
-
-  const updatedOfferSheet = {
-    ...existingSheet,
-    status: 'DECLINED',
-    declinedAt: new Date(timestamp).toISOString(),
-  };
-
-  const updatedOfferingTeam = { ...offeringTeam };
-  updatedOfferingTeam.offerSheets = [...offeringOfferSheets];
-  updatedOfferingTeam.offerSheets[offerSheetIndex] = updatedOfferSheet;
-  updatedOfferingTeam.source = {
-    ...getTeamSourceRecord(updatedOfferingTeam.source),
-    lastModifiedAt: new Date(timestamp).toISOString(),
-  };
-
-  const teamUpdates = [
-    { teamCode: offeringTeam.teamCode, team: updatedOfferingTeam },
-  ];
-
-  // MIRRORING: Update logic on home team
-  if (homeTeam && homeTeam.incomingOfferSheets) {
-    const homeIndex = homeTeam.incomingOfferSheets.findIndex(
-      (offerSheet) => offerSheet.id === offerSheetId
-    );
-    if (homeIndex !== -1) {
-      const updatedHomeTeam = { ...homeTeam };
-      const incomingOfferSheets = updatedHomeTeam.incomingOfferSheets ?? [];
-      updatedHomeTeam.incomingOfferSheets = [...incomingOfferSheets];
-      updatedHomeTeam.incomingOfferSheets[homeIndex] = updatedOfferSheet;
-      updatedHomeTeam.source = {
-        ...getTeamSourceRecord(updatedHomeTeam.source),
-        lastModifiedAt: new Date(timestamp).toISOString(),
-      };
-      teamUpdates.push({ teamCode: homeTeam.teamCode, team: updatedHomeTeam });
-    }
-  }
-
-  return {
-    success: true,
-    teamUpdates,
-    playerUpdates: [],
-    metadata: {
-      type: 'declineOfferSheet',
-      offeringTeamCode: offeringTeam.teamCode,
-      homeTeamCode: homeTeam.teamCode,
-      offerSheetId,
-      timestamp,
-    },
-  };
+    seasonId,
+    timestamp,
+    acceptedStatuses: ['PENDING_MATCH'],
+    metadataType: 'declineOfferSheet',
+  });
 }

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
@@ -1,0 +1,411 @@
+/**
+ * FILE: src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
+ * PURPOSE: Shared offer-sheet resolution OUTCOME logic (the actual player move).
+ * OWNERSHIP: Feature: architect/core
+ *
+ * BZE-191: The "match keeps the player on the home team" and "decline moves the
+ * player + cap to the offering team" outcomes were previously reachable only via
+ * the two-step finalize* mutations (which require a prior MATCHED/DECLINED status
+ * flip). This module factors that proven outcome logic out so BOTH paths reuse it:
+ *   - the legacy two-step finalize* computes (acceptedStatuses = MATCHED/DECLINED), and
+ *   - the one-click match/decline computes (acceptedStatuses = PENDING_MATCH),
+ * which now perform the whole resolution atomically in a single mutation.
+ *
+ * The finalize* fail-closed status guards are preserved exactly by passing their
+ * original acceptedStatuses; only the accepted prior-status set and the metadata
+ * type differ between callers.
+ */
+
+import {
+  buildCanonicalPlayerPersistenceManifest,
+  findPlayerInTeamPlayers,
+  getMutationPlayerId,
+  getMutationRosterEntryId,
+  getTeamSourceRecord,
+  requireOfferSheetTeamState,
+  synchronizeTeamTotalsSnapshotOrTeam,
+} from './mutationPipeline.helpers';
+import { toEndYear } from '@/features/architect/utils/seasonFormat';
+import {
+  matchesOfferSheetIdentity,
+  buildNormalizedOfferSheetFinalContract,
+  removeOfferSheetEntries,
+} from './mutationPipeline.read';
+import type {
+  ComputeResultLike,
+  MutationOfferSheetResolutionCurrentState,
+} from './mutationPipeline';
+
+export type OfferSheetOutcomeParams = {
+  payload: { dedupKey?: string | null };
+  currentState: MutationOfferSheetResolutionCurrentState;
+  seasonId: string;
+  timestamp: number;
+  /** Prior offer-sheet statuses this outcome is allowed to run from. */
+  acceptedStatuses: readonly string[];
+  /** Mutation type recorded in result metadata (drives history/receipt routing). */
+  metadataType: string;
+};
+
+function formatAcceptedStatuses(acceptedStatuses: readonly string[]): string {
+  return acceptedStatuses.join(' or ');
+}
+
+/**
+ * MATCHED outcome: the home team keeps the player. Apply the offer-sheet contract
+ * terms to the home team's player and remove the offer sheet from BOTH teams.
+ */
+export function computeMatchedOfferSheetOutcome({
+  payload,
+  currentState,
+  seasonId,
+  timestamp,
+  acceptedStatuses,
+  metadataType,
+}: OfferSheetOutcomeParams): ComputeResultLike {
+  const { homeTeam, offeringTeam, offerSheetId } = requireOfferSheetTeamState(
+    currentState,
+    metadataType
+  );
+  const incomingOfferSheets = homeTeam.incomingOfferSheets || [];
+  const requestedDedupKey = payload.dedupKey as string | null | undefined;
+  const offerSheet = incomingOfferSheets.find((existingOfferSheet) =>
+    matchesOfferSheetIdentity(
+      existingOfferSheet,
+      offerSheetId || '',
+      requestedDedupKey
+    )
+  );
+
+  if (!offerSheet) {
+    return {
+      success: false,
+      error: `Offer sheet ${offerSheetId} not found on home team.`,
+    };
+  }
+
+  if (!acceptedStatuses.includes(String(offerSheet.status))) {
+    return {
+      success: false,
+      error: `Offer sheet status is ${offerSheet.status}, expected ${formatAcceptedStatuses(acceptedStatuses)}.`,
+    };
+  }
+
+  const playerId = String(offerSheet.playerId || '').trim();
+  if (!playerId) {
+    return {
+      success: false,
+      error: `Offer sheet ${offerSheetId} is missing playerId.`,
+    };
+  }
+
+  const homeTeamPlayers = homeTeam.players ?? [];
+  const playerIndex = homeTeamPlayers.findIndex(
+    (teamPlayer) => getMutationPlayerId(teamPlayer) === playerId
+  );
+
+  if (playerIndex === -1) {
+    return {
+      success: false,
+      error: `Player ${playerId} not found on home team roster for contract application.`,
+    };
+  }
+
+  const normalizedContract = buildNormalizedOfferSheetFinalContract({
+    offerSheet,
+    signingTeam: homeTeam.teamCode || '',
+    signedUsing: 'Match',
+    timestamp,
+  });
+  if (!normalizedContract) {
+    return {
+      success: false,
+      error: `Offer sheet ${offerSheetId} could not be normalized for matched finalization.`,
+    };
+  }
+
+  const updatedPlayer = {
+    ...homeTeamPlayers[playerIndex],
+    teamCode: homeTeam.teamCode,
+    teamName: homeTeam.teamName,
+    contract: normalizedContract,
+  };
+  delete updatedPlayer.rfaOfferSheet;
+  delete updatedPlayer.rfaOfferSheetOnly;
+  delete updatedPlayer.rfaContext;
+
+  const resolvedDedupKey = String(
+    offerSheet.dedupKey || requestedDedupKey || ''
+  ).trim();
+  const updatedHomeTeam = { ...homeTeam };
+  updatedHomeTeam.incomingOfferSheets = removeOfferSheetEntries(
+    incomingOfferSheets,
+    offerSheetId || '',
+    resolvedDedupKey
+  );
+  updatedHomeTeam.players = [
+    ...homeTeamPlayers.slice(0, playerIndex),
+    updatedPlayer,
+    ...homeTeamPlayers.slice(playerIndex + 1),
+  ];
+  if (Array.isArray(updatedHomeTeam.capHolds)) {
+    updatedHomeTeam.capHolds = updatedHomeTeam.capHolds.filter(
+      (hold) => String(hold?.playerId || '').trim() !== playerId
+    );
+  }
+  updatedHomeTeam.source = {
+    ...getTeamSourceRecord(updatedHomeTeam.source),
+    type: 'world-snapshot',
+    lastModifiedAt: new Date(timestamp).toISOString(),
+  };
+  updatedHomeTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
+    updatedHomeTeam,
+    toEndYear(seasonId)
+  ).totals;
+
+  const updatedOfferingTeam = { ...offeringTeam };
+  updatedOfferingTeam.offerSheets = removeOfferSheetEntries(
+    updatedOfferingTeam.offerSheets || [],
+    offerSheetId || '',
+    resolvedDedupKey
+  );
+  updatedOfferingTeam.source = {
+    ...getTeamSourceRecord(updatedOfferingTeam.source),
+    type: 'world-snapshot',
+    lastModifiedAt: new Date(timestamp).toISOString(),
+  };
+
+  const teamUpdates = [
+    { teamCode: homeTeam.teamCode, team: updatedHomeTeam },
+    { teamCode: offeringTeam.teamCode, team: updatedOfferingTeam },
+  ];
+  const persistenceManifest = buildCanonicalPlayerPersistenceManifest({
+    teamUpdates,
+    candidates: [
+      {
+        playerId,
+        destinationTeamCode: String(homeTeam.teamCode || '').trim(),
+        mode: 'replace',
+      },
+    ],
+    manifestLabel: 'Offer sheet matched persistence manifest',
+  });
+  if ('error' in persistenceManifest) {
+    return {
+      success: false,
+      error: persistenceManifest.error,
+    };
+  }
+
+  return {
+    success: true,
+    teamUpdates,
+    playerUpdates: persistenceManifest.playerUpdates,
+    playerDeletes: persistenceManifest.playerDeletes,
+    metadata: {
+      type: metadataType,
+      offerSheetId,
+      playerId,
+      homeTeam: homeTeam.teamCode,
+      offeringTeam: offeringTeam.teamCode,
+      teamCode: homeTeam.teamCode,
+      playerName: updatedPlayer.displayName || updatedPlayer.name,
+      signedUsing: 'Match',
+      contract: normalizedContract,
+      timestamp,
+    },
+  };
+}
+
+/**
+ * DECLINED outcome: the player + cap move to the offering team. Apply the
+ * offer-sheet contract terms to the offering team's signing and remove the offer
+ * sheet (and the player) from the home team.
+ */
+export function computeDeclinedOfferSheetOutcome({
+  payload,
+  currentState,
+  seasonId,
+  timestamp,
+  acceptedStatuses,
+  metadataType,
+}: OfferSheetOutcomeParams): ComputeResultLike {
+  const { offeringTeam, homeTeam, offerSheetId } = requireOfferSheetTeamState(
+    currentState,
+    metadataType
+  );
+  const dedupKey = payload.dedupKey as string | null | undefined;
+
+  // 1. Find the offer sheet (on offering team)
+  const offerSheets = offeringTeam.offerSheets || [];
+  const offerSheet = offerSheets.find((existingOfferSheet) =>
+    matchesOfferSheetIdentity(existingOfferSheet, offerSheetId || '', dedupKey)
+  );
+
+  if (!offerSheet) {
+    return {
+      success: false,
+      error: `Offer sheet ${offerSheetId} not found on offering team.`,
+    };
+  }
+
+  if (!acceptedStatuses.includes(String(offerSheet.status))) {
+    return {
+      success: false,
+      error: `Offer sheet status is ${offerSheet.status}, expected ${formatAcceptedStatuses(acceptedStatuses)}.`,
+    };
+  }
+
+  const playerId = String(offerSheet.playerId || '').trim();
+  if (!playerId) {
+    return {
+      success: false,
+      error: `Offer sheet ${offerSheetId} is missing playerId.`,
+    };
+  }
+
+  const sourcePlayer = findPlayerInTeamPlayers(homeTeam, playerId);
+  if (!sourcePlayer) {
+    return {
+      success: false,
+      error: `Player ${playerId} not found on home team roster for declined finalization.`,
+    };
+  }
+
+  const normalizedContract = buildNormalizedOfferSheetFinalContract({
+    offerSheet,
+    signingTeam: offeringTeam.teamCode || '',
+    signedUsing: 'Offer Sheet',
+    timestamp,
+  });
+  if (!normalizedContract) {
+    return {
+      success: false,
+      error: `Offer sheet ${offerSheetId} could not be normalized for declined finalization.`,
+    };
+  }
+
+  const resolvedDedupKey = String(offerSheet.dedupKey || dedupKey || '').trim();
+  const updatedPlayer = {
+    ...sourcePlayer,
+    teamCode: offeringTeam.teamCode,
+    teamName: offeringTeam.teamName,
+    contract: normalizedContract,
+  };
+  delete updatedPlayer.rfaOfferSheet;
+  delete updatedPlayer.rfaOfferSheetOnly;
+  delete updatedPlayer.rfaContext;
+
+  const updatedOfferingTeam = { ...offeringTeam };
+  updatedOfferingTeam.offerSheets = removeOfferSheetEntries(
+    offerSheets,
+    offerSheetId || '',
+    resolvedDedupKey
+  );
+  const offeringTeamPlayers = updatedOfferingTeam.players ?? [];
+  const offeringPlayerIndex = offeringTeamPlayers.findIndex(
+    (teamPlayer) => getMutationPlayerId(teamPlayer) === playerId
+  );
+  if (offeringPlayerIndex !== -1) {
+    updatedOfferingTeam.players = [
+      ...offeringTeamPlayers.slice(0, offeringPlayerIndex),
+      updatedPlayer,
+      ...offeringTeamPlayers.slice(offeringPlayerIndex + 1),
+    ];
+  } else {
+    updatedOfferingTeam.players = [...offeringTeamPlayers, updatedPlayer];
+  }
+  if (
+    !(updatedOfferingTeam.roster || []).some(
+      (entry) => getMutationRosterEntryId(entry) === playerId
+    )
+  ) {
+    updatedOfferingTeam.roster = [
+      ...(updatedOfferingTeam.roster || []),
+      playerId,
+    ];
+  }
+  if (Array.isArray(updatedOfferingTeam.capHolds)) {
+    updatedOfferingTeam.capHolds = updatedOfferingTeam.capHolds.filter(
+      (hold) => String(hold?.playerId || '').trim() !== playerId
+    );
+  }
+  updatedOfferingTeam.source = {
+    ...getTeamSourceRecord(updatedOfferingTeam.source),
+    type: 'world-snapshot',
+    lastModifiedAt: new Date(timestamp).toISOString(),
+  };
+  updatedOfferingTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
+    updatedOfferingTeam,
+    toEndYear(seasonId)
+  ).totals;
+
+  const updatedHomeTeam = { ...homeTeam };
+  updatedHomeTeam.incomingOfferSheets = removeOfferSheetEntries(
+    updatedHomeTeam.incomingOfferSheets || [],
+    offerSheetId || '',
+    resolvedDedupKey
+  );
+  updatedHomeTeam.roster = (updatedHomeTeam.roster || []).filter(
+    (entry) => getMutationRosterEntryId(entry) !== playerId
+  );
+  updatedHomeTeam.players = (updatedHomeTeam.players || []).filter(
+    (teamPlayer) => getMutationPlayerId(teamPlayer) !== playerId
+  );
+  if (Array.isArray(updatedHomeTeam.capHolds)) {
+    updatedHomeTeam.capHolds = updatedHomeTeam.capHolds.filter(
+      (hold) => String(hold?.playerId || '').trim() !== playerId
+    );
+  }
+  updatedHomeTeam.source = {
+    ...getTeamSourceRecord(updatedHomeTeam.source),
+    type: 'world-snapshot',
+    lastModifiedAt: new Date(timestamp).toISOString(),
+  };
+  updatedHomeTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
+    updatedHomeTeam,
+    toEndYear(seasonId)
+  ).totals;
+
+  const teamUpdates = [
+    { teamCode: offeringTeam.teamCode, team: updatedOfferingTeam },
+    { teamCode: homeTeam.teamCode, team: updatedHomeTeam },
+  ];
+  const persistenceManifest = buildCanonicalPlayerPersistenceManifest({
+    teamUpdates,
+    candidates: [
+      {
+        playerId,
+        sourceTeamCode: String(homeTeam.teamCode || '').trim(),
+        destinationTeamCode: String(offeringTeam.teamCode || '').trim(),
+        mode: 'move',
+      },
+    ],
+    manifestLabel: 'Offer sheet declined persistence manifest',
+  });
+  if ('error' in persistenceManifest) {
+    return {
+      success: false,
+      error: persistenceManifest.error,
+    };
+  }
+
+  return {
+    success: true,
+    teamUpdates,
+    playerUpdates: persistenceManifest.playerUpdates,
+    playerDeletes: persistenceManifest.playerDeletes,
+    metadata: {
+      type: metadataType,
+      offerSheetId,
+      playerId,
+      offeringTeam: offeringTeam.teamCode,
+      homeTeam: homeTeam.teamCode,
+      teamCode: offeringTeam.teamCode,
+      playerName: updatedPlayer.displayName || updatedPlayer.name,
+      signedUsing: 'Offer Sheet',
+      contract: normalizedContract,
+      timestamp,
+    },
+  };
+}

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.ts
@@ -5,40 +5,31 @@
  *
  * Wave 8 Step 1: Extracted from mutationPipeline.compute.ts (L1482-L2249).
  * Wave 50 Step 1: store/match/decline functions extracted to submodule.
+ * BZE-191: matched/declined OUTCOME logic factored into the shared outcome module
+ * so the two-step finalize* path and the one-click match/decline path reuse it.
  */
 
-import {
-  buildCanonicalPlayerPersistenceManifest,
-  findPlayerInTeamPlayers,
-  getMutationPlayerId,
-  getMutationRosterEntryId,
-  getTeamSourceRecord,
-  requireOfferSheetTeamState,
-  synchronizeTeamTotalsSnapshotOrTeam,
-} from './mutationPipeline.helpers';
-import { toEndYear } from '@/features/architect/utils/seasonFormat';
-import {
-  matchesOfferSheetIdentity,
-  buildNormalizedOfferSheetFinalContract,
-  removeOfferSheetEntries,
-} from './mutationPipeline.read';
 import type {
   ComputeMutationParamsWithCurrentState,
   ComputeResultLike,
   MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType,
 } from './mutationPipeline';
+import {
+  computeMatchedOfferSheetOutcome,
+  computeDeclinedOfferSheetOutcome,
+} from './mutationPipeline.compute.offerSheets.outcome';
 
 // Wave 50 Step 1: store/match/decline functions extracted to submodule
 export * from './mutationPipeline.compute.offerSheets.initial';
+// BZE-191: shared matched/declined outcome helpers
+export * from './mutationPipeline.compute.offerSheets.outcome';
 
 /**
- * Compute MATCHED offer sheet finalization.
+ * Compute MATCHED offer sheet finalization (legacy two-step path).
  *
- * GOAL:
- * 1. Validate status is MATCHED (and acting team is home team - handled by validator).
- * 2. Apply the contract terms from offer sheet to the home team's player.
- * 3. Remove offer sheet from BOTH home and offering teams.
+ * Requires a prior MATCHED status flip; the player-move outcome is shared with
+ * the one-click match path via computeMatchedOfferSheetOutcome.
  */
 export function computeFinalizeMatchedOfferSheetResult({
   payload,
@@ -49,167 +40,21 @@ export function computeFinalizeMatchedOfferSheetResult({
   MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['finalizeMatchedOfferSheet']
 >): ComputeResultLike {
-  const { homeTeam, offeringTeam, offerSheetId } = requireOfferSheetTeamState(
+  return computeMatchedOfferSheetOutcome({
+    payload,
     currentState,
-    'finalizeMatchedOfferSheet'
-  );
-  const incomingOfferSheets = homeTeam.incomingOfferSheets || [];
-  const requestedDedupKey = payload.dedupKey as string | null | undefined;
-  const offerSheet = incomingOfferSheets.find((existingOfferSheet) =>
-    matchesOfferSheetIdentity(
-      existingOfferSheet,
-      offerSheetId || '',
-      requestedDedupKey
-    )
-  );
-
-  if (!offerSheet) {
-    return {
-      success: false,
-      error: `Offer sheet ${offerSheetId} not found on home team.`,
-    };
-  }
-
-  if (offerSheet.status !== 'MATCHED') {
-    return {
-      success: false,
-      error: `Offer sheet status is ${offerSheet.status}, expected MATCHED.`,
-    };
-  }
-
-  const playerId = String(offerSheet.playerId || '').trim();
-  if (!playerId) {
-    return {
-      success: false,
-      error: `Offer sheet ${offerSheetId} is missing playerId.`,
-    };
-  }
-
-  const homeTeamPlayers = homeTeam.players ?? [];
-  const playerIndex = homeTeamPlayers.findIndex(
-    (teamPlayer) => getMutationPlayerId(teamPlayer) === playerId
-  );
-
-  if (playerIndex === -1) {
-    return {
-      success: false,
-      error: `Player ${playerId} not found on home team roster for contract application.`,
-    };
-  }
-
-  const normalizedContract = buildNormalizedOfferSheetFinalContract({
-    offerSheet,
-    signingTeam: homeTeam.teamCode || '',
-    signedUsing: 'Match',
+    seasonId,
     timestamp,
+    acceptedStatuses: ['MATCHED'],
+    metadataType: 'finalizeMatchedOfferSheet',
   });
-  if (!normalizedContract) {
-    return {
-      success: false,
-      error: `Offer sheet ${offerSheetId} could not be normalized for matched finalization.`,
-    };
-  }
-
-  const updatedPlayer = {
-    ...homeTeamPlayers[playerIndex],
-    teamCode: homeTeam.teamCode,
-    teamName: homeTeam.teamName,
-    contract: normalizedContract,
-  };
-  delete updatedPlayer.rfaOfferSheet;
-  delete updatedPlayer.rfaOfferSheetOnly;
-  delete updatedPlayer.rfaContext;
-
-  const resolvedDedupKey = String(
-    offerSheet.dedupKey || requestedDedupKey || ''
-  ).trim();
-  const updatedHomeTeam = { ...homeTeam };
-  updatedHomeTeam.incomingOfferSheets = removeOfferSheetEntries(
-    incomingOfferSheets,
-    offerSheetId || '',
-    resolvedDedupKey
-  );
-  updatedHomeTeam.players = [
-    ...homeTeamPlayers.slice(0, playerIndex),
-    updatedPlayer,
-    ...homeTeamPlayers.slice(playerIndex + 1),
-  ];
-  if (Array.isArray(updatedHomeTeam.capHolds)) {
-    updatedHomeTeam.capHolds = updatedHomeTeam.capHolds.filter(
-      (hold) => String(hold?.playerId || '').trim() !== playerId
-    );
-  }
-  updatedHomeTeam.source = {
-    ...getTeamSourceRecord(updatedHomeTeam.source),
-    type: 'world-snapshot',
-    lastModifiedAt: new Date(timestamp).toISOString(),
-  };
-  updatedHomeTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
-    updatedHomeTeam,
-    toEndYear(seasonId)
-  ).totals;
-
-  const updatedOfferingTeam = { ...offeringTeam };
-  updatedOfferingTeam.offerSheets = removeOfferSheetEntries(
-    updatedOfferingTeam.offerSheets || [],
-    offerSheetId || '',
-    resolvedDedupKey
-  );
-  updatedOfferingTeam.source = {
-    ...getTeamSourceRecord(updatedOfferingTeam.source),
-    type: 'world-snapshot',
-    lastModifiedAt: new Date(timestamp).toISOString(),
-  };
-
-  const teamUpdates = [
-    { teamCode: homeTeam.teamCode, team: updatedHomeTeam },
-    { teamCode: offeringTeam.teamCode, team: updatedOfferingTeam },
-  ];
-  const persistenceManifest = buildCanonicalPlayerPersistenceManifest({
-    teamUpdates,
-    candidates: [
-      {
-        playerId,
-        destinationTeamCode: String(homeTeam.teamCode || '').trim(),
-        mode: 'replace',
-      },
-    ],
-    manifestLabel: 'Offer sheet matched persistence manifest',
-  });
-  if ('error' in persistenceManifest) {
-    return {
-      success: false,
-      error: persistenceManifest.error,
-    };
-  }
-
-  return {
-    success: true,
-    teamUpdates,
-    playerUpdates: persistenceManifest.playerUpdates,
-    playerDeletes: persistenceManifest.playerDeletes,
-    metadata: {
-      type: 'finalizeMatchedOfferSheet',
-      offerSheetId,
-      playerId,
-      homeTeam: homeTeam.teamCode,
-      offeringTeam: offeringTeam.teamCode,
-      teamCode: homeTeam.teamCode,
-      playerName: updatedPlayer.displayName || updatedPlayer.name,
-      signedUsing: 'Match',
-      contract: normalizedContract,
-      timestamp,
-    },
-  };
 }
 
 /**
- * Phase 18.1: Compute DECLINED offer sheet finalization.
+ * Phase 18.1: Compute DECLINED offer sheet finalization (legacy two-step path).
  *
- * GOAL:
- * 1. Validate status is DECLINED (and acting team is offering team - handled by validator).
- * 2. Remove offer sheet from BOTH teams (explicit cleanup).
- * 3. Apply the contract terms from offer sheet to the offering team's player (signing).
+ * Requires a prior DECLINED status flip; the player-move outcome is shared with
+ * the one-click decline path via computeDeclinedOfferSheetOutcome.
  */
 export function computeFinalizeDeclinedOfferSheetResult({
   payload,
@@ -220,185 +65,12 @@ export function computeFinalizeDeclinedOfferSheetResult({
   MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['finalizeDeclinedOfferSheet']
 >): ComputeResultLike {
-  const { offeringTeam, homeTeam, offerSheetId } = requireOfferSheetTeamState(
+  return computeDeclinedOfferSheetOutcome({
+    payload,
     currentState,
-    'finalizeDeclinedOfferSheet'
-  );
-  const dedupKey = payload.dedupKey as string | null | undefined;
-
-  // 1. Find the offer sheet (on offering team)
-  const offerSheets = offeringTeam.offerSheets || [];
-  const offerSheet = offerSheets.find((existingOfferSheet) =>
-    matchesOfferSheetIdentity(existingOfferSheet, offerSheetId || '', dedupKey)
-  );
-
-  if (!offerSheet) {
-    return {
-      success: false,
-      error: `Offer sheet ${offerSheetId} not found on offering team.`,
-    };
-  }
-
-  if (offerSheet.status !== 'DECLINED') {
-    return {
-      success: false,
-      error: `Offer sheet status is ${offerSheet.status}, expected DECLINED.`,
-    };
-  }
-
-  const playerId = String(offerSheet.playerId || '').trim();
-  if (!playerId) {
-    return {
-      success: false,
-      error: `Offer sheet ${offerSheetId} is missing playerId.`,
-    };
-  }
-
-  const sourcePlayer = findPlayerInTeamPlayers(homeTeam, playerId);
-  if (!sourcePlayer) {
-    return {
-      success: false,
-      error: `Player ${playerId} not found on home team roster for declined finalization.`,
-    };
-  }
-
-  const normalizedContract = buildNormalizedOfferSheetFinalContract({
-    offerSheet,
-    signingTeam: offeringTeam.teamCode || '',
-    signedUsing: 'Offer Sheet',
+    seasonId,
     timestamp,
+    acceptedStatuses: ['DECLINED'],
+    metadataType: 'finalizeDeclinedOfferSheet',
   });
-  if (!normalizedContract) {
-    return {
-      success: false,
-      error: `Offer sheet ${offerSheetId} could not be normalized for declined finalization.`,
-    };
-  }
-
-  const resolvedDedupKey = String(offerSheet.dedupKey || dedupKey || '').trim();
-  const updatedPlayer = {
-    ...sourcePlayer,
-    teamCode: offeringTeam.teamCode,
-    teamName: offeringTeam.teamName,
-    contract: normalizedContract,
-  };
-  delete updatedPlayer.rfaOfferSheet;
-  delete updatedPlayer.rfaOfferSheetOnly;
-  delete updatedPlayer.rfaContext;
-
-  const updatedOfferingTeam = { ...offeringTeam };
-  updatedOfferingTeam.offerSheets = removeOfferSheetEntries(
-    offerSheets,
-    offerSheetId || '',
-    resolvedDedupKey
-  );
-  const offeringTeamPlayers = updatedOfferingTeam.players ?? [];
-  const offeringPlayerIndex = offeringTeamPlayers.findIndex(
-    (teamPlayer) => getMutationPlayerId(teamPlayer) === playerId
-  );
-  if (offeringPlayerIndex !== -1) {
-    updatedOfferingTeam.players = [
-      ...offeringTeamPlayers.slice(0, offeringPlayerIndex),
-      updatedPlayer,
-      ...offeringTeamPlayers.slice(offeringPlayerIndex + 1),
-    ];
-  } else {
-    updatedOfferingTeam.players = [
-      ...offeringTeamPlayers,
-      updatedPlayer,
-    ];
-  }
-  if (
-    !(updatedOfferingTeam.roster || []).some(
-      (entry) => getMutationRosterEntryId(entry) === playerId
-    )
-  ) {
-    updatedOfferingTeam.roster = [
-      ...(updatedOfferingTeam.roster || []),
-      playerId,
-    ];
-  }
-  if (Array.isArray(updatedOfferingTeam.capHolds)) {
-    updatedOfferingTeam.capHolds = updatedOfferingTeam.capHolds.filter(
-      (hold) => String(hold?.playerId || '').trim() !== playerId
-    );
-  }
-  updatedOfferingTeam.source = {
-    ...getTeamSourceRecord(updatedOfferingTeam.source),
-    type: 'world-snapshot',
-    lastModifiedAt: new Date(timestamp).toISOString(),
-  };
-  updatedOfferingTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
-    updatedOfferingTeam,
-    toEndYear(seasonId)
-  ).totals;
-
-  const updatedHomeTeam = { ...homeTeam };
-  updatedHomeTeam.incomingOfferSheets = removeOfferSheetEntries(
-    updatedHomeTeam.incomingOfferSheets || [],
-    offerSheetId || '',
-    resolvedDedupKey
-  );
-  updatedHomeTeam.roster = (updatedHomeTeam.roster || []).filter(
-    (entry) => getMutationRosterEntryId(entry) !== playerId
-  );
-  updatedHomeTeam.players = (updatedHomeTeam.players || []).filter(
-    (teamPlayer) => getMutationPlayerId(teamPlayer) !== playerId
-  );
-  if (Array.isArray(updatedHomeTeam.capHolds)) {
-    updatedHomeTeam.capHolds = updatedHomeTeam.capHolds.filter(
-      (hold) => String(hold?.playerId || '').trim() !== playerId
-    );
-  }
-  updatedHomeTeam.source = {
-    ...getTeamSourceRecord(updatedHomeTeam.source),
-    type: 'world-snapshot',
-    lastModifiedAt: new Date(timestamp).toISOString(),
-  };
-  updatedHomeTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
-    updatedHomeTeam,
-    toEndYear(seasonId)
-  ).totals;
-
-  const teamUpdates = [
-    { teamCode: offeringTeam.teamCode, team: updatedOfferingTeam },
-    { teamCode: homeTeam.teamCode, team: updatedHomeTeam },
-  ];
-  const persistenceManifest = buildCanonicalPlayerPersistenceManifest({
-    teamUpdates,
-    candidates: [
-      {
-        playerId,
-        sourceTeamCode: String(homeTeam.teamCode || '').trim(),
-        destinationTeamCode: String(offeringTeam.teamCode || '').trim(),
-        mode: 'move',
-      },
-    ],
-    manifestLabel: 'Offer sheet declined persistence manifest',
-  });
-  if ('error' in persistenceManifest) {
-    return {
-      success: false,
-      error: persistenceManifest.error,
-    };
-  }
-
-  return {
-    success: true,
-    teamUpdates,
-    playerUpdates: persistenceManifest.playerUpdates,
-    playerDeletes: persistenceManifest.playerDeletes,
-    metadata: {
-      type: 'finalizeDeclinedOfferSheet',
-      offerSheetId,
-      playerId,
-      offeringTeam: offeringTeam.teamCode,
-      homeTeam: homeTeam.teamCode,
-      teamCode: offeringTeam.teamCode,
-      playerName: updatedPlayer.displayName || updatedPlayer.name,
-      signedUsing: 'Offer Sheet',
-      contract: normalizedContract,
-      timestamp,
-    },
-  };
 }

--- a/src/features/architect/utils/mutationPipeline.normalize.ts
+++ b/src/features/architect/utils/mutationPipeline.normalize.ts
@@ -12,7 +12,6 @@ import {
   normalizeTeamOnlyMutationCurrentState,
   normalizeTeamAndPlayerMutationCurrentState,
   normalizeOfferSheetTeamAndPlayerMutationCurrentState,
-  normalizeOfferSheetMirrorMutationCurrentState,
   normalizeOfferSheetResolutionMutationCurrentState,
   normalizeSignAndTradeMutationCurrentState,
   toTradePayload,
@@ -110,8 +109,6 @@ const STORE_OFFER_SHEET_MUTATION_PAYLOAD_KEYS = [
   'offerSheetId',
   'worldId',
 ] as const satisfies readonly (keyof ArchitectMutationPayload)[];
-const OFFER_SHEET_MIRROR_MUTATION_PAYLOAD_KEYS =
-  [] as const satisfies readonly (keyof ArchitectMutationPayload)[];
 const OFFER_SHEET_RESOLUTION_MUTATION_PAYLOAD_KEYS = [
   'dedupKey',
 ] as const satisfies readonly (keyof ArchitectMutationPayload)[];
@@ -210,13 +207,10 @@ function normalizeComputeWorldMutationPayload<
         STORE_OFFER_SHEET_MUTATION_PAYLOAD_KEYS
       ) as MutationPayloadInputByType[TMutationType];
 
+    // BZE-191: match/decline are now atomic resolutions sharing the finalize
+    // resolution payload shape (offer-sheet identity + optional dedupKey).
     case 'matchOfferSheet':
     case 'declineOfferSheet':
-      return pickMutationPayloadFields(
-        publicPayload,
-        OFFER_SHEET_MIRROR_MUTATION_PAYLOAD_KEYS
-      ) as MutationPayloadInputByType[TMutationType];
-
     case 'finalizeMatchedOfferSheet':
     case 'finalizeDeclinedOfferSheet':
       return pickMutationPayloadFields(
@@ -330,19 +324,11 @@ export function normalizeComputeWorldMutationArgs(
         ),
       };
 
+    // BZE-191: match/decline now perform the full atomic resolution outcome and
+    // therefore need the resolution current-state shape (both teams' players /
+    // rosters), identical to the legacy two-step finalize path.
     case 'matchOfferSheet':
     case 'declineOfferSheet':
-      return {
-        ...args,
-        payload: normalizeComputeWorldMutationPayload(
-          args.mutationType,
-          args.payload
-        ),
-        currentState: normalizeOfferSheetMirrorMutationCurrentState(
-          args.currentState
-        ),
-      };
-
     case 'finalizeMatchedOfferSheet':
     case 'finalizeDeclinedOfferSheet':
       return {

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -230,6 +230,131 @@ export async function resolveStoreOfferSheetAuthority({
   };
 }
 
+function findRawOfferSheetById(
+  offerSheets: unknown,
+  offerSheetId: string
+): Record<string, unknown> | null {
+  if (!Array.isArray(offerSheets)) {
+    return null;
+  }
+  return (
+    (offerSheets as Array<Record<string, unknown>>).find(
+      (sheet) =>
+        Boolean(sheet) &&
+        (String(sheet.id || '') === offerSheetId ||
+          String(sheet.dedupKey || '') === offerSheetId)
+    ) || null
+  );
+}
+
+function rawTeamPlayerId(player: Record<string, unknown>): string {
+  const bio =
+    player.bio && typeof player.bio === 'object'
+      ? (player.bio as Record<string, unknown>)
+      : {};
+  return String(
+    player.id || player.player_id || player.playerId || bio.playerId || ''
+  ).trim();
+}
+
+function rawRosterEntryId(entry: unknown): string {
+  if (typeof entry === 'string') {
+    return entry.trim();
+  }
+  if (entry && typeof entry === 'object') {
+    const record = entry as Record<string, unknown>;
+    return String(record.playerId || record.player_id || record.id || '').trim();
+  }
+  return '';
+}
+
+/**
+ * BZE-191: one-click match/decline atomically MOVE the offer-sheet player, so
+ * the shared resolution outcome needs the player's record on the home-team
+ * snapshot. RFA targets are frequently free agents whose rights the home team
+ * holds only through an unsigned cap hold (storeOfferSheet resolves ownership
+ * "without rostering the player"), so the player is absent from home.players.
+ * Materialize the player from authoritative truth and inject it onto the home
+ * snapshot — mirroring the cap-hold rights resolution storeOfferSheet already
+ * uses — without altering the proven outcome/guard logic. When the player is
+ * already present this is a no-op, so the legacy finalize paths are unchanged.
+ */
+async function ensureOfferSheetPlayerOnHomeTeamSnapshot({
+  worldId,
+  homeTeam,
+  offeringTeam,
+  homeTeamCode,
+  offerSheetId,
+  payloadPlayerId,
+}: {
+  worldId: string;
+  homeTeam: MutationCurrentStateOfferSheetTeamIngress | null;
+  offeringTeam: MutationCurrentStateOfferSheetTeamIngress | null;
+  homeTeamCode: string;
+  offerSheetId: string;
+  payloadPlayerId: string | null | undefined;
+}): Promise<MutationCurrentStateOfferSheetTeamIngress | null> {
+  if (!homeTeam) {
+    return homeTeam;
+  }
+
+  const offerSheet =
+    findRawOfferSheetById(homeTeam.incomingOfferSheets, offerSheetId) ||
+    findRawOfferSheetById(offeringTeam?.offerSheets, offerSheetId);
+  const playerId = String(
+    payloadPlayerId || offerSheet?.playerId || ''
+  ).trim();
+  if (!playerId) {
+    return homeTeam;
+  }
+
+  const existingPlayers = Array.isArray(homeTeam.players)
+    ? homeTeam.players
+    : [];
+  if (
+    existingPlayers.some(
+      (player) =>
+        Boolean(player) &&
+        typeof player === 'object' &&
+        rawTeamPlayerId(player as Record<string, unknown>) === playerId
+    )
+  ) {
+    return homeTeam;
+  }
+
+  let resolvedPlayer: Record<string, unknown> | null = null;
+  try {
+    resolvedPlayer = (await getPlayer(
+      worldId,
+      homeTeamCode,
+      playerId
+    )) as Record<string, unknown>;
+  } catch {
+    // Fall through with the home team unchanged; the outcome's fail-closed
+    // "player not found" guard then reports the real missing-truth error.
+    return homeTeam;
+  }
+  if (!resolvedPlayer) {
+    return homeTeam;
+  }
+
+  const injectedPlayer = {
+    ...resolvedPlayer,
+    teamCode: homeTeamCode,
+    teamName: homeTeam.teamName || resolvedPlayer.teamName || null,
+  };
+  const existingRoster = Array.isArray(homeTeam.roster) ? homeTeam.roster : [];
+  const rosterHasPlayer = existingRoster.some(
+    (entry) => rawRosterEntryId(entry) === playerId
+  );
+
+  return {
+    ...homeTeam,
+    players: [...existingPlayers, injectedPlayer],
+    roster: rosterHasPlayer ? existingRoster : [...existingRoster, playerId],
+  };
+}
+
 
 // ==============================================================================
 // MAIN ENTRY POINT
@@ -405,37 +530,37 @@ export async function loadStateForMutation(
       if (!offeringTeamCode) throw new Error(`Missing offeringTeamCode`);
       if (!offerSheetId) throw new Error(`Missing offerSheetId`);
 
-      const [homeTeam, offeringTeam] = await Promise.all([
+      const [homeTeamRaw, offeringTeamRaw] = await Promise.all([
         getTeam(worldId, homeTeamCode),
         getTeam(worldId, offeringTeamCode),
       ]);
-      const isOfferSheetMirrorMutation =
-        mutationType === 'matchOfferSheet' ||
-        mutationType === 'declineOfferSheet';
+
+      // BZE-191: match/decline are now atomic resolutions that move the player,
+      // so they require the full resolution team snapshot (players + rosters),
+      // identical to the legacy two-step finalize path. RFA targets are often
+      // free agents whose rights the home team holds only via an unsigned cap
+      // hold, so the player may be absent from the home snapshot — materialize
+      // and inject it before normalizing the resolution state.
+      const homeTeam = await ensureOfferSheetPlayerOnHomeTeamSnapshot({
+        worldId,
+        homeTeam:
+          (homeTeamRaw as MutationCurrentStateOfferSheetTeamIngress | null) ||
+          null,
+        offeringTeam:
+          (offeringTeamRaw as MutationCurrentStateOfferSheetTeamIngress | null) ||
+          null,
+        homeTeamCode,
+        offerSheetId,
+        payloadPlayerId: payload.playerId as string | null | undefined,
+      });
 
       return {
-        homeTeam: isOfferSheetMirrorMutation
-          ? toCurrentStateTeam(
-              (homeTeam as MutationCurrentStateOfferSheetTeamIngress | null) ||
-                null,
-              'offerSheetMirror'
-            )
-          : toCurrentStateTeam(
-              (homeTeam as MutationCurrentStateOfferSheetTeamIngress | null) ||
-                null,
-              'offerSheetResolution'
-            ),
-        offeringTeam: isOfferSheetMirrorMutation
-          ? toCurrentStateTeam(
-              (offeringTeam as MutationCurrentStateOfferSheetTeamIngress | null) ||
-                null,
-              'offerSheetMirror'
-            )
-          : toCurrentStateTeam(
-              (offeringTeam as MutationCurrentStateOfferSheetTeamIngress | null) ||
-                null,
-              'offerSheetResolution'
-            ),
+        homeTeam: toCurrentStateTeam(homeTeam, 'offerSheetResolution'),
+        offeringTeam: toCurrentStateTeam(
+          (offeringTeamRaw as MutationCurrentStateOfferSheetTeamIngress | null) ||
+            null,
+          'offerSheetResolution'
+        ),
         offerSheetId,
       };
     }

--- a/src/features/architect/utils/mutationPipeline.types.ingress.ts
+++ b/src/features/architect/utils/mutationPipeline.types.ingress.ts
@@ -325,8 +325,8 @@ export type PublicMutationCurrentStateInputByType = {
   optionDecision: MutationTeamAndPlayerCurrentStateInput;
   renounceRights: MutationTeamAndPlayerCurrentStateInput;
   storeOfferSheet: MutationOfferSheetTeamAndPlayerCurrentStateInput;
-  matchOfferSheet: MutationOfferSheetMirrorCurrentStateInput;
-  declineOfferSheet: MutationOfferSheetMirrorCurrentStateInput;
+  matchOfferSheet: MutationOfferSheetResolutionCurrentStateInput;
+  declineOfferSheet: MutationOfferSheetResolutionCurrentStateInput;
   finalizeMatchedOfferSheet: MutationOfferSheetResolutionCurrentStateInput;
   finalizeDeclinedOfferSheet: MutationOfferSheetResolutionCurrentStateInput;
   signAndTrade: MutationSignAndTradeCurrentStateInput;
@@ -341,8 +341,8 @@ export type PublicMutationPayloadInputByType = {
   optionDecision: PublicOptionMutationPayloadInput;
   renounceRights: PublicRenounceMutationPayloadInput;
   storeOfferSheet: PublicStoreOfferSheetMutationPayloadInput;
-  matchOfferSheet: PublicOfferSheetMirrorMutationPayloadInput;
-  declineOfferSheet: PublicOfferSheetMirrorMutationPayloadInput;
+  matchOfferSheet: PublicOfferSheetResolutionMutationPayloadInput;
+  declineOfferSheet: PublicOfferSheetResolutionMutationPayloadInput;
   finalizeMatchedOfferSheet: PublicOfferSheetResolutionMutationPayloadInput;
   finalizeDeclinedOfferSheet: PublicOfferSheetResolutionMutationPayloadInput;
   signAndTrade: PublicSignAndTradeMutationPayloadInput;
@@ -360,8 +360,8 @@ export type MutationCurrentStateInputByType = {
   optionDecision: MutationTeamAndPlayerCurrentState;
   renounceRights: MutationTeamAndPlayerCurrentState;
   storeOfferSheet: MutationOfferSheetTeamAndPlayerCurrentState;
-  matchOfferSheet: MutationOfferSheetMirrorCurrentState;
-  declineOfferSheet: MutationOfferSheetMirrorCurrentState;
+  matchOfferSheet: MutationOfferSheetResolutionCurrentState;
+  declineOfferSheet: MutationOfferSheetResolutionCurrentState;
   finalizeMatchedOfferSheet: MutationOfferSheetResolutionCurrentState;
   finalizeDeclinedOfferSheet: MutationOfferSheetResolutionCurrentState;
   signAndTrade: MutationSignAndTradeCurrentState;
@@ -376,8 +376,8 @@ export type MutationPayloadInputByType = {
   optionDecision: OptionMutationPayloadInput;
   renounceRights: RenounceMutationPayloadInput;
   storeOfferSheet: StoreOfferSheetMutationPayloadInput;
-  matchOfferSheet: OfferSheetMirrorMutationPayloadInput;
-  declineOfferSheet: OfferSheetMirrorMutationPayloadInput;
+  matchOfferSheet: OfferSheetResolutionMutationPayloadInput;
+  declineOfferSheet: OfferSheetResolutionMutationPayloadInput;
   finalizeMatchedOfferSheet: OfferSheetResolutionMutationPayloadInput;
   finalizeDeclinedOfferSheet: OfferSheetResolutionMutationPayloadInput;
   signAndTrade: SignAndTradeMutationPayloadInput;

--- a/src/tests/architect/OfferSheetList.freeAgency.test.tsx
+++ b/src/tests/architect/OfferSheetList.freeAgency.test.tsx
@@ -73,7 +73,7 @@ describe('OfferSheetList Free Agency wiring', () => {
     );
 
     fireEvent.click(
-      screen.getByRole('button', { name: /^Match \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Match$/i })
     );
     expect(onLifecycleAction).toHaveBeenCalledTimes(1);
     expect(onLifecycleAction).toHaveBeenCalledWith({
@@ -97,7 +97,7 @@ describe('OfferSheetList Free Agency wiring', () => {
     );
 
     fireEvent.click(
-      screen.getByRole('button', { name: /^Decline \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Decline$/i })
     );
     expect(onLifecycleAction).toHaveBeenCalledTimes(1);
     expect(onLifecycleAction).toHaveBeenCalledWith({
@@ -191,10 +191,10 @@ describe('OfferSheetList Free Agency wiring', () => {
       screen.getByText(/Requires an active world to commit\./i)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /^Match \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Match$/i })
     ).toBeDisabled();
     expect(
-      screen.getByRole('button', { name: /^Decline \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Decline$/i })
     ).toBeDisabled();
   });
 
@@ -290,16 +290,16 @@ describe('FreeAgencySection offer-sheet lifecycle routing', () => {
     );
 
     fireEvent.click(
-      screen.getByRole('button', { name: /^Match \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Match$/i })
     );
     fireEvent.click(
-      screen.getByRole('button', { name: /^Decline \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Decline$/i })
     );
     fireEvent.click(screen.getByRole('button', { name: /Finalize Match/i }));
     fireEvent.click(screen.getByRole('button', { name: /Finalize Signing/i }));
 
-    expect(matchOfferSheet).toHaveBeenCalledWith('NYK', 'os_match');
-    expect(declineOfferSheet).toHaveBeenCalledWith('NYK', 'os_match');
+    expect(matchOfferSheet).toHaveBeenCalledWith(incomingPendingOfferSheet);
+    expect(declineOfferSheet).toHaveBeenCalledWith(incomingPendingOfferSheet);
     expect(finalizeOfferSheet).toHaveBeenCalledTimes(2);
     expect(finalizeOfferSheet).toHaveBeenNthCalledWith(
       1,
@@ -373,11 +373,11 @@ describe('FreeAgencySection offer-sheet lifecycle routing', () => {
       ).length
     ).toBeGreaterThan(0);
     expect(
-      screen.getByRole('button', { name: /^Match \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Match$/i })
     ).toBeDisabled();
 
     fireEvent.click(
-      screen.getByRole('button', { name: /^Match \(Preview\)$/i })
+      screen.getByRole('button', { name: /^Match$/i })
     );
 
     expect(matchOfferSheet).not.toHaveBeenCalled();

--- a/src/tests/architect/freeAgency_closure.gate.test.ts
+++ b/src/tests/architect/freeAgency_closure.gate.test.ts
@@ -1311,11 +1311,11 @@ describe('Gate 6: authoritative hook path keeps world-only Free Agency routes fa
     expect(runOfferSheetResolutionActionRegion).toMatch(
       /activeTeamArrayKey:\s*'incomingOfferSheets'/
     );
+    // BZE-191: one-click match/decline resolves atomically and removes the
+    // sheet from both teams, so the committed home-team snapshot must show the
+    // sheet ABSENT (no intermediate MATCHED/DECLINED status flip).
     expect(runOfferSheetResolutionActionRegion).toMatch(
-      /presence:\s*'present'/
-    );
-    expect(runOfferSheetResolutionActionRegion).toMatch(
-      /status:\s*action\s*===\s*'match'\s*\?\s*'MATCHED'\s*:\s*'DECLINED'/
+      /presence:\s*'absent'/
     );
     expect(runOfferSheetResolutionActionRegion).toMatch(
       /executeWorldModeOfferSheetLifecycleMutation\s*\(\s*mutationType/

--- a/src/tests/architect/mutationPipeline.committedSnapshotRoundtrip.test.ts
+++ b/src/tests/architect/mutationPipeline.committedSnapshotRoundtrip.test.ts
@@ -328,7 +328,7 @@ describe('mutationPipeline committed snapshot round-trip boundary', () => {
       metadata: { scenario: 'fixture' },
       legacyPickBlob: { shouldDrop: true },
     };
-    const homeTeam = makeTeam('NYK', [], {
+    const homeTeam = makeTeam('NYK', [makePlayer('rfa_1', 'RFA One', 9_000_000, 'NYK')], {
       incomingOfferSheets: [offerSheet],
       draftPicks: [draftPick],
       totals: {
@@ -379,10 +379,17 @@ describe('mutationPipeline committed snapshot round-trip boundary', () => {
     )?.team;
     const roundTrippedPick = updatedHomeTeam?.draftPicks?.[0];
 
-    expect(updatedHomeTeam?.incomingOfferSheets?.[0]?.status).toBe('MATCHED');
+    // BZE-191: one-click match resolves atomically — the sheet is removed and
+    // the home team keeps the player. The round-trip point (committed totals,
+    // draft-pick, and source slices carry through while ingress blobs are
+    // stripped) is verified on the surviving matched home team.
+    expect(updatedHomeTeam?.incomingOfferSheets ?? []).toHaveLength(0);
+    expect(
+      updatedHomeTeam?.players?.some(
+        (teamPlayer: { id?: string | null }) => teamPlayer?.id === 'rfa_1'
+      )
+    ).toBe(true);
     expect(updatedHomeTeam?.totals).toMatchObject({
-      yearKey: 2026,
-      rosterCount: 12,
       _meta: {
         source: 'computeTeamCapTotals',
         seasonKey: SEASON_ID,

--- a/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
+++ b/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
@@ -333,23 +333,32 @@ describe('mutationPipeline current-state ingress hardening', () => {
 
     expect(result.success).toBe(true);
 
-    const updatedOfferingSheet = result.changedTeams?.find(
+    const updatedOfferingTeam = result.changedTeams?.find(
       (update) => update.teamCode === 'BOS'
-    )?.team?.offerSheets?.[0];
-    const updatedHomeSheet = result.changedTeams?.find(
+    )?.team;
+    const updatedHomeTeam = result.changedTeams?.find(
       (update) => update.teamCode === 'NYK'
-    )?.team?.incomingOfferSheets?.[0];
+    )?.team;
 
-    expect(updatedOfferingSheet?.status).toBe('MATCHED');
-    expect(updatedHomeSheet?.status).toBe('MATCHED');
-    expect(updatedOfferingSheet).not.toHaveProperty('compatBag');
-    expect(updatedHomeSheet).not.toHaveProperty('compatBag');
-    expect(updatedOfferingSheet?.salariesByYear?.[0]).not.toHaveProperty(
-      'compatRow'
+    // BZE-191: one-click match resolves atomically — the offer sheet is removed
+    // from BOTH teams and the home team keeps the player on the matched contract.
+    // There is no surviving MATCHED-status sheet to inspect, so the ingress
+    // compatibility-bag stripping point is now verified on the surviving
+    // surfaces: the home player's matched contract and the team objects.
+    expect(updatedHomeTeam?.incomingOfferSheets ?? []).toHaveLength(0);
+    expect(updatedOfferingTeam?.offerSheets ?? []).toHaveLength(0);
+
+    const matchedPlayer = updatedHomeTeam?.players?.find(
+      (teamPlayer: { id?: string | null }) => teamPlayer?.id === 'rfa_1'
     );
-    expect(updatedHomeSheet?.salariesByYear?.[0]).not.toHaveProperty(
-      'compatRow'
-    );
+    expect(matchedPlayer).toBeDefined();
+    expect(matchedPlayer?.teamCode).toBe('NYK');
+    const matchedContract = matchedPlayer?.contract;
+    expect(matchedContract).toBeDefined();
+    expect(matchedContract).not.toHaveProperty('compatBag');
+    expect(matchedContract?.salariesByYear?.[0]).not.toHaveProperty('compatRow');
+    expect(updatedHomeTeam).not.toHaveProperty('compatBag');
+    expect(updatedOfferingTeam).not.toHaveProperty('compatBag');
   });
 
   it('preserves the consumed top-level bird-rights compatibility field on the option-decline player path', async () => {

--- a/src/tests/architect/mutationPipeline.sharedTeamNormalizerClosure.test.ts
+++ b/src/tests/architect/mutationPipeline.sharedTeamNormalizerClosure.test.ts
@@ -379,8 +379,13 @@ describe('mutationPipeline shared team normalizer closure', () => {
       (update) => update.teamCode === 'BOS'
     )?.team;
 
-    expect(updatedHomeTeam?.incomingOfferSheets?.[0]?.status).toBe('MATCHED');
-    expect(updatedOfferingTeam?.offerSheets?.[0]?.status).toBe('MATCHED');
+    // BZE-191: one-click match resolves atomically — the sheet is removed from
+    // BOTH teams and the home team keeps the player. There is no surviving
+    // MATCHED-status mirror; the lane's real point (roster + exception +
+    // sidecar preservation, mirror-blob stripping) is verified on the surviving
+    // home team that retained the matched player.
+    expect(updatedHomeTeam?.incomingOfferSheets ?? []).toHaveLength(0);
+    expect(updatedOfferingTeam?.offerSheets ?? []).toHaveLength(0);
     expect(updatedHomeTeam?.roster).toEqual(['rfa_match']);
     expect(updatedHomeTeam?.exceptions).toMatchObject({
       room: {

--- a/src/tests/architect/offerSheets_closure.gate.test.ts
+++ b/src/tests/architect/offerSheets_closure.gate.test.ts
@@ -50,6 +50,11 @@ const MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH = path.resolve(
   __dirname,
   '../../features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts'
 );
+// BZE-191: shared matched/declined OUTCOME logic (player move) extracted here.
+const MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_OUTCOME_PATH = path.resolve(
+  __dirname,
+  '../../features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts'
+);
 const MUTATION_PIPELINE_COMPUTE_PATH = path.resolve(
   __dirname,
   '../../features/architect/utils/mutationPipeline.compute.ts'
@@ -301,7 +306,8 @@ describe('Gate 4: Store mirrors to offering + home team arrays (E1)', () => {
     readFileContent(MUTATION_PIPELINE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_PATH) +
-    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH);
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH) +
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_OUTCOME_PATH);
 
   it('defines computeStoreOfferSheetResult function', () => {
     const hasFunctionDef = /function\s+computeStoreOfferSheetResult/.test(
@@ -397,49 +403,49 @@ describe('Gate 4B: Store ownership resolves from strict home-team authority (E5)
 
 // === GATE 5: Match/Decline Enforce Status + Mirror Update ===
 
-describe('Gate 5: Match/Decline enforce status + mirror update (E1)', () => {
+describe('Gate 5: Match/Decline resolve atomically via shared outcome (E1)', () => {
+  // BZE-191: one-click match/decline now perform the FULL resolution outcome
+  // (player move) in a single mutation, reusing the shared outcome module — they
+  // no longer flip an intermediate MATCHED/DECLINED status.
   const content =
     readFileContent(MUTATION_PIPELINE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_PATH) +
-    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH);
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH) +
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_OUTCOME_PATH);
 
-  it('computeMatchOfferSheetResult checks for PENDING_MATCH status', () => {
-    const checksStatus =
-      /computeMatchOfferSheetResult[\s\S]{0,1500}status\s*!==\s*['"]PENDING_MATCH['"]/.test(
+  it('computeMatchOfferSheetResult delegates to the shared matched outcome', () => {
+    const delegates =
+      /computeMatchOfferSheetResult[\s\S]{0,600}computeMatchedOfferSheetOutcome/.test(
         content
       );
-    expect(checksStatus).toBe(true);
+    expect(delegates).toBe(true);
   });
 
-  it('computeMatchOfferSheetResult sets status to MATCHED', () => {
-    const setsMatched =
-      /computeMatchOfferSheetResult[\s\S]{0,2000}status\s*:\s*['"]MATCHED['"]/.test(
+  it('computeDeclineOfferSheetResult delegates to the shared declined outcome', () => {
+    const delegates =
+      /computeDeclineOfferSheetResult[\s\S]{0,600}computeDeclinedOfferSheetOutcome/.test(
         content
       );
-    expect(setsMatched).toBe(true);
+    expect(delegates).toBe(true);
   });
 
-  it('computeDeclineOfferSheetResult checks for PENDING_MATCH status', () => {
-    const checksStatus =
-      /computeDeclineOfferSheetResult[\s\S]{0,1500}status\s*!==\s*['"]PENDING_MATCH['"]/.test(
+  it('one-click match/decline accept a PENDING_MATCH sheet directly', () => {
+    const acceptsPending =
+      /compute(Match|Decline)OfferSheetResult[\s\S]{0,600}acceptedStatuses:\s*\[\s*'PENDING_MATCH'\s*\]/.test(
         content
       );
-    expect(checksStatus).toBe(true);
+    expect(acceptsPending).toBe(true);
   });
 
-  it('computeDeclineOfferSheetResult sets status to DECLINED', () => {
-    const setsDeclined =
-      /computeDeclineOfferSheetResult[\s\S]{0,2000}status\s*:\s*['"]DECLINED['"]/.test(
-        content
-      );
-    expect(setsDeclined).toBe(true);
+  it('the shared outcome enforces the accepted prior status', () => {
+    const enforcesStatus = /acceptedStatuses\.includes\(/.test(content);
+    expect(enforcesStatus).toBe(true);
   });
 
-  it('match/decline mirror update to home team incomingOfferSheets', () => {
-    // Both match and decline update home team's incomingOfferSheets
+  it('match/decline outcomes mirror against home team incomingOfferSheets', () => {
     const mirrorsUpdate =
-      /compute(Match|Decline)OfferSheetResult[\s\S]{0,3000}updatedHomeTeam\.incomingOfferSheets/.test(
+      /compute(Matched|Declined)OfferSheetOutcome[\s\S]{0,4000}incomingOfferSheets/.test(
         content
       );
     expect(mirrorsUpdate).toBe(true);
@@ -453,7 +459,8 @@ describe('Gate 6: Finalize matched recomputes home totals (E1)', () => {
     readFileContent(MUTATION_PIPELINE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_PATH) +
-    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH);
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH) +
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_OUTCOME_PATH);
 
   it('computeFinalizeMatchedOfferSheetResult is defined', () => {
     const hasFunctionDef =
@@ -463,7 +470,7 @@ describe('Gate 6: Finalize matched recomputes home totals (E1)', () => {
 
   it('removes offer sheet from home team incomingOfferSheets', () => {
     const removesFromHome =
-      /computeFinalizeMatchedOfferSheetResult[\s\S]{0,2500}updatedHomeTeam\.incomingOfferSheets\s*=[\s\S]{0,200}removeOfferSheetEntries/.test(
+      /computeMatchedOfferSheetOutcome[\s\S]{0,2500}updatedHomeTeam\.incomingOfferSheets\s*=[\s\S]{0,200}removeOfferSheetEntries/.test(
         content
       );
     expect(removesFromHome).toBe(true);
@@ -471,7 +478,7 @@ describe('Gate 6: Finalize matched recomputes home totals (E1)', () => {
 
   it('normalizes the matched contract before applying it', () => {
     const normalizesContract =
-      /computeFinalizeMatchedOfferSheetResult[\s\S]{0,3500}buildNormalizedOfferSheetFinalContract/.test(
+      /computeMatchedOfferSheetOutcome[\s\S]{0,3500}buildNormalizedOfferSheetFinalContract/.test(
         content
       );
     expect(normalizesContract).toBe(true);
@@ -479,7 +486,7 @@ describe('Gate 6: Finalize matched recomputes home totals (E1)', () => {
 
   it('recomputes home team totals through the canonical totals bridge', () => {
     const recomputesTotals =
-      /computeFinalizeMatchedOfferSheetResult[\s\S]{0,4500}updatedHomeTeam\.totals\s*=\s*(?:computeTeamCapTotals|synchronizeTeamTotalsSnapshot)/.test(
+      /computeMatchedOfferSheetOutcome[\s\S]{0,4500}updatedHomeTeam\.totals\s*=\s*(?:computeTeamCapTotals|synchronizeTeamTotalsSnapshot)/.test(
         content
       );
     expect(recomputesTotals).toBe(true);
@@ -487,7 +494,7 @@ describe('Gate 6: Finalize matched recomputes home totals (E1)', () => {
 
   it('cleans up offer sheet from offering team', () => {
     const cleansUpOffering =
-      /computeFinalizeMatchedOfferSheetResult[\s\S]{0,5500}updatedOfferingTeam\.offerSheets\s*=[\s\S]{0,200}removeOfferSheetEntries/.test(
+      /computeMatchedOfferSheetOutcome[\s\S]{0,5500}updatedOfferingTeam\.offerSheets\s*=[\s\S]{0,200}removeOfferSheetEntries/.test(
         content
       );
     expect(cleansUpOffering).toBe(true);
@@ -495,7 +502,7 @@ describe('Gate 6: Finalize matched recomputes home totals (E1)', () => {
 
   it('builds canonical replace manifest with no delete path', () => {
     const usesReplaceManifest =
-      /computeFinalizeMatchedOfferSheetResult[\s\S]{0,6500}buildCanonicalPlayerPersistenceManifest[\s\S]{0,400}mode:\s*['"]replace['"]/.test(
+      /computeMatchedOfferSheetOutcome[\s\S]{0,6500}buildCanonicalPlayerPersistenceManifest[\s\S]{0,400}mode:\s*['"]replace['"]/.test(
         content
       );
     expect(usesReplaceManifest).toBe(true);
@@ -509,7 +516,8 @@ describe('Gate 7: Finalize declined recomputes BOTH totals (E1)', () => {
     readFileContent(MUTATION_PIPELINE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_PATH) +
     readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_PATH) +
-    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH);
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_INITIAL_PATH) +
+    readFileContent(MUTATION_PIPELINE_COMPUTE_OFFER_SHEETS_OUTCOME_PATH);
 
   it('computeFinalizeDeclinedOfferSheetResult is defined', () => {
     const hasFunctionDef =
@@ -519,7 +527,7 @@ describe('Gate 7: Finalize declined recomputes BOTH totals (E1)', () => {
 
   it('adds player to offering team roster', () => {
     const addsToOffering =
-      /computeFinalizeDeclinedOfferSheetResult[\s\S]{0,5000}updatedOfferingTeam\.players\s*=/.test(
+      /computeDeclinedOfferSheetOutcome[\s\S]{0,5000}updatedOfferingTeam\.players\s*=/.test(
         content
       );
     expect(addsToOffering).toBe(true);
@@ -527,7 +535,7 @@ describe('Gate 7: Finalize declined recomputes BOTH totals (E1)', () => {
 
   it('recomputes offering team totals through the canonical totals bridge', () => {
     const recomputesOfferingTotals =
-      /computeFinalizeDeclinedOfferSheetResult[\s\S]{0,6000}updatedOfferingTeam\.totals\s*=\s*(?:computeTeamCapTotals|synchronizeTeamTotalsSnapshot)/.test(
+      /computeDeclinedOfferSheetOutcome[\s\S]{0,6000}updatedOfferingTeam\.totals\s*=\s*(?:computeTeamCapTotals|synchronizeTeamTotalsSnapshot)/.test(
         content
       );
     expect(recomputesOfferingTotals).toBe(true);
@@ -535,7 +543,7 @@ describe('Gate 7: Finalize declined recomputes BOTH totals (E1)', () => {
 
   it('removes player from home team roster', () => {
     const removesFromHome =
-      /computeFinalizeDeclinedOfferSheetResult[\s\S]{0,7000}updatedHomeTeam\.players\s*=[\s\S]{0,200}filter/.test(
+      /computeDeclinedOfferSheetOutcome[\s\S]{0,7000}updatedHomeTeam\.players\s*=[\s\S]{0,200}filter/.test(
         content
       );
     expect(removesFromHome).toBe(true);
@@ -543,7 +551,7 @@ describe('Gate 7: Finalize declined recomputes BOTH totals (E1)', () => {
 
   it('recomputes home team totals through the canonical totals bridge', () => {
     const recomputesHomeTotals =
-      /computeFinalizeDeclinedOfferSheetResult[\s\S]{0,8000}updatedHomeTeam\.totals\s*=\s*(?:computeTeamCapTotals|synchronizeTeamTotalsSnapshot)/.test(
+      /computeDeclinedOfferSheetOutcome[\s\S]{0,8000}updatedHomeTeam\.totals\s*=\s*(?:computeTeamCapTotals|synchronizeTeamTotalsSnapshot)/.test(
         content
       );
     expect(recomputesHomeTotals).toBe(true);
@@ -551,7 +559,7 @@ describe('Gate 7: Finalize declined recomputes BOTH totals (E1)', () => {
 
   it('derives destination player from canonical home snapshot plus normalized contract', () => {
     const derivesFromSourceSnapshot =
-      /computeFinalizeDeclinedOfferSheetResult[\s\S]{0,3000}const sourcePlayer = findPlayerInTeamPlayers\(homeTeam,\s*playerId\)[\s\S]{0,2200}buildNormalizedOfferSheetFinalContract[\s\S]{0,1600}const updatedPlayer = \{\s*\.\.\.sourcePlayer/.test(
+      /computeDeclinedOfferSheetOutcome[\s\S]{0,3000}const sourcePlayer = findPlayerInTeamPlayers\(homeTeam,\s*playerId\)[\s\S]{0,2200}buildNormalizedOfferSheetFinalContract[\s\S]{0,1600}const updatedPlayer = \{\s*\.\.\.sourcePlayer/.test(
         content
       );
     expect(derivesFromSourceSnapshot).toBe(true);
@@ -559,7 +567,7 @@ describe('Gate 7: Finalize declined recomputes BOTH totals (E1)', () => {
 
   it('builds canonical move manifest with explicit delete path', () => {
     const usesMoveManifest =
-      /computeFinalizeDeclinedOfferSheetResult[\s\S]{0,8500}buildCanonicalPlayerPersistenceManifest[\s\S]{0,500}mode:\s*['"]move['"]/.test(
+      /computeDeclinedOfferSheetOutcome[\s\S]{0,8500}buildCanonicalPlayerPersistenceManifest[\s\S]{0,500}mode:\s*['"]move['"]/.test(
         content
       );
     expect(usesMoveManifest).toBe(true);
@@ -785,10 +793,7 @@ describe('Gate 12: offer-sheet lifecycle routing stays role-aware (FA-6A/6B)', (
       /handleDeclineOfferSheet[\s\S]{0,600}runOfferSheetResolutionAction\s*\(\s*'decline'/
     );
     expect(content).toMatch(
-      /runOfferSheetResolutionAction[\s\S]{0,1600}activeTeamArrayKey:\s*'incomingOfferSheets'[\s\S]{0,800}presence:\s*'present'/
-    );
-    expect(content).toMatch(
-      /runOfferSheetResolutionAction[\s\S]{0,2200}status:\s*action\s*===\s*'match'\s*\?\s*'MATCHED'\s*:\s*'DECLINED'/
+      /runOfferSheetResolutionAction[\s\S]{0,1600}activeTeamArrayKey:\s*'incomingOfferSheets'[\s\S]{0,800}presence:\s*'absent'/
     );
     expect(content).toMatch(
       /executeWorldModeOfferSheetLifecycleMutation\s*\(\s*mutationType/
@@ -837,15 +842,12 @@ describe('Gate 13: offer-sheet lifecycle final-state sync stays explicit (FA-6C/
     expect(content).toMatch(/matchesCommittedOfferSheetLifecycleIdentity/);
   });
 
-  it('verifies present lifecycle truth against incomingOfferSheets for match and decline', () => {
+  it('verifies absent lifecycle truth against incomingOfferSheets for one-click match and decline', () => {
     expect(content).toMatch(
       /runOfferSheetResolutionAction[\s\S]{0,2200}activeTeamArrayKey:\s*'incomingOfferSheets'/
     );
     expect(content).toMatch(
-      /runOfferSheetResolutionAction[\s\S]{0,2200}presence:\s*'present'/
-    );
-    expect(content).toMatch(
-      /runOfferSheetResolutionAction[\s\S]{0,2200}status:\s*action\s*===\s*'match'\s*\?\s*'MATCHED'\s*:\s*'DECLINED'/
+      /runOfferSheetResolutionAction[\s\S]{0,2200}presence:\s*'absent'/
     );
   });
 

--- a/src/tests/architect/useArchitectActions.freeAgency.test.tsx
+++ b/src/tests/architect/useArchitectActions.freeAgency.test.tsx
@@ -673,7 +673,10 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     toastMocks.error.mockClear();
 
     act(() => {
-      result.current.actions.handleMatchOfferSheet('BOS', 'offer_1');
+      result.current.actions.handleMatchOfferSheet({
+        offeringTeamCode: 'BOS',
+        id: 'offer_1',
+      });
     });
 
     await waitFor(() => {
@@ -2069,9 +2072,13 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
   });
 
   it('syncs matched incoming offer-sheet truth from changedTeams after match', async () => {
-    const matchedTeam = buildIncomingOfferSheetLifecycleTeamFixture('MATCHED', {
-      id: 'offer_match_1',
-    });
+    // BZE-191: one-click match resolves atomically — the home team keeps the
+    // player and the pending sheet is removed from the committed snapshot.
+    const matchedTeam = {
+      ...baseTeamFixture,
+      offerSheets: [],
+      incomingOfferSheets: [],
+    };
     mutationMocks.applyWorldMutation.mockResolvedValue({
       success: true,
       changedTeams: [{ teamCode: 'LAL', team: matchedTeam }],
@@ -2091,13 +2098,15 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     });
 
     act(() => {
-      result.current.actions.handleMatchOfferSheet('BOS', 'offer_match_1');
+      result.current.actions.handleMatchOfferSheet({
+        offeringTeamCode: 'BOS',
+        id: 'offer_match_1',
+        playerId: 'player_1',
+      });
     });
 
     await waitFor(() => {
-      expect(
-        result.current.teamCapSheet?.incomingOfferSheets?.[0]?.status
-      ).toBe('MATCHED');
+      expect(result.current.teamCapSheet?.incomingOfferSheets).toEqual([]);
     });
 
     expect(
@@ -2129,12 +2138,13 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
   });
 
   it('syncs declined incoming offer-sheet truth from changedTeams after decline', async () => {
-    const declinedTeam = buildIncomingOfferSheetLifecycleTeamFixture(
-      'DECLINED',
-      {
-        id: 'offer_decline_1',
-      }
-    );
+    // BZE-191: one-click decline resolves atomically — the player + cap move to
+    // the offering team and the pending sheet is removed from the home snapshot.
+    const declinedTeam = {
+      ...baseTeamFixture,
+      offerSheets: [],
+      incomingOfferSheets: [],
+    };
     mutationMocks.applyWorldMutation.mockResolvedValue({
       success: true,
       changedTeams: [{ teamCode: 'LAL', team: declinedTeam }],
@@ -2152,13 +2162,15 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     });
 
     act(() => {
-      result.current.actions.handleDeclineOfferSheet('BOS', 'offer_decline_1');
+      result.current.actions.handleDeclineOfferSheet({
+        offeringTeamCode: 'BOS',
+        id: 'offer_decline_1',
+        playerId: 'player_1',
+      });
     });
 
     await waitFor(() => {
-      expect(
-        result.current.teamCapSheet?.incomingOfferSheets?.[0]?.status
-      ).toBe('DECLINED');
+      expect(result.current.teamCapSheet?.incomingOfferSheets).toEqual([]);
     });
 
     expect(
@@ -2422,9 +2434,13 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
   });
 
   it('reloads committed incoming lifecycle truth when changedTeams omits the active team after match', async () => {
-    const reloadedTeam = buildIncomingOfferSheetLifecycleTeamFixture('MATCHED', {
-      id: 'offer_reload_match_1',
-    });
+    // BZE-191: one-click match removes the pending sheet from the committed
+    // home snapshot (atomic resolution).
+    const reloadedTeam = {
+      ...baseTeamFixture,
+      offerSheets: [],
+      incomingOfferSheets: [],
+    };
     mutationMocks.applyWorldMutation.mockResolvedValue({
       success: true,
       changedTeams: [{ teamCode: 'BOS', team: { teamCode: 'BOS' } }],
@@ -2451,10 +2467,11 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     });
 
     act(() => {
-      result.current.actions.handleMatchOfferSheet(
-        'BOS',
-        'offer_reload_match_1'
-      );
+      result.current.actions.handleMatchOfferSheet({
+        offeringTeamCode: 'BOS',
+        id: 'offer_reload_match_1',
+        playerId: 'player_1',
+      });
     });
 
     await waitFor(() => {
@@ -2557,10 +2574,10 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     const beforeTeamSnapshot = result.current.teamCapSheet;
 
     act(() => {
-      result.current.actions.handleMatchOfferSheet(
-        'BOS',
-        'offer_missing_snapshot_1'
-      );
+      result.current.actions.handleMatchOfferSheet({
+        offeringTeamCode: 'BOS',
+        id: 'offer_missing_snapshot_1',
+      });
     });
 
     await waitFor(() => {
@@ -2611,7 +2628,10 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     const beforeTeamSnapshot = result.current.teamCapSheet;
 
     act(() => {
-      result.current.actions.handleMatchOfferSheet('BOS', 'offer_match_verify_1');
+      result.current.actions.handleMatchOfferSheet({
+        offeringTeamCode: 'BOS',
+        id: 'offer_match_verify_1',
+      });
     });
 
     await waitFor(() => {
@@ -2691,7 +2711,10 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     const { result } = renderActionsHarness({ worldId: null });
 
     act(() => {
-      result.current.actions.handleMatchOfferSheet('BOS', 'offer_1');
+      result.current.actions.handleMatchOfferSheet({
+        offeringTeamCode: 'BOS',
+        id: 'offer_1',
+      });
     });
 
     await waitFor(() => {

--- a/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
+++ b/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
@@ -1011,7 +1011,7 @@ describe('mutationPipeline trade persistence truth', () => {
     ).toHaveLength(0);
   });
 
-  it('keeps E4 matched finalization compatible for offer sheets created under the strict store path', async () => {
+  it('keeps E4 matched resolution compatible for offer sheets created under the strict store path', async () => {
     const worldId = 'world_offer_sheet_store_to_match_finalize';
     seedWorldMetadata(
       worldId,
@@ -1082,6 +1082,10 @@ describe('mutationPipeline trade persistence truth', () => {
       getOfferSheets(requireTeamSnapshot(worldId, 'LAL'))[0]?.id || null;
     expect(offerSheetId).toBeTruthy();
 
+    // BZE-191: one-click match resolves the sheet atomically (no separate
+    // finalize step) — the home team keeps the player on the matched contract
+    // and the sheet is removed from both teams in a single mutation. Standalone
+    // finalize coverage lives in the directly-seeded finalize* tests below.
     const matchResult = await applyWorldMutation({
       userId: USER_ID,
       worldId,
@@ -1096,20 +1100,6 @@ describe('mutationPipeline trade persistence truth', () => {
     });
     expect(matchResult.success).toBe(true);
 
-    const finalizeResult = await applyWorldMutation({
-      userId: USER_ID,
-      worldId,
-      seasonId: SEASON_ID,
-      mutationType: 'finalizeMatchedOfferSheet',
-      timestamp: TIMESTAMP + 2,
-      payload: {
-        teamCode: 'BOS',
-        offeringTeamCode: 'LAL',
-        offerSheetId,
-      },
-    });
-    expect(finalizeResult.success).toBe(true);
-
     const persistedPlayer = await getPlayer(worldId, 'BOS', 'store_match_rfa');
     expect(persistedPlayer.teamCode).toBe('BOS');
     expect(persistedPlayer.contract?.signedUsing).toBe('Match');
@@ -1119,7 +1109,7 @@ describe('mutationPipeline trade persistence truth', () => {
     ).toHaveLength(0);
   });
 
-  it('keeps E4 declined finalization compatible for offer sheets created under the strict store path', async () => {
+  it('keeps E4 declined resolution compatible for offer sheets created under the strict store path', async () => {
     const worldId = 'world_offer_sheet_store_to_decline_finalize';
     seedWorldMetadata(
       worldId,
@@ -1204,6 +1194,10 @@ describe('mutationPipeline trade persistence truth', () => {
       'Expected stored offer sheet for declined finalization path'
     );
 
+    // BZE-191: one-click decline resolves the sheet atomically (no separate
+    // finalize step) — the player + cap move to the offering team and the sheet
+    // is removed from both teams in a single mutation. Standalone finalize
+    // coverage lives in the directly-seeded finalize* tests below.
     const declineResult = await applyWorldMutation({
       userId: USER_ID,
       worldId,
@@ -1217,22 +1211,6 @@ describe('mutationPipeline trade persistence truth', () => {
       },
     });
     expect(declineResult.success).toBe(true);
-
-    const finalizeResult = await applyWorldMutation({
-      userId: USER_ID,
-      worldId,
-      seasonId: SEASON_ID,
-      mutationType: 'finalizeDeclinedOfferSheet',
-      timestamp: TIMESTAMP + 2,
-      payload: {
-        teamCode: 'LAL',
-        homeTeamCode: 'BOS',
-        offeringTeamCode: 'LAL',
-        offerSheetId: storedOfferSheet.id,
-        dedupKey: storedOfferSheet.dedupKey,
-      },
-    });
-    expect(finalizeResult.success).toBe(true);
 
     const persistedPlayer = await getPlayer(
       worldId,

--- a/tests/e2e/architect-qa.spec.ts
+++ b/tests/e2e/architect-qa.spec.ts
@@ -2638,6 +2638,262 @@ test.describe('D-MQ: Architect Manual QA Checklist', () => {
     await captureEvidence(page, testInfo, 'D-MQ-005B-rfa-offer-sheet');
   });
 
+  test('D-MQ-005D: Home-team Decline resolves an incoming offer sheet — player + cap move to the offering team', async ({
+    page,
+  }, testInfo) => {
+    // This proof spans two dashboards (store on LAL, resolve on BOS) plus a
+    // reload-parity pass, so it needs more than the default per-test budget.
+    test.setTimeout(150_000);
+    // BZE-191 acceptance gate: an incoming offer sheet is resolved with a single
+    // one-click Decline on the HOME team dashboard. The player and cap must
+    // actually move to the offering team, the sheet must disappear from both
+    // teams, a declineOfferSheet world event must persist, and reload parity
+    // must hold. (Match keeps the player on the home team — covered by the unit
+    // suite; this proof exercises the higher-risk Decline movement.)
+    await ensureTeamDataLoaded(page, testInfo);
+    const worldId = await ensureWorldSelected(page, testInfo);
+
+    await topUpWorldTeamRosterMinimum(worldId, 'LAL', 'Los Angeles Lakers');
+    await topUpWorldTeamRosterMinimum(worldId, 'BOS', 'Boston Celtics');
+    await seedWorldOfferSheetHomeTeamRights(
+      worldId,
+      'BOS',
+      'Boston Celtics',
+      REVIEW_MODE_FREE_AGENT_ID
+    );
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await ensureTeamDataLoaded(page, testInfo);
+    await ensureSpecificWorldSelected(page, worldId, testInfo);
+
+    // --- Store a pending LAL → BOS offer sheet via the offering-team (LAL) UI,
+    // mirroring D-MQ-005B so the pending state has the exact committed shape the
+    // resolution flow must consume. ---
+    await openDashboardTab(page, 'Free Agency');
+
+    const reviewFreeAgentRow = page.locator('li').filter({
+      has: page.getByText(new RegExp(`^${REVIEW_MODE_FREE_AGENT_NAME}$`, 'i')),
+    });
+    await expect(reviewFreeAgentRow).toBeVisible({ timeout: 15000 });
+
+    const menuButton = reviewFreeAgentRow
+      .locator('button')
+      .filter({ hasText: '•••' })
+      .first();
+    await menuButton.scrollIntoViewIfNeeded();
+    await menuButton.click();
+    const signAction = page.getByRole('button', { name: /^Sign Free Agent$/i });
+    await expect(signAction).toBeVisible();
+    await signAction.click();
+
+    const modal = page.getByTestId('edit-contract-modal');
+    await expect(modal).toBeVisible({ timeout: 20000 });
+    const signFreeAgentRadio = modal.getByRole('radio', {
+      name: /Sign Free Agent/i,
+    });
+    await expect(signFreeAgentRadio).toBeVisible();
+    await signFreeAgentRadio.check();
+    const offerSheetCheckbox = modal.getByLabel(/^Offer Sheet$/i);
+    await expect(offerSheetCheckbox).toBeVisible();
+    await offerSheetCheckbox.check();
+
+    const confirmActionButton = modal.getByRole('button', {
+      name: /^Confirm Action$/i,
+    });
+    await expect(confirmActionButton).toBeEnabled({ timeout: 20000 });
+    await confirmActionButton.click();
+
+    await expect(modal).toHaveCount(0, { timeout: 20000 });
+    await expect(page.getByTestId('cockpit-last-receipt')).toContainText(
+      /Offer sheet stored/i,
+      { timeout: 20000 }
+    );
+
+    await expect
+      .poll(
+        async () => {
+          const [offeringTeam, homeTeam] = await Promise.all([
+            getWorldTeamDocument(worldId, 'LAL'),
+            getWorldTeamDocument(worldId, 'BOS'),
+          ]);
+          const outgoing = (offeringTeam?.offerSheets || []).find(
+            (sheet) =>
+              sheet.playerId === REVIEW_MODE_FREE_AGENT_ID &&
+              sheet.offeringTeamCode === 'LAL' &&
+              sheet.homeTeamCode === 'BOS'
+          );
+          const incoming = (homeTeam?.incomingOfferSheets || []).find(
+            (sheet) =>
+              sheet.playerId === REVIEW_MODE_FREE_AGENT_ID &&
+              sheet.offeringTeamCode === 'LAL' &&
+              sheet.homeTeamCode === 'BOS'
+          );
+          return {
+            outgoingStatus: outgoing?.status || null,
+            incomingStatus: incoming?.status || null,
+          };
+        },
+        {
+          timeout: 20000,
+          message:
+            'offer sheet should persist as mirrored PENDING_MATCH state before resolution',
+        }
+      )
+      .toEqual({
+        outgoingStatus: 'PENDING_MATCH',
+        incomingStatus: 'PENDING_MATCH',
+      });
+
+    // --- Switch to the HOME team (BOS) dashboard and Decline the incoming
+    // offer sheet with one click. ---
+    await page.goto(GM_DASHBOARD_BOS_URL, { waitUntil: 'domcontentloaded' });
+    await ensureTeamDataLoaded(page, testInfo);
+    await ensureSpecificWorldSelected(page, worldId, testInfo);
+    await openDashboardTab(page, 'Free Agency');
+
+    const incomingOfferSheetsSection = page
+      .locator('div')
+      .filter({
+        has: page.getByRole('heading', { name: /Incoming Offer Sheets/i }),
+      })
+      .first();
+    await expect(incomingOfferSheetsSection).toBeVisible({ timeout: 20000 });
+    await expect(
+      incomingOfferSheetsSection.getByText(REVIEW_MODE_FREE_AGENT_NAME).first()
+    ).toBeVisible();
+
+    const declineButton = incomingOfferSheetsSection.getByRole('button', {
+      name: /^Decline$/i,
+    });
+    await expect(declineButton).toBeEnabled({ timeout: 20000 });
+    await declineButton.click();
+
+    // --- Acceptance assertions: the player + cap moved to LAL, the sheet is
+    // gone from both teams, the world event persisted. ---
+    await expect
+      .poll(
+        async () => {
+          const [offeringTeam, homeTeam] = await Promise.all([
+            getWorldTeamDocument(worldId, 'LAL'),
+            getWorldTeamDocument(worldId, 'BOS'),
+          ]);
+          const offeringPlayer = getTeamPlayerRecords(
+            offeringTeam as Record<string, unknown> | undefined
+          ).find((player) => {
+            const bio =
+              player.bio && typeof player.bio === 'object'
+                ? (player.bio as Record<string, unknown>)
+                : {};
+            return (
+              player.playerId === REVIEW_MODE_FREE_AGENT_ID ||
+              player.player_id === REVIEW_MODE_FREE_AGENT_ID ||
+              player.id === REVIEW_MODE_FREE_AGENT_ID ||
+              bio.playerId === REVIEW_MODE_FREE_AGENT_ID
+            );
+          });
+          const offeringContract =
+            offeringPlayer && typeof offeringPlayer.contract === 'object'
+              ? (offeringPlayer.contract as Record<string, unknown>)
+              : null;
+          return {
+            offeringHasPlayer: Boolean(offeringPlayer),
+            offeringPlayerTeam: String(offeringPlayer?.teamCode || ''),
+            offeringSignedUsing: String(offeringContract?.signedUsing || ''),
+            offeringRosterHasPlayer: getTeamPlayerIds(
+              offeringTeam as Record<string, unknown> | undefined
+            ).includes(REVIEW_MODE_FREE_AGENT_ID),
+            offeringSheetCount: (offeringTeam?.offerSheets || []).filter(
+              (sheet) => sheet.playerId === REVIEW_MODE_FREE_AGENT_ID
+            ).length,
+            homeIncomingCount: (homeTeam?.incomingOfferSheets || []).filter(
+              (sheet) => sheet.playerId === REVIEW_MODE_FREE_AGENT_ID
+            ).length,
+            homeRosterHasPlayer: getTeamPlayerIds(
+              homeTeam as Record<string, unknown> | undefined
+            ).includes(REVIEW_MODE_FREE_AGENT_ID),
+          };
+        },
+        {
+          timeout: 25000,
+          message:
+            'declining the offer sheet should move the player + cap to LAL and clear the sheet from both teams',
+        }
+      )
+      .toEqual({
+        offeringHasPlayer: true,
+        offeringPlayerTeam: 'LAL',
+        offeringSignedUsing: 'Offer Sheet',
+        offeringRosterHasPlayer: true,
+        offeringSheetCount: 0,
+        homeIncomingCount: 0,
+        homeRosterHasPlayer: false,
+      });
+
+    await expect
+      .poll(
+        async () => {
+          const persistedEvents = await getWorldEventDocuments(worldId);
+          return persistedEvents.some((event) => {
+            const metadata =
+              event.metadata && typeof event.metadata === 'object'
+                ? (event.metadata as Record<string, unknown>)
+                : {};
+            return (
+              event.mutationType === 'declineOfferSheet' &&
+              metadata.playerId === REVIEW_MODE_FREE_AGENT_ID
+            );
+          });
+        },
+        {
+          timeout: 20000,
+          message: 'decline should persist one declineOfferSheet world event',
+        }
+      )
+      .toBe(true);
+
+    // --- Reload parity: the resolved state survives a fresh load. ---
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await ensureTeamDataLoaded(page, testInfo);
+    await ensureSpecificWorldSelected(page, worldId, testInfo);
+    await openDashboardTab(page, 'Free Agency');
+    await expect(
+      page.getByRole('heading', { name: /Incoming Offer Sheets/i })
+    ).toHaveCount(0, { timeout: 20000 });
+
+    const [reloadedOfferingTeam, reloadedHomeTeam] = await Promise.all([
+      getWorldTeamDocument(worldId, 'LAL'),
+      getWorldTeamDocument(worldId, 'BOS'),
+    ]);
+    expect(
+      getTeamPlayerIds(reloadedOfferingTeam as Record<string, unknown> | undefined)
+    ).toContain(REVIEW_MODE_FREE_AGENT_ID);
+    expect(
+      getTeamPlayerIds(reloadedHomeTeam as Record<string, unknown> | undefined)
+    ).not.toContain(REVIEW_MODE_FREE_AGENT_ID);
+    expect(
+      (reloadedOfferingTeam?.offerSheets || []).filter(
+        (sheet) => sheet.playerId === REVIEW_MODE_FREE_AGENT_ID
+      )
+    ).toHaveLength(0);
+
+    addAuditNote(
+      testInfo,
+      'This proves BZE-191 offer-sheet resolution in browser review mode: a pending LAL → BOS offer sheet is resolved with a single one-click Decline on the BOS (home) dashboard; the player and cap move to LAL with an Offer Sheet contract, the sheet disappears from both teams, a declineOfferSheet world event persists, and the resolved state survives reload.'
+    );
+    await captureEvidence(page, testInfo, 'D-MQ-005D-offer-sheet-decline');
+  });
+
+  // NOTE (BZE-191): a one-click *Match* browser proof was attempted (D-MQ-005E)
+  // but intentionally removed. In the review world (as-of 2026-07-01) an offer
+  // sheet stored "now" carries a wall-clock createdAt, so the 48-hour match
+  // window has already expired and the leagueInvariants guard *correctly* blocks
+  // the match ("48-hour match window expired"). That guard is pre-existing,
+  // correct legality — not a BZE-191 movement defect — and a green Match proof
+  // would only be reachable by manipulating the world clock (testing the window
+  // invariant, not the resolution). Match's player-keep movement is covered by
+  // the unit suite (sharedTeamNormalizerClosure / committedSnapshotRoundtrip /
+  // currentStateIngressHardening) and exercises the identical stateLoader RFA
+  // cap-hold injection that the Decline proof (D-MQ-005D) verifies live.
+
   test('D-MQ-005A: Canonical V1 saved-world own-FA Re-sign persists FCT, Roster, history, compare, and reload', async ({
     page,
   }, testInfo) => {


### PR DESCRIPTION
## Summary

One-click **Match** / **Decline** on the home team's "Incoming Offer Sheets" row now resolves an offer sheet atomically — Match keeps the player on the home team, Decline moves the player + cap to the offering team — by reusing the proven finalize OUTCOME logic (fail-closed status guards preserved).

## Live bug found & fixed by the browser proof

RFA targets are free agents whose rights the home team holds only via an unsigned cap hold, so the player was absent from the home snapshot the atomic move needs (*"Player … not found on home team roster"*). Fix: the resolution state-loader now materialises the offer-sheet player via `getPlayer` and injects it onto the home team when missing — mirroring the cap-hold rights resolution `storeOfferSheet` already uses; a no-op when the player is present, so the legacy finalize paths are unchanged.

## Changes

- Shared atomic resolution outcome reused by match/decline and the legacy finalize paths.
- State-loader RFA cap-hold player injection (the fix above).
- 5 stale unit tests reframed from the retired two-step status-flip to the one-click reality (sheet removed from both teams; player kept/moved).
- New e2e `D-MQ-005D` Decline proof (store on LAL → Decline on BOS): player + cap move to LAL, sheet cleared from both teams, `declineOfferSheet` event persisted, reload parity.

## Match note

A live Match proof (`D-MQ-005E`) was attempted but removed — in the review world (as-of 2026-07-01) a freshly-stored sheet's 48-hour match window has already expired, so the leagueInvariants guard *correctly* blocks the match. That's pre-existing, correct legality, not a movement defect (tracked separately in BZE-196). Match's player-keep movement is covered by the unit suite and exercises the identical state-loader injection the Decline proof verifies live.

## Verification

- tsc `--noEmit`: 0 errors
- Full node suite green except 3 pre-existing failures that also fail on `main`
- .tsx UI tests green
- ESLint gate: PASS (no change vs baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offer-sheet actions now use simpler **Match** and **Decline** labels in the dashboard.
  * Added one-click offer-sheet decline support in the home-team workflow.

* **Bug Fixes**
  * Offer-sheet resolution now completes in a single step, removing the sheet from both teams immediately.
  * Resolved offer-sheet actions now keep player, roster, and cap details in sync more reliably.
  * Improved visibility and gating for offer-sheet actions in supported states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->