### PR TITLE
BZE-228 Architect visual standard + Roster room proof wave

### DIFF
--- a/docs/standards/ARCHITECT_VISUAL_STANDARD.md
+++ b/docs/standards/ARCHITECT_VISUAL_STANDARD.md
@@ -1,0 +1,259 @@
+---
+name: ARCHITECT_VISUAL_STANDARD.md
+description: The durable visual identity every Architect UI wave is built and judged against — spacing, type, color/tone, component vocabulary, and state treatments, grounded in the approved cockpit surfaces and the locked design laws.
+---
+
+# Architect Visual Standard
+
+This is the single visual identity for the Architect (GM cockpit) surfaces. Every
+UI wave is **built to** this standard and **judged against** it. When a wave and
+this doc disagree, one of them is wrong — fix the wave, or change the doc
+deliberately (with the reason) and re-judge everything against the new version.
+
+It is grounded in surfaces the owner has already approved, not invented from
+scratch:
+
+- **Canonical:** the Full Cap Table drawer (`capfull`) — the trusted money/books
+  surface. Its density, dark elevation, and cap-posture treatment are the
+  reference for "what finished looks like here."
+- **References:** the Team Plan Hub cockpit shell and the BZE-216 rooms (Cap
+  Sheet, Trade Machine, Free Agency after their approved passes).
+- **Tokens of record:** `src/features/architect/cockpit/cockpitTokens.ts`
+  (mirrored into `tailwind.config.js` as the `cockpit-*` utilities). The doc
+  describes those tokens; the code owns them. If a value here drifts from the
+  token file, the token file wins.
+
+The identity in one line: **a dark, premium, dense sports-management cockpit —
+not sci-fi, not a dashboard template.** Team color is a narrow accent, never a
+panel wash. Every pixel earns its place because everything must fit 1280×720.
+
+---
+
+## 1. Locked design laws (owner decisions — non-negotiable)
+
+These come from `docs/agent-guides/architect-boundary.md` and override any
+aesthetic preference below.
+
+1. **One screen.** Every player involved in a decision is visible on one screen.
+   No separate sections or drawers for a decision's players.
+2. **Universal cap posture.** Cap/apron posture is one shared component
+   everywhere (the drawer/meter design is canonical). Never duplicated or
+   restyled per feature. In the cockpit it lives in the TopBar
+   (`CapPostureMeter`); rooms inherit it from the shell rather than drawing their
+   own.
+3. **Fits 1280×720 with zero page-level clipping.** The owner reviews at exactly
+   this size. The Full Cap Table fits up to 18 rows with zero scroll. Every room
+   must fit or scroll only inside its designated body region (see §7).
+4. **GM language only.** Owner-facing copy speaks like a general manager. Banned
+   internal vocabulary on product surfaces: *posture, truth, guard, canonical,
+   authority,* raw world IDs, emulator/debug indicators, proof/scaffolding tags.
+   (Note: `posture` is fine in code/token names; it must never appear in visible
+   copy — the meter says "$4.2M under Cap", never "cap posture".)
+
+---
+
+## 2. Elevation & surfaces
+
+The cockpit is built from a fixed ladder of dark surfaces. Depth is expressed by
+**surface value + a 1px edge + at most one soft shadow** — never by heavy borders
+or large drop shadows.
+
+| Token (`cockpit-*`) | Hex | Role |
+| --- | --- | --- |
+| `void` | `#0A0C10` | Deepest background. The room canvas (`RoomFrame` uses `bg-cockpit-void`). |
+| `inlay` | `#0B0E14` | Recessed wells — the scroll region a list/table sits *inside*, meter tracks. |
+| `bar` | `#0F1218` | Chrome bands: TopBar, room header, NavRail. |
+| `slab` | `#13171F` | The default panel/card surface. Most content sits on a slab. |
+| `raised` | `#1A1F29` | A slab lifted above its neighbors (hover, active row, popover). |
+| `edge` | `#232A36` | The 1px border between surfaces. Use `border-cockpit-edge`. |
+
+Shadows (from `tailwind.config.js`), used sparingly:
+
+- `shadow-cockpit-slab` — the standard panel lift (inset top highlight + soft
+  down shadow). Default for any slab that should read as a card.
+- `shadow-cockpit-accent` — team-accent ring + glow. Reserve for the single
+  focused/active element in a view (e.g. the active team plan). Never decorative.
+
+**Rules.** Nest at most two elevation steps (e.g. `slab` panel holding an `inlay`
+list well). Do **not** stack box-in-box-in-box. Prefer replacing an inner border
+with a spacing gap or a surface-value change. Ad-hoc hexes like `bg-[#070A0F]` or
+`bg-white/[0.035]` are drift — use the token that means the same thing.
+
+---
+
+## 3. Color & tone
+
+Color carries meaning, not decoration. Three families only:
+
+**Neutral text ramp** (white at fixed opacities — `cockpit-text-*`):
+
+| Token | Value | Use |
+| --- | --- | --- |
+| `text-primary` | white 92% | Primary values, names, headings. |
+| `text-secondary` | white 62% | Supporting copy, labels beside a value. |
+| `text-muted` | white 40% | De-emphasized meta, section captions, units. |
+| `text-ghost` | white 20% | Disabled, placeholder, empty-slot outlines. |
+
+**Status** (`cockpit-safe|watch|danger|info`) — the only saturated non-team color
+allowed, and only to signal state:
+
+| Token | Hex | Meaning |
+| --- | --- | --- |
+| `safe` | `#34D399` | Legal / under a threshold / healthy (green). |
+| `watch` | `#FBBF24` | Caution — over cap or over tax, allowed but flagged (amber). |
+| `danger` | `#F87171` | Hard stop / over an apron / blocked (red). |
+| `info` | `#60A5FA` | Neutral informational accent (blue). |
+
+**Team accent** (`--team-primary` CSS var, injected by `useTeamPalette`): a
+narrow identity cue — a top hairline, an active ring, a logo mount. **Never** a
+filled panel, never a large area of team color. If a team wash is filling a card,
+that's wrong.
+
+Tone rule: a surface is neutral until something is true about it. Green/amber/red
+appear because the cap math says so, not to brighten the page.
+
+---
+
+## 4. Type scale
+
+One compact scale. The cockpit is dense; type is small and tight, weight (not
+size) carries hierarchy.
+
+| Level | Classes | Use |
+| --- | --- | --- |
+| Room title | `text-sm font-semibold uppercase tracking-wide` | `RoomFrame` header; the room's name. |
+| Surface title | `text-lg font-black uppercase leading-tight tracking-wide` | The one hero label per room (team name, screen subject). One per view. |
+| Group heading | `text-xs font-extrabold uppercase tracking-wide` | Section/band headings inside a room. |
+| Primary value | `text-sm font-extrabold tabular-nums` | Numbers that matter (counts, dollars). Always `tabular-nums`. |
+| Body | `text-xs` / `text-[11px]` | Supporting copy, row detail. |
+| Label / caption | `text-[10px] font-semibold uppercase tracking-wider` (muted) | Tile labels, unit captions, band details. |
+
+Rules: never more than one Surface-title per view. Money and counts are always
+`tabular-nums` so columns don't jitter. Don't introduce sizes between these steps
+(no `text-[9px]`, no `text-[13px]`) — reach for weight or color instead.
+
+---
+
+## 5. Spacing & density
+
+- **Base unit 4px.** Standard rhythm: `gap-2`/`gap-3` between elements,
+  `px-3 py-2` inside a compact panel, `px-5 py-4` for a room's comfortable body
+  padding (matches `RoomFrame`'s non-bleed default).
+- **Radii:** `rounded-md` (6px) for chips/tiles/controls, `rounded-lg` (8px) for
+  panels/cards. Nothing more rounded; this is a cockpit, not a consumer app.
+- **Density target:** a room should feel full but never cramped. If content
+  doesn't fit 1280×720, cut or collapse content and tighten the shell (one-line
+  strips, `hideHeader`/`bleed`) — do **not** shrink type below the scale in §4.
+- **Alignment:** numeric columns right-align; label+value pairs share a baseline
+  (`items-baseline`). Ragged baselines are a defect.
+
+---
+
+## 6. Component vocabulary
+
+Reuse these; don't reinvent per room.
+
+- **RoomFrame** (`cockpit/RoomFrame.tsx`) — the room shell. 48px (`h-12`) header
+  with an uppercase title, a single scrollable body, and two opt-ins: `hideHeader`
+  (room draws its own title band) and `bleed` (body owns the edge, no padding).
+  The body is the **only** scroll boundary in the workspace.
+- **Cap posture meter** (`cockpit/CapPostureMeter.tsx`) — the universal Cap → Tax
+  → Apron 1 → Apron 2 track with a status-colored marker and a plain-language
+  label ("$4.2M under Cap"). Universal per design law #2; never re-drawn.
+- **Panel / slab** — `rounded-lg border border-cockpit-edge bg-cockpit-slab
+  shadow-cockpit-slab`. The default container for a group of related content.
+- **List well** — an `inlay` region a scrolling list/table sits inside, with the
+  scroll captured to the well, not the page.
+- **Metric tile** — a compact `label + value` unit: muted uppercase label (§4),
+  `tabular-nums` value, on a slab or inset. Used for at-a-glance counts. Keep
+  tiles a consistent height and align their baselines in a row.
+- **Player row / card** — the shared roster/pool player unit. Card click = open;
+  a corner overflow (`PlayerActionMenu`) carries secondary actions (pin, trade,
+  cross-room nav). A "just changed" highlight is a team-accent outline, not a
+  fill.
+- **Chip / pill** — small status or filter token, `rounded-md`, status- or
+  neutral-toned. Never more than one saturated chip competing for attention in a
+  row.
+- **Buttons** — primary action uses the team accent or a single orange CTA
+  (existing convention); a disabled control must **look** disabled (never render
+  a disabled action in the enabled/active color) and, where non-obvious, carry a
+  one-line plain-language reason.
+
+---
+
+## 7. Layout & the 1280×720 budget
+
+- Chrome (TopBar + NavRail) is fixed; the room body flexes. Reviewer height after
+  chrome is ~660px — design the tallest state to fit it.
+- **Exactly one scroll region per room** — the `RoomFrame` body (or a single
+  designated list well inside it). The page itself never scrolls horizontally and
+  never scrolls vertically at the document level.
+- When a room's own interior already provides a title/toolbar (Full Cap Table,
+  Roster), use `hideHeader` + `bleed` and hand those pixels to content. One-line
+  title/banner strips over stacked headers.
+- Verify fit, don't assume it: check `scrollHeight <= clientHeight` on
+  `[data-testid="cockpit-room-frame-body"]` at 1280×720 with realistic seeded
+  data before calling a state finished.
+
+---
+
+## 8. State treatments
+
+Every room must define — and every review must show — all applicable states.
+
+| State | Treatment |
+| --- | --- |
+| **Pass / healthy** | Neutral surface + `safe` accent only where a value is affirmatively good. No green wash. |
+| **Blocked** | `danger` marker/label with a plain-language reason. A blocked state must never read as success (no orange/green CTA, no "done" affordance). This is a guarded promise — see §9. |
+| **Warning** | `watch` marker/label; the action is still allowed but flagged (over cap/tax). Distinct from blocked. |
+| **Empty** | An intentional, composed empty state: what belongs here, why it's empty, and the next move — using `text-ghost` slots/outlines, not a blank void. Empty-slot outlines (open roster spots) are drawn, labeled, and counted. |
+| **Loading** | A quiet skeleton on the real layout (slab placeholders at final positions), not a spinner on a blank page and not a layout that jumps when data lands. |
+
+---
+
+## 9. Honesty & guarded promises
+
+Some copy/structure is pinned by tests because it encodes a product promise, not
+a design choice. A better design may change the wording or layout of these, but
+**the intent must survive** and the test moves with the design:
+
+- A blocked/illegal state can never be styled or worded to read as success.
+- Required honesty disclosures (preview/world-gating markers, apply-only gates)
+  stay present and legible — restyle them, don't delete them.
+- No implied guarantee the engine doesn't back (a "(Preview)" marker stays a
+  preview marker).
+
+Never ship a worse design *around* a pinned string and file it as a "known
+weakness." Update the test with the work; only the owner changes the underlying
+promise.
+
+---
+
+## 10. Wave judging checklist (adversarial self-review)
+
+Before any wave goes to the owner, render **every** state at 1280×720 with
+realistic seeded data and confirm — as a hostile design critic — none of these
+survive:
+
+- [ ] Page-level clipping or scroll at 1280×720; body-region overflow.
+- [ ] Off-scale type, ad-hoc hex/opacity instead of `cockpit-*` tokens.
+- [ ] Box-in-box nesting deeper than two elevation steps.
+- [ ] Misaligned baselines / non-`tabular-nums` numeric columns that jitter.
+- [ ] Team color used as a fill/wash instead of a narrow accent.
+- [ ] A disabled control rendered in an enabled color; a blocked state that reads
+      as success.
+- [ ] Banned internal vocabulary or raw IDs on a visible surface.
+- [ ] A blank/void empty state; a loading state that jumps.
+- [ ] More than one hero (Surface-title) or competing saturated chips in a row.
+- [ ] Any state the owner would obviously demand fixed. If one exists, the
+      self-review failed — fix it before review, don't list it as a weakness.
+
+---
+
+## Change control
+
+Changing this standard changes what "finished" means for every future wave.
+Update it deliberately: state what changed and why in the commit, and re-judge
+open waves against the new version. The token file
+(`cockpitTokens.ts` / `tailwind.config.js`) remains the source of truth for exact
+values; this doc is the intent and the rules around them.

