### PR TITLE
BZE-210 Fix rosterBuilderHelpers default-year salary read (season rollover)

### DIFF
--- a/src/tests/roster/rosterBuilderHelpers.test.ts
+++ b/src/tests/roster/rosterBuilderHelpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getDefaultAddPlayerFilters } from '@/shared/utils/filtering';
+import { DEFAULT_SALARY_YEAR } from '@/constants/yearDefaults';
 import {
   createMissingRosterPlayer,
   filterRosterDrawerPlayers,
@@ -135,7 +136,7 @@ describe('Roster Builder Helpers', () => {
     const salary = findSalaryForYear({
       currentContractView: {
         salaryByYear: {
-          2025: 24_500_000,
+          [DEFAULT_SALARY_YEAR]: 24_500_000,
         },
       },
     });


### PR DESCRIPTION
Fixes BZE-210

## Cause
`findSalaryForYear` defaults its lookup year to `DEFAULT_SALARY_YEAR`, which is derived from `getCurrentSeasonYear()`. The NBA season rolls over July 1, so as of July 2026 the default year is **2026**. The test fixture hardcoded `2025` as the `salaryByYear` key, so the default-year lookup missed the fixture and the helper returned `null` — a date-brittle test, not a helper bug. Confirmed pre-existing (surfaced during the BZE-209 landing gate).

## Fix
Key the fixture on `DEFAULT_SALARY_YEAR` instead of a literal `2025`, so it stays season-relative and actually exercises the shared-default-year path the test name describes. Production `findSalaryForYear` is unchanged.

## Files changed
- `src/tests/roster/rosterBuilderHelpers.test.ts`

## Validation
- `npx vitest run -c vitest.node.config.js src/tests/roster/rosterBuilderHelpers.test.ts` → 5 passed
- `npm run test:roster` → 31 passed (3 files)
- `npm run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)