### PR TITLE
BZE-224: Trade Machine visual pass

### DIFF
--- a/src/features/architect/cockpit/TradeOverlay.tsx
+++ b/src/features/architect/cockpit/TradeOverlay.tsx
@@ -75,11 +75,15 @@ export const TradeOverlay = ({
         </button>
       </div>
 
+      {/* Padding lives on an inner wrapper, not the scroll container: sticky
+          children (the Trade Machine's verdict banner) pin to the scrollport
+          edge, and container padding would leave a gap above them where
+          scrolled content ghosts through (BZE-224 review fix). */}
       <div
-        className="flex-1 min-h-0 overflow-auto px-5 py-4"
+        className="flex-1 min-h-0 overflow-auto"
         data-testid="trade-overlay-body"
       >
-        {children}
+        <div className="px-5 pt-4 pb-5">{children}</div>
       </div>
     </div>
   );

--- a/src/features/architect/tradeMachine/EntitlementPicksList.tsx
+++ b/src/features/architect/tradeMachine/EntitlementPicksList.tsx
@@ -139,7 +139,7 @@ export const EntitlementPicksList = ({
     return (
       <div>
         <div className="flex items-center justify-between mb-1">
-          <h4 className="text-sm text-white/70">Draft Assets (Entitlements)</h4>
+          <h4 className="text-sm text-white/70">Draft Picks</h4>
           {onCreateEntitlement && (
             <EntitlementEditorCreateButton
               onClick={onCreateEntitlement}
@@ -148,7 +148,7 @@ export const EntitlementPicksList = ({
           )}
         </div>
         <div className="text-xs text-white/40 px-1">
-          No entitlements loaded.
+          No draft picks to show.
           {emptyStateHint && (
             <span className="block mt-1 text-white/30 text-[10px]">
               {emptyStateHint}
@@ -162,7 +162,7 @@ export const EntitlementPicksList = ({
   return (
     <div>
       <div className="flex items-center justify-between mb-1">
-        <h4 className="text-sm text-white/70">Draft Assets (Entitlements)</h4>
+        <h4 className="text-sm text-white/70">Draft Picks</h4>
         {onCreateEntitlement && (
           <EntitlementEditorCreateButton
             onClick={onCreateEntitlement}

--- a/src/features/architect/tradeMachine/TradeEditor.tsx
+++ b/src/features/architect/tradeMachine/TradeEditor.tsx
@@ -998,8 +998,13 @@ export const TradeEditor = ({
       {/* Stale validation fix: Uses hasCurrentValidation to only show "Validated"
           when the current preview authority/detail payload matches this draft */}
       {/* BZE-224: sticky so the verdict (especially a blocked deal) stays
-          visible while scrolling the cards / validation details below. */}
-      <div className="sticky top-0 z-30 -mx-5 bg-[#05070c]/95 px-5 py-1 backdrop-blur-sm">
+          visible while scrolling the cards / validation details below. The
+          band is opaque and matches the overlay void, so at rest it is
+          invisible and, when pinned, content slides cleanly underneath it —
+          no translucent ghosting (owner review fix). The -mx-5/px-5 bleed
+          matches TradeOverlay's inner padding, the overlay being the Trade
+          Machine's only host. */}
+      <div className="sticky top-0 z-30 -mx-5 bg-cockpit-void px-5 pb-2 pt-2 shadow-[0_10px_14px_-12px_rgba(0,0,0,0.85)]">
         <ValidationStateHeader
           hasValidatorResult={hasCurrentValidation}
           isValidating={isValidating}

--- a/src/features/architect/tradeMachine/TradeEditor.tsx
+++ b/src/features/architect/tradeMachine/TradeEditor.tsx
@@ -517,13 +517,16 @@ export const TradeEditor = ({
         };
       }
 
+      // E2A disclosure guardrail: the apply surface must keep naming the
+      // remaining apply-only gates (duplicates, pick conflicts, exclusivity)
+      // and that they run at apply time.
       if (previewHasApplyTimeWorldChecks) {
         return {
           tone: 'info',
           label: 'Ready with apply-time checks',
           message: isVacuumMode
-            ? 'Local checks passed; session checks run at apply.'
-            : 'Local checks passed; final Team Plan checks run at apply.',
+            ? 'Local checks passed; duplicate-player, pick-conflict, and exclusivity checks run at apply time.'
+            : 'Local checks passed; the Team Plan runs duplicate-player, pick-conflict, and exclusivity checks at apply time.',
         };
       }
 

--- a/src/features/architect/tradeMachine/TradeEditor.tsx
+++ b/src/features/architect/tradeMachine/TradeEditor.tsx
@@ -858,7 +858,7 @@ export const TradeEditor = ({
   };
 
   return (
-    <div className="text-white space-y-6">
+    <div className="text-white space-y-4">
       {showContextBanner && tradeContext && bannerAuthority ? (
         <div
           className="flex items-start justify-between gap-2 rounded-md border border-white/15 bg-white/[0.04] px-3 py-2"
@@ -997,12 +997,16 @@ export const TradeEditor = ({
       {/* Task A: Mode + Validation State Header */}
       {/* Stale validation fix: Uses hasCurrentValidation to only show "Validated"
           when the current preview authority/detail payload matches this draft */}
-      <ValidationStateHeader
-        hasValidatorResult={hasCurrentValidation}
-        isValidating={isValidating}
-        validatedAt={getValidatedAt()}
-        readiness={tradeReadiness}
-      />
+      {/* BZE-224: sticky so the verdict (especially a blocked deal) stays
+          visible while scrolling the cards / validation details below. */}
+      <div className="sticky top-0 z-30 -mx-5 bg-[#05070c]/95 px-5 py-1 backdrop-blur-sm">
+        <ValidationStateHeader
+          hasValidatorResult={hasCurrentValidation}
+          isValidating={isValidating}
+          validatedAt={getValidatedAt()}
+          readiness={tradeReadiness}
+        />
+      </div>
 
       {/* Phase 16.3: Init error display */}
       {initError && teams.length === 0 && (
@@ -1131,34 +1135,8 @@ export const TradeEditor = ({
         </div>
       )}
 
-      {/* Apply-action context — the Apply button itself now lives in the header
-          toolbar; this row carries only the contextual warning / blocked text. */}
-      {((canApplyTrade && previewHasApplyTimeWorldChecks) ||
-        currentPreviewAuthority?.legal === false) && (
-        <div className="flex flex-wrap gap-3 items-center">
-          {canApplyTrade && previewHasApplyTimeWorldChecks && (
-            <span className="text-xs text-yellow-400/50">
-              All local preview checks passed. World-state checks (duplicate
-              players, entitlement conflicts, exclusivity) run at apply time and
-              may still reject this trade.
-            </span>
-          )}
-
-          {currentPreviewAuthority?.legal === false && (
-            <span
-              className={`text-xs ${
-                previewOverrideRequested ? 'text-amber-300' : 'text-red-400'
-              }`}
-            >
-              {previewOverrideRequested
-                ? `Override requested, but preview authority still blocks this trade: ${
-                    previewAuthorityReason
-                  }`
-                : `Trade blocked: ${previewAuthorityReason}`}
-            </span>
-          )}
-        </div>
-      )}
+      {/* The verdict banner (ValidationStateHeader) above the cards carries the
+          blocked / apply-time-checks messaging; no duplicate text row here. */}
 
       {/* Tasks B, C, D, E: Validation Details Panel with hard-gating and mode tags */}
       {/* Stale validation fix: Uses hasCurrentValidation for proper authority/detail gating */}

--- a/src/features/architect/tradeMachine/TradeExportCapture.tsx
+++ b/src/features/architect/tradeMachine/TradeExportCapture.tsx
@@ -257,7 +257,7 @@ const TradeExportCapture = React.forwardRef<HTMLDivElement, TradeExportCapturePr
                       {/* 🧾 Entitlements Section (Phase 15) */}
                       <div className="min-h-[150px] mt-6 flex flex-col justify-end">
                         <h4 className="text-neutral-300 font-semibold text-sm uppercase tracking-wide border-l-4 border-neutral-500 pl-3">
-                          Entitlements Received
+                          Picks Received
                         </h4>
                         <div className="space-y-2 min-h-[60px] mt-2">
                           {entitlements.length ? (
@@ -305,7 +305,7 @@ const TradeExportCapture = React.forwardRef<HTMLDivElement, TradeExportCapturePr
                             })
                           ) : (
                             <div className="text-neutral-500 text-center py-2 italic text-sm">
-                              No entitlements received
+                              No picks received
                             </div>
                           )}
                         </div>

--- a/src/features/architect/tradeMachine/TradePreviewModal.tsx
+++ b/src/features/architect/tradeMachine/TradePreviewModal.tsx
@@ -71,14 +71,16 @@ const TradePreviewModal = ({
           }}
           onClick={(e) => e.stopPropagation()}
         >
+          {/* Close sits outside the overflow-hidden capture card so it never
+              overlaps the summary header (date) baked into the export. */}
+          <button
+            onClick={onClose}
+            className="absolute -top-5 -right-5 z-30 rounded-full border border-white/20 bg-neutral-900 p-2 text-white/70 shadow-lg hover:text-white hover:bg-neutral-800 transition-colors"
+            title="Close"
+          >
+            <X size={22} />
+          </button>
           <div className="rounded-2xl border border-white/20 shadow-2xl overflow-hidden bg-[#111] relative">
-            <button
-              onClick={onClose}
-              className="absolute top-2 right-2 text-white/60 hover:text-white z-20"
-              title="Close"
-            >
-              <X size={36} />
-            </button>
             <TradeExportCapture
               teams={teams}
               previewAuthority={previewAuthority}

--- a/src/features/architect/tradeMachine/TradeTeamCard.tsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.tsx
@@ -82,8 +82,10 @@ export const TradeTeamCard = ({
 }: TradeTeamCardProps) => {
   const [activeTab, setActiveTab] = useState('players');
   const [editingTeam, setEditingTeam] = useState(false);
-  const [showOutgoing, setShowOutgoing] = useState(false);
-  const [showIncoming, setShowIncoming] = useState(false);
+  // Staged pieces are the deal — show them by default so the package is
+  // readable at a glance; the rows still toggle closed for a tighter card.
+  const [showOutgoing, setShowOutgoing] = useState(true);
+  const [showIncoming, setShowIncoming] = useState(true);
   const selectRef = useRef<{
     focus: () => void;
     showPicker?: () => void;
@@ -328,9 +330,12 @@ export const TradeTeamCard = ({
                 return (
                   <span
                     key={String(getPlayerKey(p))}
-                    className="bg-[#2a2a2a] text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-white/10 flex items-center gap-1"
+                    className="bg-red-950/40 text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-red-400/25 flex items-center gap-1"
                   >
                     {getPlayerLabel(p)}
+                    <span className="text-white/50">
+                      {formatSalary(baseSalary)}
+                    </span>
                     {/* P1: Player-level adjustment indicator with specific tooltip */}
                     {hasPlayerAdjustment && (
                       <span
@@ -357,9 +362,14 @@ export const TradeTeamCard = ({
                 .map((e) => (
                   <span
                     key={String(getEntitlementKey(e))}
-                    className="bg-[#2a2a2a] text-white/70 text-[11px] px-2 py-0.5 rounded-full border border-white/10"
+                    className="bg-red-950/40 text-white/80 text-[11px] px-2 py-0.5 rounded-full border border-red-400/25"
                   >
-                    {e.seasonYear ?? '—'} R{e.round ?? '—'}{' '}
+                    {e.seasonYear ?? '—'}{' '}
+                    {Number(e.round) === 1
+                      ? '1st Rd'
+                      : Number(e.round) === 2
+                        ? '2nd Rd'
+                        : `R${e.round ?? '—'}`}{' '}
                     {e.kind === 'swap_right' ? 'Swap' : 'Pick'}
                   </span>
                 ))}
@@ -443,9 +453,12 @@ export const TradeTeamCard = ({
                 return (
                   <span
                     key={String(getPlayerKey(p))}
-                    className="bg-[#2a2a2a] text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-white/10 flex items-center gap-1"
+                    className="bg-green-950/40 text-white/90 text-[11px] px-2 py-0.5 rounded-full border border-green-400/25 flex items-center gap-1"
                   >
                     {getPlayerLabel(p)}
+                    <span className="text-white/50">
+                      {formatSalary(baseSalary)}
+                    </span>
                     {/* P1: Player-level adjustment indicator with specific tooltip */}
                     {hasPlayerAdjustment && (
                       <span
@@ -470,10 +483,15 @@ export const TradeTeamCard = ({
               {incomingEntitlements.map((e) => (
                 <span
                   key={String(getEntitlementKey(e))}
-                  className="bg-[#2a2a2a] text-white/70 text-[11px] px-2 py-0.5 rounded-full border border-white/10"
+                  className="bg-green-950/40 text-white/80 text-[11px] px-2 py-0.5 rounded-full border border-green-400/25"
                 >
-                  {e.seasonYear ?? '—'} R{e.round ?? '—'}{' '}
-                  {e.kind === 'swap_right' ? 'Swap' : ''}
+                  {e.seasonYear ?? '—'}{' '}
+                  {Number(e.round) === 1
+                    ? '1st Rd'
+                    : Number(e.round) === 2
+                      ? '2nd Rd'
+                      : `R${e.round ?? '—'}`}{' '}
+                  {e.kind === 'swap_right' ? 'Swap' : 'Pick'}
                 </span>
               ))}
             </div>
@@ -532,6 +550,8 @@ export const TradeTeamCard = ({
                   The formatSkipReasonLabel helper converts internal codes to readable labels. */}
               {/* Show rule label only when applicable (no skipReason) and rule is meaningful */}
               {/* P0-3: Hide rule label during validation */}
+              {/* BZE-224: run the rule label through the skip-reason formatter so
+                  validator codes (UNDER_CAP, SECOND_APRON…) never render raw */}
               {!isValidating &&
                 !salaryMatchingSkipReason &&
                 salaryMatchingRuleLabel &&
@@ -540,9 +560,15 @@ export const TradeTeamCard = ({
                     className="ml-1 text-white/40"
                     title={salaryMatchingFormula}
                     role="note"
-                    aria-label={`Rule: ${salaryMatchingRuleLabel}. Formula: ${salaryMatchingFormula}`}
+                    aria-label={`Rule: ${
+                      formatSkipReasonLabel(salaryMatchingRuleLabel) ??
+                      salaryMatchingRuleLabel
+                    }. Formula: ${salaryMatchingFormula}`}
                   >
-                    ({salaryMatchingRuleLabel})
+                    (
+                    {formatSkipReasonLabel(salaryMatchingRuleLabel) ??
+                      salaryMatchingRuleLabel}
+                    )
                   </span>
                 )}
               {!isValidating && hardCapIsLimiter && (
@@ -648,8 +674,7 @@ export const TradeTeamCard = ({
             .filter((id): id is string | number => id !== undefined)}
           // Phase 12.3B: Pass pick rules for structured derivation
           pickRulesById={team.pickRulesById || {}}
-          // Phase 14: Empty state hint for debugging
-          emptyStateHint="Check emulator seed / baseTeams.entitlementIds"
+          emptyStateHint="This team has no tradeable picks loaded."
           // Phase 17: Pass multi-team destination routing props
           otherTeams={entitlementOtherTeams}
           entitlementsOut={entitlementsOut}

--- a/src/features/architect/tradeMachine/ValidationDetailsPanel.tsx
+++ b/src/features/architect/tradeMachine/ValidationDetailsPanel.tsx
@@ -159,8 +159,10 @@ export const ValidationDetailsPanel = ({
           <span className="flex items-center gap-2">
             <ClipboardList size={15} className="text-white/60" />
             <span>Validation Results</span>
+            {/* Neutral on purpose: results existing is not a verdict — the
+                banner above owns pass/blocked coloring. */}
             {hasValidatorResult && (
-              <span className="text-xs text-green-400">Results available</span>
+              <span className="text-xs text-white/50">Results available</span>
             )}
           </span>
           {productionExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}

--- a/src/features/architect/tradeMachine/ValidationStateHeader.tsx
+++ b/src/features/architect/tradeMachine/ValidationStateHeader.tsx
@@ -84,6 +84,9 @@ export const ModeTag = ({ mode }: ModeTagProps) => {
   );
 };
 
+// The pill is deliberately neutral: it reports WHEN the deal was last checked,
+// while the surrounding banner carries the verdict color. A green pill next to
+// a red "Trade blocked" banner half-read as success (BZE-224).
 const ValidationStatePill = ({
   hasValidatorResult,
   isValidating,
@@ -91,8 +94,8 @@ const ValidationStatePill = ({
 }: ValidationStatePillProps) => {
   if (isValidating) {
     return (
-      <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-blue-600/20 text-blue-300 border border-blue-500/30">
-        <span className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-blue-600/20 text-blue-300 border border-blue-500/30">
+        <span className="w-1.5 h-1.5 rounded-full bg-blue-400 animate-pulse" />
         Validating…
       </span>
     );
@@ -107,80 +110,73 @@ const ValidationStatePill = ({
       : '';
 
     return (
-      <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-green-600/20 text-green-300 border border-green-500/30">
-        <span className="w-2 h-2 rounded-full bg-green-400" />
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-white/5 text-white/60 border border-white/15">
+        <span className="w-1.5 h-1.5 rounded-full bg-white/40" />
         Validated{timeStr && ` at ${timeStr}`}
       </span>
     );
   }
 
   return (
-    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-neutral-600/20 text-neutral-400 border border-neutral-500/30">
-      <span className="w-2 h-2 rounded-full bg-neutral-500" />
+    <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-neutral-600/20 text-neutral-400 border border-neutral-500/30">
+      <span className="w-1.5 h-1.5 rounded-full bg-neutral-500" />
       Not validated
     </span>
   );
 };
 
+// One banner row carries the verdict: the container color IS the state. The
+// blocked tone is deliberately the loudest treatment on the page so a failed
+// deal can never scan as success.
 const READINESS_STYLES: Record<
   TradeReadinessTone,
-  { icon: LucideIcon; className: string }
+  { icon: LucideIcon; container: string; label: string; message: string }
 > = {
   setup: {
     icon: CircleDashed,
-    className: 'border-neutral-500/30 bg-neutral-500/10 text-neutral-200',
+    container: 'border-white/10 border-l-neutral-400/60 bg-[#0a0a0a]',
+    label: 'text-neutral-200',
+    message: 'text-neutral-400',
   },
   ready: {
     icon: Info,
-    className: 'border-sky-500/30 bg-sky-500/10 text-sky-200',
+    container: 'border-sky-500/25 border-l-sky-400/80 bg-sky-950/30',
+    label: 'text-sky-100',
+    message: 'text-sky-200/70',
   },
   validating: {
     icon: Loader2,
-    className: 'border-blue-500/30 bg-blue-500/10 text-blue-200',
+    container: 'border-blue-500/25 border-l-blue-400/80 bg-blue-950/30',
+    label: 'text-blue-100',
+    message: 'text-blue-200/70',
   },
   blocked: {
     icon: XCircle,
-    className: 'border-red-500/40 bg-red-500/10 text-red-200',
+    container: 'border-red-500/50 border-l-red-500 bg-red-950/50',
+    label: 'text-red-100',
+    message: 'text-red-200/90',
   },
   warning: {
     icon: AlertTriangle,
-    className: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+    container: 'border-amber-500/40 border-l-amber-400 bg-amber-950/40',
+    label: 'text-amber-100',
+    message: 'text-amber-200/80',
   },
   info: {
     icon: Info,
-    className: 'border-blue-500/30 bg-blue-500/10 text-blue-200',
+    container: 'border-blue-500/25 border-l-blue-400/80 bg-blue-950/30',
+    label: 'text-blue-100',
+    message: 'text-blue-200/70',
   },
   success: {
     icon: CheckCircle2,
-    className: 'border-green-500/30 bg-green-500/10 text-green-200',
+    container: 'border-green-500/40 border-l-green-400 bg-green-950/40',
+    label: 'text-green-100',
+    message: 'text-green-200/80',
   },
 };
 
-const TradeReadinessLine = ({
-  readiness,
-}: {
-  readiness: TradeReadinessSummary;
-}) => {
-  const style = READINESS_STYLES[readiness.tone];
-  const Icon = style.icon;
-
-  return (
-    <div
-      className={`flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border px-3 py-2 text-xs ${style.className}`}
-      data-testid="trade-readiness-summary"
-      aria-live="polite"
-    >
-      <Icon
-        size={14}
-        className={
-          readiness.tone === 'validating' ? 'shrink-0 animate-spin' : 'shrink-0'
-        }
-      />
-      <span className="font-semibold">{readiness.label}</span>
-      <span className="text-current/80">{readiness.message}</span>
-    </div>
-  );
-};
+const NEUTRAL_CONTAINER = 'border-white/10 bg-[#0a0a0a]';
 
 export const ValidationStateHeader = ({
   hasValidatorResult = false,
@@ -188,20 +184,50 @@ export const ValidationStateHeader = ({
   validatedAt = null,
   readiness = null,
 }: ValidationStateHeaderProps) => {
+  const style = readiness ? READINESS_STYLES[readiness.tone] : null;
+  const Icon = style?.icon;
+
   return (
     <div
-      className="flex flex-col gap-2 px-4 py-3 mb-4 bg-[#0a0a0a] border border-white/10 rounded-lg"
+      className={`rounded-lg border border-l-4 px-4 py-2.5 ${
+        style ? style.container : NEUTRAL_CONTAINER
+      }`}
       data-testid="validation-state-header"
     >
-      <div className="flex flex-wrap items-center gap-3">
-        <span className="text-xs text-white/50 font-medium">Validation:</span>
-        <ValidationStatePill
-          hasValidatorResult={hasValidatorResult}
-          isValidating={isValidating}
-          validatedAt={validatedAt}
-        />
+      <div
+        className="flex flex-wrap items-center gap-x-2.5 gap-y-1"
+        data-testid="trade-readiness-summary"
+        aria-live="polite"
+      >
+        {readiness && style && Icon ? (
+          <>
+            <Icon
+              size={16}
+              className={`shrink-0 ${style.label} ${
+                readiness.tone === 'validating' ? 'animate-spin' : ''
+              }`}
+            />
+            <span
+              className={`text-sm font-bold uppercase tracking-wide ${style.label}`}
+            >
+              {readiness.label}
+            </span>
+            <span className={`text-xs ${style.message}`}>
+              {readiness.message}
+            </span>
+          </>
+        ) : null}
+        <span className="ml-auto flex shrink-0 items-center gap-2">
+          <span className="text-[11px] text-white/40 font-medium">
+            Validation:
+          </span>
+          <ValidationStatePill
+            hasValidatorResult={hasValidatorResult}
+            isValidating={isValidating}
+            validatedAt={validatedAt}
+          />
+        </span>
       </div>
-      {readiness && <TradeReadinessLine readiness={readiness} />}
     </div>
   );
 };

--- a/src/tests/trade/TradePreviewExport.guardrail.test.tsx
+++ b/src/tests/trade/TradePreviewExport.guardrail.test.tsx
@@ -396,11 +396,11 @@ describe('E99 TradeExportCapture guardrails', () => {
     expect(teamHeadings).toEqual(['Boston Celtics', 'Los Angeles Lakers']);
 
     expect(screen.getAllByText('Players Received')).toHaveLength(2);
-    expect(screen.getAllByText('Entitlements Received')).toHaveLength(2);
+    expect(screen.getAllByText('Picks Received')).toHaveLength(2);
     expect(screen.getByText('Visible Name')).toBeInTheDocument();
     expect(screen.getByText('SALARY:7500000 • 3 yrs')).toBeInTheDocument();
     expect(screen.getByText('No players received')).toBeInTheDocument();
-    expect(screen.getByText('No entitlements received')).toBeInTheDocument();
+    expect(screen.getByText('No picks received')).toBeInTheDocument();
     expect(screen.getByText('2028 R1')).toBeInTheDocument();
     expect(screen.getByText('BADGE')).toBeInTheDocument();
     expect(screen.getByText('formatted terms')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Owner-approved presentation-only visual pass on the Trade Machine (no CBA/engine/data-contract changes):

- Sticky single-row verdict banner: container color carries pass/blocked tone; timestamp pill is neutral so a blocked deal can never read as success; banner pins flush and opaque when scrolled (revision commit)
- Staged sends/receives render as salary-labeled chips with direction tints — the deal package is readable without clicking
- Validator rule codes (SECOND_APRON, UNDER_CAP, OVER_CAP_BAND_2) formatted for owner-facing display
- Picks tab: "Draft Picks" heading, owner-safe empty state; export summary says "Picks Received"; preview close button no longer overlaps the date
- Removed duplicate blocked/warning text row; "Results available" label neutral instead of green-while-blocked

## Validation

- npm run test:trade — 72 files / 635 tests passed
- npm run test:ui — 138 files / 1164 tests passed
- npm run typecheck — clean
- npm run build — clean (pre-existing chunk-size warning only)
- Owner reviewed screenshots at 1280×720 and approved merge

Fixes BZE-224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated trade screens with clearer, more polished labels for draft picks and received picks.
  * Validation and readiness banners now use a more consistent, always-visible presentation.

* **Bug Fixes**
  * Improved overlay scrolling and spacing so content is easier to read and stays properly framed.
  * Repositioned the close button in the trade preview to avoid overlapping content.
  * Expanded trade sections by default and refreshed chip, badge, and status styling for better clarity.

* **Tests**
  * Updated coverage to match the new draft pick wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->