### PR TITLE
BZE-222 Free Agency selected-player pass + review revisions

### DIFF
--- a/src/features/architect/GMDashboard/GMDashboard.tsx
+++ b/src/features/architect/GMDashboard/GMDashboard.tsx
@@ -1368,6 +1368,8 @@ export const GMDashboard = () => {
     fa: {
       id: 'fa',
       title: 'Free Agency',
+      hideHeader: true,
+      bleed: true,
       content: <FreeAgencySection {...freeAgencySectionSurface} />,
     },
     offseason: {

--- a/src/features/architect/GMDashboard/components/OfferSheetList.tsx
+++ b/src/features/architect/GMDashboard/components/OfferSheetList.tsx
@@ -96,7 +96,7 @@ function getOfferSheetLifecycleSurfaceState(
       return {
         kind: 'info',
         text: 'Matched by Home Team',
-        className: 'text-xs text-blue-600 font-medium',
+        className: 'text-xs text-blue-300 font-medium',
       };
     case 'outgoing:PENDING_MATCH':
       return {
@@ -124,20 +124,22 @@ export const OfferSheetList = ({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow p-4 mb-6">
-      <h3 className="text-lg font-bold mb-4">{title}</h3>
+    <div className="rounded-md border border-white/10 bg-cockpit-slab px-3 py-2">
+      <h3 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-white/55">
+        {title}
+      </h3>
       {actionsDisabled && (
-        <p className="text-xs text-amber-700 mb-3">{actionsDisabledReason}</p>
+        <p className="mb-2 text-xs text-amber-400">{actionsDisabledReason}</p>
       )}
-      <table className="w-full text-left text-sm">
+      <table className="w-full text-left text-xs text-white/80">
         <thead>
-          <tr className="border-b">
-            <th className="py-2">Player</th>
-            <th className="py-2">{getOfferSheetCounterpartyLabel(surfaceRole)}</th>
-            <th className="py-2">Terms</th>
-            <th className="py-2">Status</th>
-            <th className="py-2">Date</th>
-            <th className="py-2 text-right">Actions</th>
+          <tr className="border-b border-white/10 text-[10px] uppercase tracking-wider text-white/40">
+            <th className="py-1 font-semibold">Player</th>
+            <th className="py-1 font-semibold">{getOfferSheetCounterpartyLabel(surfaceRole)}</th>
+            <th className="py-1 font-semibold">Terms</th>
+            <th className="py-1 font-semibold">Status</th>
+            <th className="py-1 font-semibold">Date</th>
+            <th className="py-1 text-right font-semibold">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -150,32 +152,32 @@ export const OfferSheetList = ({
             return (
               <tr
                 key={os.id}
-                className="border-b last:border-0 hover:bg-gray-50"
+                className="border-b border-white/5 last:border-0 hover:bg-white/[0.04]"
               >
-                <td className="py-3 font-medium">{os.playerName}</td>
-                <td className="py-3">
+                <td className="py-1.5 font-medium text-white">{os.playerName}</td>
+                <td className="py-1.5">
                   {getOfferSheetCounterpartyCode(os, surfaceRole)}
                 </td>
-                <td className="py-3">
+                <td className="py-1.5 tabular-nums">
                   {os.contractYears}y / {formatCurrency(os.totalValue)}
                 </td>
-                <td className="py-3">
+                <td className="py-1.5">
                   <span
-                    className={`px-2 py-1 rounded text-xs font-bold
-                    ${os.status === 'MATCHED' ? 'bg-blue-100 text-blue-800' : ''}
-                    ${os.status === 'DECLINED' ? 'bg-red-100 text-red-800' : ''}
-                    ${os.status === 'PENDING_MATCH' ? 'bg-yellow-100 text-yellow-800' : ''}
+                    className={`px-1.5 py-0.5 rounded text-[10px] font-bold
+                    ${os.status === 'MATCHED' ? 'bg-blue-500/20 text-blue-200' : ''}
+                    ${os.status === 'DECLINED' ? 'bg-red-500/20 text-red-200' : ''}
+                    ${os.status === 'PENDING_MATCH' ? 'bg-yellow-500/20 text-yellow-100' : ''}
                   `}
                   >
                     {os.status.replace('_', ' ')}
                   </span>
                 </td>
-                <td className="py-3 text-gray-500">
+                <td className="py-1.5 text-white/45">
                   {new Date(
                     os.createdAt as string | number | Date
                   ).toLocaleDateString()}
                 </td>
-                <td className="py-3 text-right space-x-2">
+                <td className="py-1.5 text-right space-x-2">
                   {lifecycleSurfaceState.kind === 'actions' &&
                     lifecycleSurfaceState.actions.map((action) => (
                       <button

--- a/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
+++ b/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
@@ -112,35 +112,46 @@ const FreeAgencySection = ({
     }
   };
 
+  const hasOfferSheets =
+    (incomingOfferSheets?.length ?? 0) > 0 ||
+    (outgoingOfferSheets?.length ?? 0) > 0;
+
   return (
-    <div>
+    <div className="flex h-full min-h-0 flex-col gap-2 px-4 py-3">
       {/*
         OFFER-SHEET SECTION CONTRACT: lifecycle actions are persist-only world
         mutations. This wrapper renders the published gating state and routes
         UI events into the lifecycle owner; it does not own those mutations.
       */}
-      {offerSheetSectionAvailability.actionsDisabled &&
+      {hasOfferSheets &&
+      offerSheetSectionAvailability.actionsDisabled &&
       offerSheetLifecycleDisabledReason ? (
-        <p className="text-xs text-amber-400 mb-2">
+        <p className="shrink-0 text-xs text-amber-400">
           {offerSheetLifecycleDisabledReason}
         </p>
       ) : null}
 
-      {/* Incoming Offers (Home Team View) */}
-      <OfferSheetList
-        {...incomingOfferSheetSurface}
-        onLifecycleAction={handleOfferSheetLifecycleAction}
-        actionsDisabled={offerSheetSectionAvailability.actionsDisabled}
-        actionsDisabledReason={offerSheetLifecycleDisabledReason}
-      />
+      {/* Offer-sheet surfaces stay pinned above the pool but never eat the
+          room: they cap at ~1/4 of the viewport and scroll internally. */}
+      {hasOfferSheets ? (
+        <div className="max-h-[180px] shrink-0 space-y-2 overflow-y-auto">
+          {/* Incoming Offers (Home Team View) */}
+          <OfferSheetList
+            {...incomingOfferSheetSurface}
+            onLifecycleAction={handleOfferSheetLifecycleAction}
+            actionsDisabled={offerSheetSectionAvailability.actionsDisabled}
+            actionsDisabledReason={offerSheetLifecycleDisabledReason}
+          />
 
-      {/* Outgoing Offers (Offering Team View) */}
-      <OfferSheetList
-        {...outgoingOfferSheetSurface}
-        onLifecycleAction={handleOfferSheetLifecycleAction}
-        actionsDisabled={offerSheetSectionAvailability.actionsDisabled}
-        actionsDisabledReason={offerSheetLifecycleDisabledReason}
-      />
+          {/* Outgoing Offers (Offering Team View) */}
+          <OfferSheetList
+            {...outgoingOfferSheetSurface}
+            onLifecycleAction={handleOfferSheetLifecycleAction}
+            actionsDisabled={offerSheetSectionAvailability.actionsDisabled}
+            actionsDisabledReason={offerSheetLifecycleDisabledReason}
+          />
+        </div>
+      ) : null}
 
       {/* FREE-AGENT POOL CONTRACT: the pool only receives the modal/rendering
           slice of the broader Free Agency action contract. Offer-sheet

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgencyFilterBar.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgencyFilterBar.tsx
@@ -42,7 +42,7 @@ export const FreeAgencyFilterBar = ({
     'w-[130px] border border-none focus:outline-none focus:ring-1 focus:ring-white/30 hover:bg-[#3a3a3a] text-xs rounded-md';
 
   return (
-    <div className="px-6 mb-2">
+    <div className="mb-2 shrink-0">
       <div className="bg-[#1a1a1a] border border-white/10 rounded-md p-2 flex flex-wrap items-center gap-2">
         <input
           type="text"

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentCard.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentCard.tsx
@@ -1,10 +1,16 @@
 /**
  * FILE: src/features/architect/freeAgency/FreeAgentPool/FreeAgentCard.tsx
  * PURPOSE: Authoritative selected-player card renderer for the Free Agent Pool surface.
+ *          Compact horizontal decision card: identity, prior salary, signing
+ *          context, and an always-visible Sign action sized for the selected
+ *          deck at the 1280×720 review viewport.
  * OWNERSHIP: Feature: architect/freeAgency
  *
  * HISTORY:
  *  - 2026-03-14: Migrated from JSX during TM_VALIDATOR_TS_FREE_AGENT_POOL_SURFACE_E86 execution.
+ *  - 2026-07-07: BZE-222 selected-player pass — vertical trading card reworked
+ *    into a horizontal deck card so every selected player keeps its Sign action
+ *    on screen at 720p.
  *
  * LINKS:
  *  - Return Package: return_packages/trade_machine/TM_VALIDATOR_TS_FREE_AGENT_POOL_SURFACE_E86_RETURN_PACKAGE.md
@@ -28,7 +34,6 @@ export const FreeAgentCard = ({
   onRemove,
 }: FreeAgentCardProps) => {
   const { surfacePlayer: player } = entry;
-  // Logic from FreeAgentRow to format name/headshot
   const formattedName =
     player.bio?.displayName || player.displayName || player.name || '';
   const nameParts = formattedName.split(' ');
@@ -36,53 +41,39 @@ export const FreeAgentCard = ({
   const lastName = nameParts.slice(1).join(' ') || '';
 
   const rawPosition = player.bio?.position || player.formattedPosition || '';
-  // Simple mapping if utils not available, or just render raw.
-  // Assuming getPlayerPositionLabel isn't strictly needed for the simplified card or we can key off raw.
-  // Let's try to match row style but keep it simple.
 
   const formatHeight = (inches: number | string | null | undefined) => {
     if (!inches || inches === 0) return null;
     const numericInches = Number(inches);
-    if (Number.isNaN(numericInches)) return null;
+    if (Number.isNaN(numericInches)) return inches;
     return `${Math.floor(numericInches / 12)}-${numericInches % 12}`;
   };
 
-  const height = formatHeight(player.bio?.height) || player.height || '—';
-  const weight = player.bio?.weight || player.weight || '—';
+  const height =
+    formatHeight(player.bio?.height) ||
+    player.height ||
+    entry.freeAgent.height ||
+    '—';
+  const weight =
+    player.bio?.weight || player.weight || entry.freeAgent.weight || '—';
 
   const prevSalaryValue = player.previousSalary || player.askingSalary;
   const prevSalary =
     prevSalaryValue != null ? `$${prevSalaryValue.toLocaleString()}` : 'N/A';
 
   const signingContext = getFreeAgentSigningContext(entry);
-  const rights = signingContext.rightsLabel;
 
   return (
-    <div className="w-[180px] bg-[#1a1a1a] rounded-lg border border-white/10 overflow-hidden flex flex-col relative group hover:border-white/30 transition-colors">
-      {/* Remove Button (top right) */}
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onRemove(entry.selectionKey);
-        }}
-        className="absolute top-1 right-1 z-10 w-6 h-6 rounded-full bg-black/50 hover:bg-red-500/80 text-white flex items-center justify-center text-xs opacity-0 group-hover:opacity-100 transition-opacity"
-      >
-        ✕
-      </button>
-
-      {/* Headshot Area */}
-      <div className="h-[140px] w-full bg-[#151515] relative flex items-end justify-center pt-2">
-        {/* Team Logo Background/Overlay */}
+    <div className="flex h-[104px] items-stretch overflow-hidden rounded-md border border-white/10 bg-cockpit-slab transition-colors hover:border-white/30">
+      {/* Headshot */}
+      <div className="relative w-[84px] shrink-0 bg-cockpit-inlay">
         {player.teamCode && (
-          <div className="absolute top-2 left-2 opacity-20 z-0">
-            <img
-              src={`/assets/logos/${getTeamLogoId(player.teamCode)}.png`}
-              className="h-8 w-8 object-contain"
-              alt=""
-            />
-          </div>
+          <img
+            src={`/assets/logos/${getTeamLogoId(player.teamCode)}.png`}
+            className="absolute left-1 top-1 z-0 h-5 w-5 object-contain opacity-30"
+            alt=""
+          />
         )}
-
         <img
           src={
             player.headshotUrl ||
@@ -97,68 +88,72 @@ export const FreeAgentCard = ({
             }.png`
           }
           onError={(e) => {
-            e.currentTarget.onerror = null; e.currentTarget.src = '/assets/headshots/default.png';
+            e.currentTarget.onerror = null;
+            e.currentTarget.src = '/assets/headshots/default.png';
           }}
           alt={formattedName}
-          className="h-full object-contain relative z-1"
+          className="relative z-1 h-full w-full object-cover"
         />
+      </div>
 
-        {/* Name Overlay */}
-        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/90 to-transparent p-2 pt-8">
-          <div className="font-anton font-bold uppercase text-white text-lg leading-none">
-            {firstName} <span className="text-white/70 block">{lastName}</span>
+      {/* Identity + signing context */}
+      <div className="flex min-w-0 flex-1 flex-col justify-between px-3 py-2">
+        <div className="min-w-0">
+          <div className="truncate font-anton font-bold uppercase leading-none text-white text-[17px]">
+            {firstName} <span className="font-light text-white/70">{lastName}</span>
           </div>
-          <div className="text-[10px] text-white/60 font-mono mt-1 flex justify-between">
-            <span>{rawPosition}</span>
-            <span>{rights !== 'None' ? rights : ''}</span>
+          <div className="mt-1 flex items-center gap-2 whitespace-nowrap font-mono text-[10px] text-white/50">
+            <span>{rawPosition || '—'}</span>
+            <span className="text-white/25">|</span>
+            <span>
+              {height} · {weight !== '—' ? `${weight} lbs` : '—'}
+            </span>
           </div>
+        </div>
+        <div
+          data-testid="free-agent-card-signing-context"
+          className="flex flex-wrap items-center gap-1.5 text-[10px] leading-tight"
+        >
+          <span className="rounded-sm border border-white/10 bg-black/25 px-1.5 py-0.5 text-white/75">
+            {signingContext.rightsLabel}
+          </span>
+          <span className="rounded-sm border border-cyan-300/15 bg-cyan-400/[0.07] px-1.5 py-0.5 text-cyan-100/85">
+            {signingContext.laneLabel}
+          </span>
+          {signingContext.capHoldLabel && (
+            <span className="rounded-sm border border-amber-300/15 bg-amber-400/[0.06] px-1.5 py-0.5 text-amber-100/85">
+              {signingContext.capHoldLabel}
+            </span>
+          )}
         </div>
       </div>
 
-      {/* Info Body */}
-      <div className="p-3 bg-[#1a1a1a] flex-1 flex flex-col gap-2">
-        <div className="flex justify-between items-center text-xs text-white/50 border-b border-white/5 pb-2">
-          <span>
-            {height} | {weight}lbs
-          </span>
-        </div>
-        <div className="text-center py-1">
-          <div className="text-[10px] uppercase text-white/40 font-semibold mb-0.5">
-            Previous Salary
-          </div>
-          <div className="text-sm font-mono text-white/90">{prevSalary}</div>
-        </div>
-
-        <div
-          data-testid="free-agent-card-signing-context"
-          className="rounded-md border border-white/10 bg-black/20 px-2 py-2 text-[10px] leading-tight text-white/60"
-        >
-          <div className="flex items-center justify-between gap-2">
-            <span className="uppercase tracking-wider text-white/35">Rights</span>
-            <span className="truncate text-white/85">{signingContext.rightsLabel}</span>
-          </div>
-          <div className="mt-1 flex items-center justify-between gap-2">
-            <span className="uppercase tracking-wider text-white/35">Lane</span>
-            <span className="truncate text-cyan-100/90">
-              {signingContext.laneLabel}
-            </span>
-          </div>
-          {signingContext.capHoldLabel && (
-            <div className="mt-1 flex items-center justify-between gap-2">
-              <span className="uppercase tracking-wider text-white/35">Cap</span>
-              <span className="truncate text-amber-100/90">
-                {signingContext.capHoldLabel}
-              </span>
+      {/* Prior salary + actions */}
+      <div className="flex w-[150px] shrink-0 flex-col items-end justify-between border-l border-white/5 bg-black/20 px-2.5 py-2">
+        <div className="flex w-full items-start justify-between gap-2">
+          <div className="min-w-0 text-left">
+            <div className="text-[9px] font-semibold uppercase tracking-wider text-white/40">
+              Previous Salary
             </div>
-          )}
+            <div className="font-mono text-xs text-white/90">{prevSalary}</div>
+          </div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(entry.selectionKey);
+            }}
+            title="Remove from selection"
+            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white/10 text-[10px] text-white/70 transition-colors hover:bg-red-500/80 hover:text-white"
+          >
+            ✕
+          </button>
         </div>
-
         <button
           data-action-exposure-classification="preview-only"
           onClick={() => onOpenContractModal(entry)}
-          className="w-full mt-auto bg-green-600 hover:bg-green-500 text-white text-xs font-bold uppercase tracking-wider py-2 rounded transition-colors"
+          className="w-full rounded bg-green-600 py-1.5 text-[11px] font-bold uppercase tracking-wider text-white transition-colors hover:bg-green-500"
         >
-          Sign Player (Preview)
+          Sign Player
         </button>
       </div>
     </div>

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentCard.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentCard.tsx
@@ -32,6 +32,7 @@ export const FreeAgentCard = ({
   entry,
   onOpenContractModal,
   onRemove,
+  isPreviewSigning = false,
 }: FreeAgentCardProps) => {
   const { surfacePlayer: player } = entry;
   const formattedName =
@@ -151,9 +152,14 @@ export const FreeAgentCard = ({
         <button
           data-action-exposure-classification="preview-only"
           onClick={() => onOpenContractModal(entry)}
-          className="w-full rounded bg-green-600 py-1.5 text-[11px] font-bold uppercase tracking-wider text-white transition-colors hover:bg-green-500"
+          className="w-full rounded bg-green-600 py-1.5 text-[11px] font-bold uppercase leading-none tracking-wider text-white transition-colors hover:bg-green-500"
         >
           Sign Player
+          {isPreviewSigning && (
+            <span className="mt-0.5 block text-[8px] font-semibold normal-case tracking-normal text-white/85">
+              (Preview)
+            </span>
+          )}
         </button>
       </div>
     </div>

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPool.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPool.tsx
@@ -471,19 +471,18 @@ export const FreeAgentPool = ({
   ]);
 
   return (
-    <div className="text-white">
-      <h2 className="text-xl font-semibold mb-2">Free Agent Pool</h2>
+    <div className="flex h-full min-h-0 flex-1 flex-col text-white">
       <section
         data-testid="free-agent-pool-management"
         aria-label="Free-agent pool management"
-        className="mb-3 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2"
+        className="mb-2 shrink-0 rounded-md border border-white/10 bg-white/[0.04] px-3 py-1.5"
       >
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="min-w-0">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-white/45">
-              Pool Builder
-            </div>
-            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-white/65">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-white">
+              Free Agent Pool
+            </h2>
+            <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-white/65">
               <span className="rounded border border-white/10 bg-black/20 px-1.5 py-0.5">
                 {selectedEntries.length} selected
               </span>
@@ -564,7 +563,7 @@ export const FreeAgentPool = ({
           </div>
         </div>
         {poolManagement?.disabledReason || poolManagementMessage ? (
-          <p className="mt-2 text-[11px] text-white/45">
+          <p className="mt-1 text-[11px] text-white/45">
             {poolManagementMessage || poolManagement?.disabledReason}
           </p>
         ) : null}
@@ -577,15 +576,15 @@ export const FreeAgentPool = ({
         totalCount={allAgents.length}
       />
 
-      <FreeAgentPoolHeader />
-
       <SelectedFreeAgentCards
         selectedEntries={selectedEntries}
         onOpenContractModal={openContractModal}
         onRemove={handleRemove}
       />
 
-      <ul className="space-y-[3px] mb-4 px-6">
+      <FreeAgentPoolHeader />
+
+      <ul className="min-h-0 flex-1 space-y-[3px] overflow-y-auto pb-2">
         {filteredEntries.length === 0 ? (
           <li className="text-center text-sm text-white/60 py-4">No matches</li>
         ) : (

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPool.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPool.tsx
@@ -456,6 +456,15 @@ export const FreeAgentPool = ({
         : undefined) as EditContractModalProps['onStoreOfferSheet'],
       actionsOverride: freeAgentModalAvailability.visibleActions,
       actionLabelsOverride: freeAgentModalAvailability.actionLabelsOverride,
+      // Free Agency signing context: keep the modal copy about signing a pool
+      // free agent to a new contract. Without this the modal infers the intro
+      // paragraph from the player's fixture contract and can show expiring /
+      // extend / waive language, which is wrong for a free-agent signing.
+      actionContextCopy:
+        'is a free agent. Set the salary and term below, then confirm to sign him to a new contract.',
+      actionDescriptionsOverride: {
+        signNew: 'Sign him to a new contract at the salary and term you set below.',
+      },
       showOfferSheetToggle:
         freeAgentModalAvailability.showOfferSheetToggle &&
         targetAllowsOfferSheet,
@@ -580,6 +589,7 @@ export const FreeAgentPool = ({
         selectedEntries={selectedEntries}
         onOpenContractModal={openContractModal}
         onRemove={handleRemove}
+        isPreviewSigning={/\(Preview\)/i.test(standardSigningActionLabel)}
       />
 
       <FreeAgentPoolHeader />

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPoolHeader.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPoolHeader.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 export const FreeAgentPoolHeader = () => (
-  <div className="px-6 mb-1">
+  <div className="mb-1 shrink-0">
     <div className="mr-2 flex h-5 items-center text-[11px] font-semibold text-cockpit-text-muted">
       <div className="w-[45px] text-center">POS</div>
       <div className="w-[50px] text-center ml-1">TEAM</div>

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
@@ -10,7 +10,7 @@
  *  - Return Package: return_packages/trade_machine/TM_VALIDATOR_TS_FREE_AGENT_POOL_SURFACE_E86_RETURN_PACKAGE.md
  *  - Master Doc: docs/architect/TRADE_MACHINE_MASTER.md
  */
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { getPlayerPositionLabel } from '@/shared/utils/roles';
 import { getPlayerProfileUrl } from '@/shared/utils/routing/playerRouteUtils';
 import { TeamCodeMap, type TeamCode } from '@/constants/teamList';
@@ -48,6 +48,9 @@ export const FreeAgentRow = ({
     : false;
   const menuRef = useRef<HTMLDivElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  // The pool list is a scroll container, so a downward menu on the last
+  // visible rows would clip. Flip upward when the space below is short.
+  const [menuOpensUp, setMenuOpensUp] = useState(false);
 
   useEffect(() => {
     if (openMenuSelectionKey === entry.selectionKey) {
@@ -239,6 +242,11 @@ export const FreeAgentRow = ({
           ref={buttonRef}
           onClick={(e) => {
             e.stopPropagation();
+            const buttonRect = e.currentTarget.getBoundingClientRect();
+            const scrollBoundary =
+              e.currentTarget.closest('ul')?.getBoundingClientRect().bottom ??
+              window.innerHeight;
+            setMenuOpensUp(scrollBoundary - buttonRect.bottom < 160);
             setOpenMenuSelectionKey(
               openMenuSelectionKey === entry.selectionKey
                 ? null
@@ -252,7 +260,7 @@ export const FreeAgentRow = ({
         {openMenuSelectionKey === entry.selectionKey && (
           <div
             ref={menuRef}
-            className="absolute right-0 top-5 bg-[#222] border border-white/20 rounded z-20 text-xs min-w-[8rem]"
+            className={`absolute right-0 ${menuOpensUp ? 'bottom-5' : 'top-5'} bg-[#222] border border-white/20 rounded z-20 text-xs min-w-[8rem]`}
           >
             <button
               data-action-exposure-classification={

--- a/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
@@ -13,12 +13,16 @@ interface SelectedFreeAgentCardsProps {
   selectedEntries: FreeAgentSurfaceEntry[];
   onOpenContractModal: (entry: FreeAgentSurfaceEntry) => void;
   onRemove: (selectionKey: string) => void;
+  // Mirrors the modal's world-aware signing label so the deck's Sign action
+  // carries the same "(Preview)" marker in sandbox and drops it in a saved world.
+  isPreviewSigning?: boolean;
 }
 
 export const SelectedFreeAgentCards = ({
   selectedEntries,
   onOpenContractModal,
   onRemove,
+  isPreviewSigning = false,
 }: SelectedFreeAgentCardsProps) => {
   if (selectedEntries.length === 0) return null;
 
@@ -34,6 +38,7 @@ export const SelectedFreeAgentCards = ({
             entry={entry}
             onOpenContractModal={onOpenContractModal}
             onRemove={onRemove}
+            isPreviewSigning={isPreviewSigning}
           />
         ))}
       </div>

--- a/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
@@ -1,6 +1,8 @@
 /**
  * FILE: src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
- * PURPOSE: Selected free-agent card strip rendered above the pool list.
+ * PURPOSE: Selected free-agent decision deck docked between the filters and the
+ *          pool list. Fixed-height region so the pool always stays on screen at
+ *          the 1280×720 review viewport; overflows internally beyond two rows.
  * OWNERSHIP: Feature: architect/freeAgency
  */
 import React from 'react';
@@ -21,15 +23,20 @@ export const SelectedFreeAgentCards = ({
   if (selectedEntries.length === 0) return null;
 
   return (
-    <div className="bg-[#1a1a1a] p-4 rounded border border-white/10 mb-3 flex flex-wrap gap-4">
-      {selectedEntries.map((entry) => (
-        <FreeAgentCard
-          key={entry.selectionKey}
-          entry={entry}
-          onOpenContractModal={onOpenContractModal}
-          onRemove={onRemove}
-        />
-      ))}
+    <div
+      data-testid="selected-free-agent-deck"
+      className="mb-2 max-h-[236px] shrink-0 overflow-y-auto rounded-md border border-cockpit-info/25 bg-white/[0.03] p-2"
+    >
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-2">
+        {selectedEntries.map((entry) => (
+          <FreeAgentCard
+            key={entry.selectionKey}
+            entry={entry}
+            onOpenContractModal={onOpenContractModal}
+            onRemove={onRemove}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/features/architect/freeAgency/FreeAgentPool/types.ts
+++ b/src/features/architect/freeAgency/FreeAgentPool/types.ts
@@ -124,4 +124,5 @@ export interface FreeAgentCardProps {
   entry: FreeAgentSurfaceEntry;
   onOpenContractModal: (entry: FreeAgentSurfaceEntry) => void;
   onRemove: (selectionKey: string) => void;
+  isPreviewSigning?: boolean;
 }

--- a/src/shared/components/EditContractModal.ActionSelector.tsx
+++ b/src/shared/components/EditContractModal.ActionSelector.tsx
@@ -25,6 +25,8 @@ type ContractActionSelectorProps = {
   selectedAction: SelectedContractAction;
   onSelectAction: (action: SelectedContractAction) => void;
   actionLabelsOverride: Partial<Record<string, string>>;
+  actionDescriptionsOverride?: Partial<Record<string, string>>;
+  actionContextCopy?: string | null;
   extensionEligibilityReason?: string | null;
 };
 
@@ -43,6 +45,8 @@ export const ContractActionSelector = ({
   selectedAction,
   onSelectAction,
   actionLabelsOverride,
+  actionDescriptionsOverride = {},
+  actionContextCopy = null,
   extensionEligibilityReason,
 }: ContractActionSelectorProps) => {
   const isPlayerControlledOption =
@@ -53,6 +57,13 @@ export const ContractActionSelector = ({
   return (
     <>
     <div className="mb-6 text-sm text-white/70 leading-relaxed">
+      {actionContextCopy ? (
+        <p>
+          <span className="text-white font-semibold">{playerName}</span>{' '}
+          {actionContextCopy}
+        </p>
+      ) : (
+        <>
       {hasOption && (
         <p>
           <span className="text-white font-semibold">{playerName}</span>{' '}
@@ -87,6 +98,8 @@ export const ContractActionSelector = ({
           under contract. You can extend his deal if eligible, or waive him to
           clear a roster spot (with potential dead cap implications).
         </p>
+      )}
+        </>
       )}
     </div>
 
@@ -141,7 +154,7 @@ export const ContractActionSelector = ({
                 {actionLabelsOverride[type] || ACTION_LABELS[type]}
               </div>
               <div className="text-xs text-white/50 mt-0.5">
-                {ACTION_DESCRIPTIONS[type]}
+                {actionDescriptionsOverride[type] || ACTION_DESCRIPTIONS[type]}
                 {extendBlocked && (
                   <span className="block text-red-300 mt-1">
                     {extensionEligibilityReason || 'Not extension eligible'}

--- a/src/shared/components/EditContractModal.SummaryPanel.tsx
+++ b/src/shared/components/EditContractModal.SummaryPanel.tsx
@@ -32,10 +32,11 @@ export const ContractSummaryPanel = ({
   currentYear,
   freeAgencyYears = [],
 }: ContractSummaryPanelProps) => (
-  // No internal scroll — the panel sizes to its content so every contract
-  // year stays visible.
-  <div className="w-full lg:w-[35%] bg-[#161616] border-r border-white/10 flex flex-col">
-    <div className="flex flex-1 flex-col px-8 pt-5 pb-6">
+  // The panel sizes to its content so every contract year stays visible;
+  // overflow-y is a safety net for short (720p) viewports where the modal
+  // itself is height-capped and would otherwise hard-clip the year list.
+  <div className="w-full lg:w-[35%] bg-[#161616] border-r border-white/10 flex min-h-0 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-8 pt-5 pb-6">
       <div className="text-center mb-4">
         <div className="text-2xl font-bold text-white tracking-tight">
           {formatCurrency(summary.totalValue)}{' '}

--- a/src/shared/components/EditContractModal.tsx
+++ b/src/shared/components/EditContractModal.tsx
@@ -111,6 +111,8 @@ export const EditContractModal = ({
   rulesLeagueContext = null,
   actionsOverride = null,
   actionLabelsOverride = {},
+  actionDescriptionsOverride = {},
+  actionContextCopy = null,
   showOfferSheetToggle = null,
   onAuditLog = null, // Callback to record override audit entries
 }: EditContractModalProps) => {
@@ -526,6 +528,23 @@ export const EditContractModal = ({
     !buyoutAmountIsValid ||
     isSubmitting;
 
+  // Plain-language "why is Confirm unavailable" line shown next to the button so
+  // the disabled state is never a mystery. Presentational only — mirrors the
+  // disableConfirm predicate above, it does not gate the action itself.
+  const confirmDisabledReason = isSubmitting
+    ? null
+    : !selectedAction
+      ? 'Select an action to continue'
+      : selectedAction === 'signAndTrade' && !resolvedDestinationTeamCode
+        ? 'Choose a destination team'
+        : !buyoutAmountIsValid
+          ? 'Enter a valid buyout amount'
+          : validationState.incomplete
+            ? 'Finish the contract details to continue'
+            : !validationState.isLegal && !isOverrideConfirmed
+              ? 'Resolve the blocking issues above to continue'
+              : null;
+
   const showOverrideOption =
     canOverride &&
     selectedAction &&
@@ -878,6 +897,8 @@ export const EditContractModal = ({
             selectedAction={selectedAction}
             onSelectAction={setSelectedAction}
             actionLabelsOverride={actionLabelsOverride}
+            actionDescriptionsOverride={actionDescriptionsOverride}
+            actionContextCopy={actionContextCopy}
             extensionEligibilityReason={playerRulesProfile?.extensionEligibility?.reason}
           />
 
@@ -1008,11 +1029,19 @@ export const EditContractModal = ({
           </div>
 
           {/* Footer Buttons */}
-          <div className="flex shrink-0 justify-end gap-3 px-8 py-4">
+          <div className="flex shrink-0 items-center gap-3 px-8 py-4">
+            {disableConfirm && confirmDisabledReason && (
+              <span
+                data-testid="edit-contract-confirm-disabled-reason"
+                className="mr-auto text-xs text-amber-300/80"
+              >
+                {confirmDisabledReason}
+              </span>
+            )}
             <button
               onClick={onClose}
               disabled={isSubmitting}
-              className="px-4 py-2 text-sm font-medium rounded bg-white/5 hover:bg-white/10 text-white transition-colors"
+              className="ml-auto px-4 py-2 text-sm font-medium rounded bg-white/5 hover:bg-white/10 text-white transition-colors"
             >
               Cancel
             </button>
@@ -1020,12 +1049,14 @@ export const EditContractModal = ({
               data-testid="edit-contract-confirm-action-button"
               onClick={handleConfirm}
               disabled={disableConfirm}
-              className={`px-6 py-2 text-sm font-bold rounded shadow-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed ${
-                validationState.isLegal
-                  ? 'bg-orange-600 hover:bg-orange-500 text-white shadow-orange-900/20'
+              aria-disabled={disableConfirm}
+              title={disableConfirm ? confirmDisabledReason ?? undefined : undefined}
+              className={`px-6 py-2 text-sm font-bold rounded shadow-lg transition-all ${
+                disableConfirm
+                  ? 'cursor-not-allowed bg-white/[0.06] text-white/35 shadow-none ring-1 ring-inset ring-white/10'
                   : isOverrideConfirmed
                     ? 'bg-red-600 hover:bg-red-500 text-white shadow-red-900/20'
-                    : 'bg-gray-600 text-white/50'
+                    : 'bg-orange-600 hover:bg-orange-500 text-white shadow-orange-900/20'
               }`}
             >
               {confirmButtonLabel}

--- a/src/shared/components/EditContractModal.tsx
+++ b/src/shared/components/EditContractModal.tsx
@@ -848,7 +848,10 @@ export const EditContractModal = ({
           />
 
           {/* === RIGHT PANEL: Actions === */}
-          <div className="w-full lg:w-[65%] p-8 bg-[#0f0f0f] flex flex-col overflow-y-auto">
+          {/* Footer stays pinned below the scrollable action content so
+              Cancel/Confirm never leave the viewport at short (720p) heights. */}
+          <div className="w-full lg:w-[65%] bg-[#0f0f0f] flex min-h-0 flex-col">
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-8 pb-2">
           <h2 className="text-xl font-bold text-white mb-4">
             Available Actions
           </h2>
@@ -1002,8 +1005,10 @@ export const EditContractModal = ({
             </div>
           )}
 
+          </div>
+
           {/* Footer Buttons */}
-          <div className="mt-auto pt-6 flex justify-end gap-3">
+          <div className="flex shrink-0 justify-end gap-3 px-8 py-4">
             <button
               onClick={onClose}
               disabled={isSubmitting}

--- a/src/shared/components/EditContractModal.types.ts
+++ b/src/shared/components/EditContractModal.types.ts
@@ -295,6 +295,11 @@ export type EditContractModalProps = {
   rulesLeagueContext?: RulesLeagueContextLike;
   actionsOverride?: string[] | null;
   actionLabelsOverride?: Partial<Record<ContractActionKey, string>>;
+  actionDescriptionsOverride?: Partial<Record<ContractActionKey, string>>;
+  // When provided, replaces the inferred contract-state intro paragraph with a
+  // caller-supplied predicate (rendered after the bold player name). Used by the
+  // Free Agency sign flow so pool free agents don't get expiring/extend/waive copy.
+  actionContextCopy?: string | null;
   showOfferSheetToggle?: boolean | null;
   onAuditLog?: AuditLogCallback | null;
   capProjections?: CapProjectionOverrides | null;


### PR DESCRIPTION
Fixes BZE-222

Presentation/copy pass on the Architect **Free Agency** room so every selected free agent stays on one screen at 1280×720 with a truthful, unambiguous sign flow. **No CBA / rules / engine logic changed** — this is UI layout, copy, and action-label truth only.

## Selected-player deck
- Selected free agents dock as a **fixed-height horizontal-card deck** between the filters and the pool list (was a 180px vertical trading card → now a 104px horizontal decision card). Each card keeps identity, rights + lane chips, previous salary, a remove control, and a visible Sign action, while the pool list stays on screen.
- The FA room goes full-height (hideHeader + bleed) with the list as the only scroll region; row menus flip upward near the scroll boundary.
- Offer-sheet lists get the dark cockpit treatment + a capped, internally-scrolling region, and only render when offer sheets exist.

## Revision pass (owner review feedback)
- **Modal copy / action truth** — the FA sign flow no longer inherits *expiring-contract / extend / waive / "replacing the option"* language. The modal now frames a free-agent signing ("… is a free agent. Set the salary and term below, then confirm to sign him to a new contract") with a matching action description. Implemented via optional copy-override props on the shared `EditContractModal`, so option/under-contract flows on other surfaces are untouched.
- **Preview labeling** — the deck Sign button carries the same **world-aware "(Preview)"** marker the modal uses (sandbox shows it, a saved world drops it), threaded `pool → deck → card`, instead of a hardcoded "Sign Player".
- **Confirm Action behavior** — the button is keyed on its disabled state: a disabled Confirm renders muted/inert (never the enabled orange) with a plain-language reason beside it ("Select an action to continue", etc.); selecting an action flips it to solid orange.
- **Nav-expanded proof** — left nav expanded + 3 selected fits at 1280×720 with no clipping and the pool still visible.
- **6-selected overflow proof** — six selected renders a 2-column deck that scrolls internally while the pool stays on screen (verified directly; no follow-up ticket needed).

## Validation
- `npm run typecheck` → clean
- `npm run test:diff` → **138 files / 1162 tests passed**
- All states captured live at 1280×720 in Architect review mode (MIAMI HEAT, 2026-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)