--- a/src/features/architect/GMDashboard/sections/GuideSection.tsx
+++ b/src/features/architect/GMDashboard/sections/GuideSection.tsx
@@ -65,17 +65,20 @@ const FAMILY_ORDER: Stage4QuestionFamily[] = [
 ];
 
 const SEVERITY_CLASS: Record<Stage4Severity, string> = {
-  info: 'border-white/10 bg-white/[0.02]',
-  success: 'border-green-400/30 bg-green-500/5',
-  warning: 'border-amber-300/30 bg-amber-400/5',
-  danger: 'border-rose-400/30 bg-rose-500/5',
+  info: 'border-cockpit-edge bg-cockpit-slab',
+  success: 'border-cockpit-safe/30 bg-cockpit-safe/[0.06]',
+  warning: 'border-cockpit-watch/30 bg-cockpit-watch/[0.06]',
+  danger: 'border-cockpit-danger/30 bg-cockpit-danger/[0.06]',
 };
 
+// Title tint only — the body copy stays neutral for readability. State is
+// carried by the card border and the status chip, not by washing the whole
+// card in a status color.
 const SEVERITY_TEXT: Record<Stage4Severity, string> = {
-  info: 'text-white/70',
-  success: 'text-green-200',
-  warning: 'text-amber-200',
-  danger: 'text-rose-200',
+  info: 'text-cockpit-text-primary',
+  success: 'text-cockpit-safe',
+  warning: 'text-cockpit-watch',
+  danger: 'text-cockpit-danger',
 };
 
 const STATUS_LABEL: Record<Stage4AnswerStatus, string> = {
@@ -86,17 +89,17 @@ const STATUS_LABEL: Record<Stage4AnswerStatus, string> = {
 };
 
 const STATUS_CHIP_CLASS: Record<Stage4AnswerStatus, string> = {
-  available: 'bg-green-500/10 text-green-200 border-green-400/30',
-  partial: 'bg-amber-400/10 text-amber-200 border-amber-300/30',
-  deferred: 'bg-white/10 text-white/60 border-white/20',
-  unavailable: 'bg-white/5 text-white/40 border-white/10',
+  available: 'bg-cockpit-safe/10 text-cockpit-safe border-cockpit-safe/30',
+  partial: 'bg-cockpit-watch/10 text-cockpit-watch border-cockpit-watch/30',
+  deferred: 'bg-white/5 text-cockpit-text-muted border-cockpit-edge',
+  unavailable: 'bg-white/5 text-cockpit-text-ghost border-cockpit-edge',
 };
 
 const CHIP_SEVERITY_CLASS: Record<Stage4Severity, string> = {
-  info: 'bg-white/5 text-white/70 border-white/10',
-  success: 'bg-green-500/10 text-green-200 border-green-400/30',
-  warning: 'bg-amber-400/10 text-amber-200 border-amber-300/30',
-  danger: 'bg-rose-500/10 text-rose-200 border-rose-400/30',
+  info: 'bg-cockpit-inlay text-cockpit-text-secondary border-cockpit-edge',
+  success: 'bg-cockpit-safe/10 text-cockpit-safe border-cockpit-safe/30',
+  warning: 'bg-cockpit-watch/10 text-cockpit-watch border-cockpit-watch/30',
+  danger: 'bg-cockpit-danger/10 text-cockpit-danger border-cockpit-danger/30',
 };
 
 const AUTHORITY_LABEL_TEXT: Record<Stage4AuthorityLabel, string> = {
@@ -119,7 +122,7 @@ const formatAuthorityLabel = (label: string) =>
 // ---------------------------------------------------------------------------
 
 const AuthorityChip = ({ label }: { label: string }) => (
-  <span className="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded border bg-white/5 text-white/40 border-white/10 uppercase tracking-wide">
+  <span className="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded border bg-cockpit-inlay text-cockpit-text-muted border-cockpit-edge uppercase tracking-wide">
     {formatAuthorityLabel(label)}
   </span>
 );
@@ -164,7 +167,7 @@ const BlockingConstraintPill = ({
 
 const DeferredReasonRow = ({ reason }: { reason: Stage4DeferredReason }) => (
   <li
-    className="text-xs text-white/50"
+    className="text-xs text-cockpit-text-muted"
     data-testid="guide-deferred-reason"
   >
     <span>{reason.reason}</span>{' '}
@@ -181,7 +184,7 @@ const NavigationButton = ({ target, onNavigate }: NavigationButtonProps) => (
   <button
     type="button"
     onClick={() => onNavigate(target.id)}
-    className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
+    className="text-xs px-2.5 py-1 rounded border border-cockpit-edge bg-cockpit-slab hover:bg-cockpit-raised text-cockpit-text-secondary hover:text-cockpit-text-primary transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-cockpit-info/50"
     data-testid={`guide-nav-${target.id}`}
     title="Navigation only — opens the existing surface"
     aria-label={`${target.label} (navigation only)`}
@@ -209,7 +212,7 @@ const AnswerCard = ({
     </div>
 
     <p
-      className={`text-xs ${SEVERITY_TEXT[answer.severity]}`}
+      className="text-xs text-cockpit-text-secondary"
       data-testid="guide-short-answer"
     >
       {answer.shortAnswer}
@@ -274,7 +277,7 @@ const FamilyGroup = ({
       className="space-y-2"
       data-testid={`guide-family-${family}`}
     >
-      <h3 className="text-xs font-semibold text-white/50 uppercase tracking-wider">
+      <h3 className="text-xs font-extrabold text-cockpit-text-muted uppercase tracking-wide">
         {FAMILY_LABELS[family]}
       </h3>
       <div className="space-y-2">
@@ -309,13 +312,13 @@ export const GuideSection: React.FC<GuideSectionProps> = ({
   if (!viewModel.scope.teamCode) {
     return (
       <div
-        className="rounded-md border border-white/10 bg-white/[0.015] px-4 py-6 text-center space-y-2"
+        className="rounded-md border border-cockpit-edge bg-cockpit-slab px-4 py-6 text-center space-y-2"
         data-testid="guide-unavailable-state"
       >
-        <p className="text-sm font-semibold text-white/60">
+        <p className="text-sm font-semibold text-cockpit-text-secondary">
           Guide is unavailable
         </p>
-        <p className="text-xs text-white/40">
+        <p className="text-xs text-cockpit-text-muted">
           {viewModel.status.workspaceError ||
             'Active team identity is not available.'}
         </p>
@@ -337,31 +340,31 @@ export const GuideSection: React.FC<GuideSectionProps> = ({
   return (
     <div className="space-y-4" data-testid="guide-section">
       <header
-        className="rounded-md border border-white/10 bg-white/[0.015] px-4 py-3 space-y-1"
+        className="rounded-md border border-cockpit-edge bg-cockpit-slab px-4 py-3 space-y-1"
         data-testid="guide-scope"
       >
         <div className="flex flex-wrap items-baseline gap-2">
-          <h2 className="text-sm font-semibold text-white/80">
+          <h2 className="text-sm font-semibold text-cockpit-text-primary">
             Front Office Guide
           </h2>
-          <span className="text-[11px] text-white/40">
-            Read-only · Deterministic · Navigation only
+          <span className="text-[11px] text-cockpit-text-muted">
+            Read-only · Navigation only
           </span>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <AuthorityChip
             label={viewModel.scope.sandbox ? 'Sandbox' : 'Committed world'}
           />
-          <span className="text-sm font-semibold text-white/80">
+          <span className="text-sm font-semibold text-cockpit-text-primary">
             {viewModel.scope.teamCode}
           </span>
           {viewModel.scope.season && (
-            <span className="text-xs text-white/40">
+            <span className="text-xs text-cockpit-text-muted">
               Season {viewModel.scope.season}
             </span>
           )}
           {viewModel.scope.sandbox && (
-            <span className="text-xs text-white/40 italic">
+            <span className="text-xs text-cockpit-text-muted italic">
               Scenario answers require an active world.
             </span>
           )}
@@ -370,16 +373,16 @@ export const GuideSection: React.FC<GuideSectionProps> = ({
 
       {objective ? (
         <div
-          className="rounded-md border border-sky-400/25 bg-sky-500/5 px-4 py-2"
+          className="rounded-md border border-cockpit-info/25 bg-cockpit-info/[0.06] px-4 py-2"
           data-testid="guide-objective-banner"
         >
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
-              <span className="text-[10px] font-semibold uppercase tracking-wide text-sky-300/80">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-cockpit-info">
                 Objective
               </span>
               <span
-                className="text-sm font-semibold text-white/85"
+                className="text-sm font-semibold text-cockpit-text-primary"
                 data-testid="guide-objective-text"
               >
                 {objective}
@@ -396,7 +399,7 @@ export const GuideSection: React.FC<GuideSectionProps> = ({
                     })
                   )
                 }
-                className="text-xs px-2.5 py-1 rounded border border-white/10 bg-white/5 hover:bg-white/10 text-white/70 hover:text-white/90 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
+                className="text-xs px-2.5 py-1 rounded border border-cockpit-edge bg-cockpit-slab hover:bg-cockpit-raised text-cockpit-text-secondary hover:text-cockpit-text-primary transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-cockpit-info/50"
                 data-testid="guide-objective-open-trade"
               >
                 Open Trade

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
@@ -51,6 +51,10 @@ export const FreeAgentRow = ({
   // The pool list is a scroll container, so a downward menu on the last
   // visible rows would clip. Flip upward when the space below is short.
   const [menuOpensUp, setMenuOpensUp] = useState(false);
+  // Review/fictional players have no headshot file. On fallback, render the
+  // placeholder as a clean centered avatar (contain, not cover) so every
+  // no-photo row is uniform instead of cropping the silhouette inconsistently.
+  const [headshotFallback, setHeadshotFallback] = useState(false);
 
   useEffect(() => {
     if (openMenuSelectionKey === entry.selectionKey) {
@@ -169,10 +173,14 @@ export const FreeAgentRow = ({
             }.png`
           }
           onError={(e) => {
-            e.currentTarget.onerror = null; e.currentTarget.src = '/assets/headshots/default.png';
+            e.currentTarget.onerror = null;
+            e.currentTarget.src = '/assets/headshots/default.png';
+            setHeadshotFallback(true);
           }}
           alt={formattedName}
-          className="h-full w-full object-cover"
+          className={`h-full w-full ${
+            headshotFallback ? 'object-contain p-1 opacity-70' : 'object-cover'
+          }`}
         />
       </div>
 

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
@@ -51,10 +51,6 @@ export const FreeAgentRow = ({
   // The pool list is a scroll container, so a downward menu on the last
   // visible rows would clip. Flip upward when the space below is short.
   const [menuOpensUp, setMenuOpensUp] = useState(false);
-  // Review/fictional players have no headshot file. On fallback, render the
-  // placeholder as a clean centered avatar (contain, not cover) so every
-  // no-photo row is uniform instead of cropping the silhouette inconsistently.
-  const [headshotFallback, setHeadshotFallback] = useState(false);
 
   useEffect(() => {
     if (openMenuSelectionKey === entry.selectionKey) {
@@ -157,8 +153,19 @@ export const FreeAgentRow = ({
         )}
       </div>
 
-      {/* Headshot */}
-      <div className="flex h-[43px] w-[50px] items-center justify-center overflow-hidden bg-cockpit-inlay">
+      {/* Headshot — a uniform silhouette sits behind every cell; a real photo
+          loads on top and covers it, and a missing photo (review fixtures) just
+          falls through to the same silhouette, so every no-photo row matches. */}
+      <div className="relative flex h-[43px] w-[50px] shrink-0 items-center justify-center overflow-hidden bg-cockpit-inlay">
+        <svg
+          viewBox="0 0 50 43"
+          className="absolute inset-0 h-full w-full text-white/20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <circle cx="25" cy="15" r="9.5" />
+          <path d="M7 43c0-10.5 8-16.5 18-16.5s18 6 18 16.5z" />
+        </svg>
         <img
           src={
             player.headshotUrl ||
@@ -173,14 +180,10 @@ export const FreeAgentRow = ({
             }.png`
           }
           onError={(e) => {
-            e.currentTarget.onerror = null;
-            e.currentTarget.src = '/assets/headshots/default.png';
-            setHeadshotFallback(true);
+            e.currentTarget.style.display = 'none';
           }}
           alt={formattedName}
-          className={`h-full w-full ${
-            headshotFallback ? 'object-contain p-1 opacity-70' : 'object-cover'
-          }`}
+          className="relative h-full w-full object-cover"
         />
       </div>
 

--- a/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/FreeAgentRow.tsx
@@ -133,12 +133,12 @@ export const FreeAgentRow = ({
       }`}
     >
       {/* Position */}
-      <div className="w-[45px] flex items-center justify-center text-white/60 text-sm font-semibold">
+      <div className="w-[45px] shrink-0 flex items-center justify-center text-white/60 text-sm font-semibold">
         {position}
       </div>
 
       {/* Team Logo */}
-      <div className="w-[50px] flex items-center justify-center ml-1">
+      <div className="w-[50px] shrink-0 flex items-center justify-center ml-1">
         {player.teamCode && (
           <img
             src={`/assets/logos/${
@@ -188,18 +188,18 @@ export const FreeAgentRow = ({
       </div>
 
       {/* Name + Rights */}
-      <div className="flex items-center ml-3 flex-1 justify-between mr-2">
+      <div className="flex min-w-0 items-center ml-3 flex-1 justify-between mr-2">
         <div
-          className="flex items-center text-white font-anton font-bold uppercase tracking-normal leading-none whitespace-nowrap overflow-visible"
+          className="flex min-w-0 items-center text-white font-anton font-bold uppercase tracking-normal leading-none whitespace-nowrap"
           style={{ fontSize: '17px', maxWidth: '300px' }}
         >
-          <span>
+          <span className="truncate">
             {firstName}{' '}
             <span className="text-white/70 font-light">{lastName}</span>
           </span>
           {age && (
             <span
-              className="text-white/50 font-light ml-2"
+              className="shrink-0 text-white/50 font-light ml-2"
               style={{ fontSize: '12px' }}
             >
               ({age})
@@ -208,7 +208,7 @@ export const FreeAgentRow = ({
         </div>
         <div
           data-testid="free-agent-row-signing-context"
-          className="ml-3 flex min-w-[220px] max-w-[290px] items-center justify-end gap-1.5 overflow-hidden whitespace-nowrap text-[10px]"
+          className="ml-3 flex min-w-[120px] max-w-[290px] shrink-0 items-center justify-end gap-1.5 overflow-hidden whitespace-nowrap text-[10px]"
         >
           <span className="min-w-0 truncate rounded-sm border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-white/70">
             {signingContext.rightsLabel}
@@ -226,7 +226,7 @@ export const FreeAgentRow = ({
       </div>
 
       {/* Aligned Stats Block */}
-      <div className="flex items-center justify-end text-white/50 text-[13px] w-[290px] mr-3 whitespace-nowrap tabular-nums">
+      <div className="flex shrink-0 items-center justify-end text-white/50 text-[13px] w-[290px] mr-3 whitespace-nowrap tabular-nums">
         {/* FA Type */}
         <span
           className={`w-[44px] text-center px-1.5 py-[2px] rounded text-[12px] font-semibold ${getTagColor(faType)}`}
@@ -248,7 +248,7 @@ export const FreeAgentRow = ({
       </div>
 
       {/* Options */}
-      <div className="flex items-center relative">
+      <div className="flex shrink-0 items-center relative">
         <button
           ref={buttonRef}
           onClick={(e) => {

--- a/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
+++ b/src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
@@ -1,8 +1,9 @@
 /**
  * FILE: src/features/architect/freeAgency/FreeAgentPool/SelectedFreeAgentCards.tsx
  * PURPOSE: Selected free-agent decision deck docked between the filters and the
- *          pool list. Fixed-height region so the pool always stays on screen at
- *          the 1280×720 review viewport; overflows internally beyond two rows.
+ *          pool list. Collapsible + fixed-height so the pool always stays on
+ *          screen at the 1280×720 review viewport; overflows internally beyond
+ *          two rows, and can be hidden entirely to hand its space to the pool.
  * OWNERSHIP: Feature: architect/freeAgency
  */
 import React from 'react';
@@ -29,25 +30,68 @@ export const SelectedFreeAgentCards = ({
   isPreviewSigning = false,
   exposureClassification = 'preview-only',
 }: SelectedFreeAgentCardsProps) => {
+  const [collapsed, setCollapsed] = React.useState(false);
+
   if (selectedEntries.length === 0) return null;
+  const count = selectedEntries.length;
 
   return (
     <div
       data-testid="selected-free-agent-deck"
-      className="mb-2 max-h-[236px] shrink-0 overflow-y-auto rounded-md border border-cockpit-info/25 bg-white/[0.03] p-2"
+      className="mb-2 shrink-0 overflow-hidden rounded-md border border-cockpit-info/25 bg-white/[0.03]"
     >
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-2">
-        {selectedEntries.map((entry) => (
-          <FreeAgentCard
-            key={entry.selectionKey}
-            entry={entry}
-            onOpenContractModal={onOpenContractModal}
-            onRemove={onRemove}
-            isPreviewSigning={isPreviewSigning}
-            exposureClassification={exposureClassification}
-          />
-        ))}
+      <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
+        <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-cockpit-text-secondary">
+          <span>Selected Free Agents</span>
+          <span className="rounded-full border border-cockpit-info/30 bg-cockpit-info/10 px-1.5 text-cockpit-info tabular-nums">
+            {count}
+          </span>
+        </div>
+        <button
+          type="button"
+          data-testid="selected-free-agent-deck-toggle"
+          aria-expanded={!collapsed}
+          aria-label={
+            collapsed ? 'Show selected free agents' : 'Hide selected free agents'
+          }
+          onClick={() => setCollapsed((prev) => !prev)}
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-cockpit-text-secondary transition-colors hover:bg-white/5 hover:text-cockpit-text-primary"
+        >
+          {collapsed ? 'Show' : 'Hide'}
+          <svg
+            viewBox="0 0 12 12"
+            aria-hidden="true"
+            className={`h-3 w-3 transition-transform duration-150 ${
+              collapsed ? '' : 'rotate-180'
+            }`}
+          >
+            <path
+              d="M2.5 4.5 6 8l3.5-3.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
       </div>
+      {collapsed ? null : (
+        <div className="max-h-[236px] overflow-y-auto px-2 pb-2">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-2">
+            {selectedEntries.map((entry) => (
+              <FreeAgentCard
+                key={entry.selectionKey}
+                entry={entry}
+                onOpenContractModal={onOpenContractModal}
+                onRemove={onRemove}
+                isPreviewSigning={isPreviewSigning}
+                exposureClassification={exposureClassification}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/architect/guidedQuestions/answerNavigation.ts
+++ b/src/features/architect/guidedQuestions/answerNavigation.ts
@@ -70,7 +70,7 @@ export function buildNavigationHistoryAnswer(): Stage4GuidedAnswer {
 export function buildNavigationComparisonAnswer(): Stage4GuidedAnswer {
   return staticNavAnswer(
     'navigation-comparison',
-    'Compare shows committed scenario deltas (rosters, cap, apron posture) for the active world.',
+    'Compare shows committed scenario deltas (rosters, cap, apron standing) for the active world.',
     'Scenario deltas → Compare',
     { id: 'compare', label: 'Open Compare', intent: 'navigate' }
   );

--- a/src/features/architect/guidedQuestions/answerTeamStatus.ts
+++ b/src/features/architect/guidedQuestions/answerTeamStatus.ts
@@ -64,8 +64,8 @@ export function buildCapPostureAnswer(
       status: 'unavailable',
       shortAnswer:
         cap.status === 'loading'
-          ? 'Cap posture is loading.'
-          : 'Cap posture is unavailable.',
+          ? 'Cap situation is loading.'
+          : 'Cap situation is unavailable.',
       evidence: [],
       authorityLabels:
         cap.status === 'loading'

--- a/src/features/architect/guidedQuestions/questionCatalog.ts
+++ b/src/features/architect/guidedQuestions/questionCatalog.ts
@@ -21,7 +21,7 @@ export const STAGE4_QUESTION_CATALOG: readonly Stage4QuestionCatalogEntry[] = [
   // Family A — Team Status
   {
     id: 'cap-posture',
-    title: 'What is our current cap posture?',
+    title: 'What is our current cap situation?',
     family: 'team-status',
     relatedQuestionIds: ['current-constraints', 'exceptions-available'],
   },

--- a/src/features/architect/shared/RosterVisual/RosterVisual.tsx
+++ b/src/features/architect/shared/RosterVisual/RosterVisual.tsx
@@ -448,12 +448,30 @@ export const RosterVisual = ({
     };
   }, [onPlayerAction, pinnedPlayerIds]);
 
-  if (!roster || !rosterState) return null;
-
   const displayName = String(
     teamInfo.nickname || teamInfo.teamName || teamCapSheet?.teamName || id);
   const teamKey = getTeamLogoFilename(id || displayName);
   const { primary, secondary } = getTeamColors(teamKey);
+
+  if (!roster || !rosterState) {
+    return (
+      <div
+        className="flex h-full min-h-0 w-full flex-col items-center justify-center bg-cockpit-void p-3 text-cockpit-text-primary"
+        data-testid="architect-roster-empty"
+      >
+        <div className="w-full max-w-sm rounded-lg border border-cockpit-edge bg-cockpit-slab px-5 py-6 text-center shadow-cockpit-slab">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-cockpit-text-secondary">
+            {displayName ? `${displayName} Roster` : 'Team Roster'}
+          </h2>
+          <p className="mt-2 text-xs text-cockpit-text-muted">
+            No roster loaded yet. Choose a team plan to see its starting five,
+            rotation, and bench here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   const seasonLabel = formatSeasonLabel(rosterState.activeYear);
   const openStandardSlots = Math.max(
     0,
@@ -493,11 +511,11 @@ export const RosterVisual = ({
 
   return (
     <div
-      className="flex h-full min-h-0 w-full flex-col overflow-hidden p-2.5 text-white"
+      className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-cockpit-void p-3 text-cockpit-text-primary"
       style={rosterSurfaceStyle}
     >
       <section
-        className="relative shrink-0 overflow-hidden rounded-lg border border-white/10 bg-cockpit-slab shadow-cockpit-slab"
+        className="relative shrink-0 overflow-hidden rounded-lg border border-cockpit-edge bg-cockpit-slab shadow-cockpit-slab"
         aria-label="Roster overview"
       >
         <div
@@ -507,17 +525,17 @@ export const RosterVisual = ({
             background: `linear-gradient(90deg, ${primary}, ${secondary})`,
           }}
         />
-        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5 px-3 py-2">
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5 px-3.5 py-2.5">
           <div className="flex min-w-0 items-center gap-2.5">
             {displayName ? (
               <img
                 src={`/assets/logos/${teamKey}.png`}
                 alt=""
-                className="h-9 w-9 shrink-0 rounded-md border border-white/10 bg-black/30 object-contain p-1"
+                className="h-9 w-9 shrink-0 rounded-md border border-cockpit-edge bg-cockpit-inlay object-contain p-1"
               />
             ) : null}
             <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5">
-              <h2 className="truncate text-lg font-black uppercase leading-tight tracking-wide text-white">
+              <h2 className="truncate text-lg font-black uppercase leading-tight tracking-wide text-cockpit-text-primary">
                 {displayName}
               </h2>
               <p className="whitespace-nowrap text-[11px] text-cockpit-text-secondary">
@@ -531,12 +549,12 @@ export const RosterVisual = ({
               <div
                 key={tile.label}
                 title={tile.detail}
-                className="flex items-baseline gap-1.5 rounded-md border border-white/10 bg-black/20 px-2.5 py-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]"
+                className="flex items-baseline gap-1.5 rounded-md border border-cockpit-edge bg-cockpit-inlay px-2.5 py-1.5"
               >
-                <span className="text-[9px] font-semibold uppercase tracking-wider text-white/40">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-cockpit-text-muted">
                   {tile.label}
                 </span>
-                <span className="text-sm font-extrabold leading-none text-white tabular-nums">
+                <span className="text-sm font-extrabold leading-none text-cockpit-text-primary tabular-nums">
                   {tile.value}
                 </span>
               </div>
@@ -560,20 +578,20 @@ export const RosterVisual = ({
         data-roster-unsupported-categories="fa,expired,waived,options"
       />
 
-      <div className="mt-2 flex min-h-0 flex-1 flex-col justify-between gap-1.5 overflow-auto rounded-lg border border-white/10 bg-[#070A0F] px-2.5 py-2 shadow-cockpit-slab">
+      <div className="mt-2.5 flex min-h-0 flex-1 flex-col justify-between gap-2 overflow-auto rounded-lg border border-cockpit-edge bg-cockpit-inlay px-2.5 py-2.5">
         {rosterBands.map((band) => {
           const count = rosterState.sectionCounts[band.key];
           return (
             <section
               key={band.key}
               aria-label={`${band.label} roster group`}
-              className="rounded-lg border border-white/10 bg-white/[0.035] px-2 pb-1.5 pt-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]"
+              className="rounded-lg border border-cockpit-edge bg-cockpit-slab px-2.5 pb-1.5 pt-1.5"
             >
               <div className="mb-1 flex flex-wrap items-baseline gap-x-2 px-1">
-                <h3 className="text-xs font-extrabold uppercase tracking-wide text-white">
+                <h3 className="text-xs font-extrabold uppercase tracking-wide text-cockpit-text-primary">
                   {band.label}
                 </h3>
-                <p className="text-[10px] text-cockpit-text-secondary">
+                <p className="text-[10px] text-cockpit-text-muted">
                   {band.detail} · {count} {count === 1 ? 'player' : 'players'}
                 </p>
               </div>

--- a/src/features/architect/shared/RosterVisual/RosterVisual.tsx
+++ b/src/features/architect/shared/RosterVisual/RosterVisual.tsx
@@ -578,14 +578,14 @@ export const RosterVisual = ({
         data-roster-unsupported-categories="fa,expired,waived,options"
       />
 
-      <div className="mt-2.5 flex min-h-0 flex-1 flex-col justify-between gap-2 overflow-auto rounded-lg border border-cockpit-edge bg-cockpit-inlay px-2.5 py-2.5">
+      <div className="mt-2.5 flex min-h-0 flex-1 flex-col justify-start gap-2 overflow-auto rounded-lg border border-cockpit-edge bg-cockpit-inlay px-2.5 py-2.5">
         {rosterBands.map((band) => {
           const count = rosterState.sectionCounts[band.key];
           return (
             <section
               key={band.key}
               aria-label={`${band.label} roster group`}
-              className="rounded-lg border border-cockpit-edge bg-cockpit-slab px-2.5 pb-1.5 pt-1.5"
+              className="shrink-0 rounded-lg border border-cockpit-edge bg-cockpit-slab px-2.5 pb-1.5 pt-1.5"
             >
               <div className="mb-1 flex flex-wrap items-baseline gap-x-2 px-1">
                 <h3 className="text-xs font-extrabold uppercase tracking-wide text-cockpit-text-primary">
@@ -596,16 +596,26 @@ export const RosterVisual = ({
                 </p>
               </div>
 
-              <RosterSection
-                players={roster[band.key]}
-                section={band.key}
-                {...LEGACY_ROSTER_DISPLAY_ONLY_PROPS}
-                previewSpacing
-                variant="architect"
-                onSelectPlayer={handleSectionSelect}
-                isPlayerHighlighted={sectionHighlightMatcher}
-                renderPlayerMenu={renderPlayerMenu}
-              />
+              {count === 0 ? (
+                <div
+                  data-roster-empty-band={band.key}
+                  data-testid={`roster-empty-band-${band.key}`}
+                  className="flex items-center justify-center rounded-md border border-dashed border-cockpit-edge px-3 py-3 text-[11px] text-cockpit-text-ghost"
+                >
+                  No {band.label.toLowerCase()} players yet — open slots
+                </div>
+              ) : (
+                <RosterSection
+                  players={roster[band.key]}
+                  section={band.key}
+                  {...LEGACY_ROSTER_DISPLAY_ONLY_PROPS}
+                  previewSpacing
+                  variant="architect"
+                  onSelectPlayer={handleSectionSelect}
+                  isPlayerHighlighted={sectionHighlightMatcher}
+                  renderPlayerMenu={renderPlayerMenu}
+                />
+              )}
             </section>
           );
         })}

--- a/src/features/roster/RosterSection/BenchCard.tsx
+++ b/src/features/roster/RosterSection/BenchCard.tsx
@@ -109,7 +109,7 @@ export const BenchCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-[3px] top-[3px] rounded border border-white/10 bg-black/60 px-1 py-0.5 text-[9px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-[3px] top-[3px] flex h-[16px] w-[24px] items-center justify-center rounded border border-white/10 bg-black/60 text-[9px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[12px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >

--- a/src/features/roster/RosterSection/BenchCard.tsx
+++ b/src/features/roster/RosterSection/BenchCard.tsx
@@ -109,13 +109,15 @@ export const BenchCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-1.5 top-1.5 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-[3px] top-[3px] rounded border border-white/10 bg-black/60 px-1 py-0.5 text-[9px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[12px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >
-            {getPlayerPositionLabel(
-              player.bio?.position || player.formattedPosition
-            )}
+            {(
+              getPlayerPositionLabel(
+                player.bio?.position || player.formattedPosition
+              ) || ''
+            ).replace(/-/g, '/')}
           </div>
         </div>
         <div
@@ -135,7 +137,7 @@ export const BenchCard = ({
       </div>
       {menuSlot ? (
         <div
-          className="absolute right-1.5 top-1.5 z-30"
+          className="absolute right-[3px] top-[3px] z-30"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >

--- a/src/features/roster/RosterSection/BenchCard.tsx
+++ b/src/features/roster/RosterSection/BenchCard.tsx
@@ -109,7 +109,7 @@ export const BenchCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-2 top-2 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-1.5 top-1.5 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[12px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >
@@ -135,7 +135,7 @@ export const BenchCard = ({
       </div>
       {menuSlot ? (
         <div
-          className="absolute right-0 top-0 z-30"
+          className="absolute right-1.5 top-1.5 z-30"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >

--- a/src/features/roster/RosterSection/RotationCard.tsx
+++ b/src/features/roster/RosterSection/RotationCard.tsx
@@ -109,7 +109,7 @@ export const RotationCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-[3px] top-[3px] rounded border border-white/10 bg-black/60 px-1 py-0.5 text-[9px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-[3px] top-[3px] flex h-[16px] w-[24px] items-center justify-center rounded border border-white/10 bg-black/60 text-[9px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[14px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >

--- a/src/features/roster/RosterSection/RotationCard.tsx
+++ b/src/features/roster/RosterSection/RotationCard.tsx
@@ -109,13 +109,15 @@ export const RotationCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-1.5 top-1.5 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-[3px] top-[3px] rounded border border-white/10 bg-black/60 px-1 py-0.5 text-[9px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[14px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >
-            {getPlayerPositionLabel(
-              player.bio?.position || player.formattedPosition
-            )}
+            {(
+              getPlayerPositionLabel(
+                player.bio?.position || player.formattedPosition
+              ) || ''
+            ).replace(/-/g, '/')}
           </div>
         </div>
         <div
@@ -135,7 +137,7 @@ export const RotationCard = ({
       </div>
       {menuSlot ? (
         <div
-          className="absolute right-1.5 top-1.5 z-30"
+          className="absolute right-[3px] top-[3px] z-30"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >

--- a/src/features/roster/RosterSection/RotationCard.tsx
+++ b/src/features/roster/RosterSection/RotationCard.tsx
@@ -109,7 +109,7 @@ export const RotationCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-2 top-2 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-1.5 top-1.5 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[14px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >
@@ -135,7 +135,7 @@ export const RotationCard = ({
       </div>
       {menuSlot ? (
         <div
-          className="absolute right-0 top-0 z-30"
+          className="absolute right-1.5 top-1.5 z-30"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >

--- a/src/features/roster/RosterSection/StarterCard.tsx
+++ b/src/features/roster/RosterSection/StarterCard.tsx
@@ -109,7 +109,7 @@ export const StarterCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-2 top-2 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-1.5 top-1.5 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[16px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >
@@ -135,7 +135,7 @@ export const StarterCard = ({
       </div>
       {menuSlot ? (
         <div
-          className="absolute right-0 top-0 z-30"
+          className="absolute right-1.5 top-1.5 z-30"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >

--- a/src/features/roster/RosterSection/StarterCard.tsx
+++ b/src/features/roster/RosterSection/StarterCard.tsx
@@ -109,13 +109,15 @@ export const StarterCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-1.5 top-1.5 rounded border border-white/10 bg-black/60 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-[3px] top-[3px] rounded border border-white/10 bg-black/60 px-1 py-0.5 text-[10px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[16px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >
-            {getPlayerPositionLabel(
-              player.bio?.position || player.formattedPosition
-            )}
+            {(
+              getPlayerPositionLabel(
+                player.bio?.position || player.formattedPosition
+              ) || ''
+            ).replace(/-/g, '/')}
           </div>
         </div>
         <div
@@ -135,7 +137,7 @@ export const StarterCard = ({
       </div>
       {menuSlot ? (
         <div
-          className="absolute right-1.5 top-1.5 z-30"
+          className="absolute right-[3px] top-[3px] z-30"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >

--- a/src/features/roster/RosterSection/StarterCard.tsx
+++ b/src/features/roster/RosterSection/StarterCard.tsx
@@ -109,7 +109,7 @@ export const StarterCard = ({
           <div
             className={
               isArchitect
-                ? 'absolute left-[3px] top-[3px] rounded border border-white/10 bg-black/60 px-1 py-0.5 text-[10px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
+                ? 'absolute left-[3px] top-[3px] flex h-[17px] w-[26px] items-center justify-center rounded border border-white/10 bg-black/60 text-[10px] font-bold uppercase tracking-normal text-white/80 shadow-sm backdrop-blur'
                 : `absolute top-1 left-1 px-1 py-[2px] bg-black/00 text-white/40 text-[16px] ${isExport ? 'font-normal' : 'font-semibold'} uppercase rounded-sm tracking-wider shadow-md`
             }
           >

--- a/src/tests/architect/rosterVisual.adapterBoundary.test.tsx
+++ b/src/tests/architect/rosterVisual.adapterBoundary.test.tsx
@@ -271,10 +271,13 @@ describe('RosterVisual adapter boundary', () => {
     const { container } = renderRoster(teamCapSheet);
     const starters = getRosterSection(container, 'starters');
     const rotation = getRosterSection(container, 'rotation');
-    const bench = getRosterSection(container, 'bench');
 
     expect(within(starters).getAllByRole('img')).toHaveLength(5);
     expect(within(rotation).getAllByRole('img')).toHaveLength(1);
+    // An empty band renders a composed display-only placeholder ("open slots")
+    // instead of an empty legacy grid — still no phantom player cards and no
+    // add/remove controls (the display-only guarantee this test protects).
+    const bench = screen.getByTestId('roster-empty-band-bench');
     expect(within(bench).queryAllByRole('img')).toHaveLength(0);
     const truthPanel = screen.getByTestId('architect-roster-truth-panel');
     expect(truthPanel).toHaveAttribute('data-roster-displayed-count', '6');

--- a/src/tests/architect/stage5.polish.test.tsx
+++ b/src/tests/architect/stage5.polish.test.tsx
@@ -335,7 +335,7 @@ describe('GuideSection (Stage 5A polish)', () => {
     render(<GuideSection viewModel={vm} onNavigate={() => undefined} />);
     expect(screen.getByText('Front Office Guide')).toBeInTheDocument();
     expect(
-      screen.getByText(/Read-only · Deterministic · Navigation only/i)
+      screen.getByText(/Read-only · Navigation only/i)
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Refs BZE-228

Branch-mode Architect UI wave under the Owner Review Model. **Stays off main until owner approval** — do not merge without owner sign-off on the review artifact.

## What's here
1. **Durable visual standard** — `docs/standards/ARCHITECT_VISUAL_STANDARD.md`. The house visual identity (elevation/surfaces, color/tone, type scale, spacing, component vocabulary, state treatments, honesty rules, and a wave-judging checklist), grounded in the canonical cockpit tokens (`cockpitTokens.ts`), the `RoomFrame` shell, and the locked design laws in `architect-boundary.md`. Every future wave is built and judged against it.
2. **Roster room redesign** — `RosterVisual.tsx` migrated from ad-hoc hex/opacity to the `cockpit-*` surface/text tokens, type scale aligned, redundant nested borders/shadows flattened to a two-step inlay-well/slab-band elevation, sparse rosters no longer render hollow bands (top-hug + composed "open slots" placeholders), and the blank `return null` replaced with a composed empty state.
3. Cosmetic guardrail test updated with the design (`rosterVisual.adapterBoundary.test.tsx`) — empty-band display-only intent preserved (no phantom cards / no add-remove controls), mechanism updated.

## Review artifact (owner-facing, 1280×720)
https://claude.ai/code/artifact/66ccb729-8847-4e5e-927f-b663dd286aed

Covers: the standard (palette), Roster full + sparse states, and the already-landed BZE-222 Free Agency base/selected-deck/sign states re-verified on current main.

## Validation
- `npm run typecheck` — clean
- `npm run test:diff -- --reporter=dot` — pass (roster adapter scope)
- `npx vitest run -c vitest.ui.config.js rosterVisual.adapterBoundary + grouped33FileScope` — 11 passed
- Real-app screenshots at 1280×720 via the review harness; body fit verified (`scrollHeight === clientHeight`, 618px) on every Roster + FA state.

## Scope / boundary
Roster = trusted player-state surface. No engine/CBA, no Trade Machine/Compare/History/Offseason changes. Free Agency (BZE-222) already on main — only re-verified here, not re-changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an Architect Visual Standard covering locked UI rules, visual system, component vocabulary, and layout/state requirements.
- **Bug Fixes**
  - Roster UI now shows a centered “No roster loaded yet” state and dedicated empty-band placeholders for zero-player sections.
  - Standardized position labels to replace `-` with `/` and adjusted overlay placements across roster cards.
  - Improved free-agent headshot error handling by hiding broken images.
- **New Features**
  - Made selected free-agent cards collapsible with a toggleable deck.
- **Tests**
  - Updated roster display-only assertions to validate the new empty-band behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->