### PR TITLE
BZE-186 Honest exposure classification on FA selected-card deck

### DIFF
--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentCard.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentCard.tsx
@@ -33,6 +33,7 @@ export const FreeAgentCard = ({
   onOpenContractModal,
   onRemove,
   isPreviewSigning = false,
+  exposureClassification = 'preview-only',
 }: FreeAgentCardProps) => {
   const { surfacePlayer: player } = entry;
   const formattedName =
@@ -150,7 +151,7 @@ export const FreeAgentCard = ({
           </button>
         </div>
         <button
-          data-action-exposure-classification="preview-only"
+          data-action-exposure-classification={exposureClassification}
           onClick={() => onOpenContractModal(entry)}
           className="w-full rounded bg-green-600 py-1.5 text-[11px] font-bold uppercase leading-none tracking-wider text-white transition-colors hover:bg-green-500"
         >

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPool.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentPool.tsx
@@ -590,6 +590,7 @@ export const FreeAgentPool = ({
         onOpenContractModal={openContractModal}
         onRemove={handleRemove}
         isPreviewSigning={/\(Preview\)/i.test(standardSigningActionLabel)}
+        exposureClassification={standardSigningExposureClassification}
       />
 
       <FreeAgentPoolHeader />

--- a/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
@@ -7,6 +7,7 @@
  */
 import React from 'react';
 import { FreeAgentCard } from './FreeAgentCard';
+import type { ActionExposureClassification } from '@/features/architect/GMDashboard/hooks/useArchitectActions.types';
 import type { FreeAgentSurfaceEntry } from './types';
 
 interface SelectedFreeAgentCardsProps {
@@ -16,6 +17,9 @@ interface SelectedFreeAgentCardsProps {
   // Mirrors the modal's world-aware signing label so the deck's Sign action
   // carries the same "(Preview)" marker in sandbox and drops it in a saved world.
   isPreviewSigning?: boolean;
+  // Same world-aware exposure truth the pool rows report, so the deck's Sign
+  // action doesn't hardcode a preview-only classification in a saved world.
+  exposureClassification?: ActionExposureClassification;
 }
 
 export const SelectedFreeAgentCards = ({
@@ -23,6 +27,7 @@ export const SelectedFreeAgentCards = ({
   onOpenContractModal,
   onRemove,
   isPreviewSigning = false,
+  exposureClassification = 'preview-only',
 }: SelectedFreeAgentCardsProps) => {
   if (selectedEntries.length === 0) return null;
 
@@ -39,6 +44,7 @@ export const SelectedFreeAgentCards = ({
             onOpenContractModal={onOpenContractModal}
             onRemove={onRemove}
             isPreviewSigning={isPreviewSigning}
+            exposureClassification={exposureClassification}
           />
         ))}
       </div>

--- a/src/features/architect/freeAgency/FreeAgentPool/types.ts
+++ b/src/features/architect/freeAgency/FreeAgentPool/types.ts
@@ -125,4 +125,11 @@ export interface FreeAgentCardProps {
   onOpenContractModal: (entry: FreeAgentSurfaceEntry) => void;
   onRemove: (selectionKey: string) => void;
   isPreviewSigning?: boolean;
+  /**
+   * Machine-readable exposure honesty for the deck Sign action. Mirrors the row's
+   * `standardSigningExposureClassification` so the deck reports the same
+   * supported/preview truth (V1 supported in a saved world, preview-only in sandbox)
+   * instead of a hardcoded value.
+   */
+  exposureClassification?: ActionExposureClassification;
 }

--- a/src/tests/architect/freeAgentPool.surface.e86.behavior.test.tsx
+++ b/src/tests/architect/freeAgentPool.surface.e86.behavior.test.tsx
@@ -341,6 +341,50 @@ describe('FreeAgentPool surface E86 behavior', () => {
     ).not.toBeInTheDocument();
   });
 
+  // BZE-186: the selected-card deck must report the same action-exposure truth
+  // the pool rows do, instead of hardcoding preview-only. Otherwise the deck
+  // Sign action misreports a V1-supported saved-world signing as preview-only.
+  it('reports V1-supported exposure on the deck Sign action in a saved world', () => {
+    renderPool({
+      actionOwner: buildActionOwner({
+        freeAgentModalAvailability: {
+          actionLabelsOverride: { signNew: 'Sign Free Agent' },
+          standardSigningExposureClassification: 'V1 supported',
+        },
+      }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /test player/i }));
+    const deckSignButton = screen.getByRole('button', { name: /Sign Player/i });
+
+    expect(deckSignButton).toHaveAttribute(
+      'data-action-exposure-classification',
+      'V1 supported'
+    );
+    // Supported saved-world signing must not carry the sandbox "(Preview)" marker.
+    expect(deckSignButton).not.toHaveTextContent(/\(Preview\)/i);
+  });
+
+  it('reports preview-only exposure and marker on the deck Sign action in sandbox', () => {
+    renderPool({
+      actionOwner: buildActionOwner({
+        freeAgentModalAvailability: {
+          actionLabelsOverride: { signNew: 'Sign Free Agent (Preview)' },
+          standardSigningExposureClassification: 'preview-only',
+        },
+      }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /test player/i }));
+    const deckSignButton = screen.getByRole('button', { name: /Sign Player/i });
+
+    expect(deckSignButton).toHaveAttribute(
+      'data-action-exposure-classification',
+      'preview-only'
+    );
+    expect(deckSignButton).toHaveTextContent(/\(Preview\)/i);
+  });
+
   it('generates and saves a managed pool from visible entries', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     renderPool({


### PR DESCRIPTION
## What

Verification pass for BZE-186 (action-label truth on the redesigned Free Agency selected-player deck after BZE-222). One real truth issue found and fixed; everything else verified honest.

## Finding

Every Architect action surface exposes a machine-readable `data-action-exposure-classification` (`V1 supported` / `preview-only`) — it's the canonical exposure-honesty signal, asserted directly in tests. The pool row derives it from the real `standardSigningExposureClassification`. The redesigned selected-card **deck hardcoded `"preview-only"`**.

Source of truth ([useArchitectActions.ts](src/features/architect/GMDashboard/hooks/useArchitectActions.ts)): in a **saved world** standard FA signing is `V1 supported`; in **sandbox** it's `preview-only`. So the deck Sign action was misreporting a supported saved-world signing as preview-only. The visible `(Preview)` marker was already world-aware and honest — only the classification attribute lied.

## Fix (smallest, no redesign)

Thread the real classification `pool → deck → card` and use it for the attribute (defaults to `preview-only`, preserving sandbox behavior). No layout, copy, or gating-logic change; the visible deck is untouched.

- `FreeAgentPool.tsx` — pass `standardSigningExposureClassification` to the deck
- `SelectedFreeAgentCards.tsx` / `FreeAgentCard.tsx` / `types.ts` — thread + apply it

## Verified honest (no change needed)

- **Row** — label + classification both world-aware and consistent.
- **Modal** — `signNew` option label carries the world-aware `(Preview)` marker via `actionLabelsOverride`; intro copy and action description reframed as a free-agent signing (BZE-222).
- **Deck button ↔ modal** — same Preview/supported story.

## Validation

- `npm run typecheck` → clean
- `npm run test:diff` (node + UI tiers over changed files) → **37 tests pass**, incl. 2 new deck tests asserting `V1 supported` (no marker) in a saved world and `preview-only` (with marker) in sandbox.

Fixes BZE-186
Refs BZE-222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Sign Player” action now reflects the correct visibility/exposure label in free agent pool cards.
  * Free agent selection cards can now carry and pass along a configurable exposure setting.

* **Bug Fixes**
  * Fixed cases where the sign action always appeared as preview-only, even when a more specific exposure label should be shown.

* **Tests**
  * Added UI behavior checks for both preview-only and supported exposure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->