### PR TITLE
Fix Trade Receipt guardrail tests in CI (BZE-226)

### DIFF
--- a/src/tests/trade/TradeValidationGating.guardrail.test.tsx
+++ b/src/tests/trade/TradeValidationGating.guardrail.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { ValidationStateHeader, ModeTag, MODE_TAGS } from '@/features/architect/tradeMachine/ValidationStateHeader';
 import { ValidationDetailsPanel } from '@/features/architect/tradeMachine/ValidationDetailsPanel';
 import { TRADE_MACHINE_DEBUG_FLAG } from '@/features/architect/tradeMachine/utils/tradeMachineDebugFlag';
@@ -99,6 +99,10 @@ const emptyIncomingAssets: NonNullable<
 
 const enableTradeMachineDebugPanel = () => {
   window.localStorage.setItem(TRADE_MACHINE_DEBUG_FLAG, 'true');
+  // The Trade Receipt section is also gated on the VITE_SHOW_TRADE_RECEIPT build
+  // flag. It's only present via a local .env.local, so stub it here — otherwise
+  // these tests silently pass on a dev machine and fail in CI where it's unset.
+  vi.stubEnv('VITE_SHOW_TRADE_RECEIPT', 'true');
 };
 
 describe('ValidationStateHeader Guardrail Tests (Task A)', () => {
@@ -217,6 +221,7 @@ describe('ValidationStateHeader Guardrail Tests (Task A)', () => {
 describe('ValidationDetailsPanel Guardrail Tests (Tasks B, C, D, E)', () => {
   afterEach(() => {
     window.localStorage.clear();
+    vi.unstubAllEnvs();
     cleanup();
   });
 


### PR DESCRIPTION
## What

Test-only fix for the CI env-flag setup issue that is blocking PR #485 / BZE-222.

`CD-GR-05` and `C-GR-06` assert the Trade Receipt section renders, but that section is gated on `import.meta.env.VITE_SHOW_TRADE_RECEIPT === 'true'`. That flag only comes from a local, gitignored `.env.local`, which CI does not provide. The tests set the localStorage debug flag but never stub the env var, so they pass on a dev machine and fail in CI (the `section-trade-receipt` node is missing).

## Change

In `src/tests/trade/TradeValidationGating.guardrail.test.tsx`:
- `enableTradeMachineDebugPanel()` now also calls `vi.stubEnv('VITE_SHOW_TRADE_RECEIPT', 'true')`.
- The panel suite's `afterEach` now calls `vi.unstubAllEnvs()`.

No Trade Machine production behavior changes. No Free Agency / BZE-222 changes.

## Validation

- CI-like run (`.env.local` hidden), targeted guardrail suite: **26/26 pass** (previously 2 failed).
- `npm run typecheck`: clean.

Fixes BZE-226
Refs BZE-222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test coverage for environment-gated trade UI, helping ensure the Trade Receipt section appears consistently across local and CI environments.
  * Added cleanup for environment stubs after tests to prevent cross-test side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->