### PR TITLE
BZE-253 Fix two cap-engine accuracy bugs: waive-and-stretch term + trade salary-matching tiers

### DIFF
--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.contractActions.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.contractActions.ts
@@ -17,6 +17,8 @@ import {
 import { toSeasonCode } from '@/features/architect/utils/seasonFormat';
 import {
   allocateStandardWaiverDeadCapBySeason,
+  countRemainingContractSeasons,
+  getStretchProvisionYears,
   sumWaiverDeadCapAllocations,
 } from '@/features/architect/utils/waiverDeadCapAllocation';
 import type { ManualExceptionsSavePayload } from '@/features/architect/capSheet/CapSheet/CapSheet';
@@ -641,6 +643,16 @@ export function useContractActions({
         ? Math.max(0, Number(buyoutAmount) || 0)
         : 0;
 
+      // CBA stretch term for the persisted metadata: (2 x seasons remaining) + 1.
+      const payloadStretchYears = stretch
+        ? getStretchProvisionYears(
+            countRemainingContractSeasons({
+              salaryRows: player.contract?.salariesByYear || [],
+              currentSeason: toSeasonCode(currentYear),
+            })
+          ) || 3
+        : 0;
+
       const mutationResult = applyCapAuditedTeamMutation({
         mutationType: 'waivePlayer',
         playerIds: [String(playerId)],
@@ -678,7 +690,15 @@ export function useContractActions({
             : remainingGuaranteed;
 
           const shouldStretch = !!stretch && deadCapAmount > 0;
-          const stretchYears = shouldStretch ? 3 : 1;
+          // CBA stretch term: (2 x seasons remaining) + 1, derived from the
+          // contract. Falls back to 3 only when the term can't be computed.
+          const remainingSeasonCount = countRemainingContractSeasons({
+            salaryRows: contractRows,
+            currentSeason: toSeasonCode(currentYear),
+          });
+          const stretchYears = shouldStretch
+            ? getStretchProvisionYears(remainingSeasonCount) || 3
+            : 1;
           const baseAmount = shouldStretch
             ? Math.floor(deadCapAmount / stretchYears)
             : deadCapAmount;
@@ -755,7 +775,7 @@ export function useContractActions({
           teamCode,
           playerId,
           stretch: !!stretch,
-          stretchYears: stretch ? 3 : 0, // Default stretch years
+          stretchYears: payloadStretchYears, // CBA term: (2 x seasons remaining) + 1
           buyout: !!buyout,
           buyoutAmount: buyout ? normalizedBuyoutAmount : 0,
           isGracePeriod: false, // Default, UI doesn't currently expose this

--- a/src/features/architect/hooks/useCapValidation.ts
+++ b/src/features/architect/hooks/useCapValidation.ts
@@ -613,12 +613,18 @@ export function useCapValidation({
         });
 
         if (action === 'waiveStretch') {
-          const stretchYears = Math.ceil(
-            remainingGuaranteed / (remainingGuaranteed / 3)
-          );
+          // CBA stretch term: (2 x seasons remaining on the contract) + 1.
+          const remainingSeasonCount = (
+            player.contract?.salariesByYear || []
+          ).filter((y) => {
+            const yearNum = parseInt(String(y.season).split('-')[1], 10) + 2000;
+            return yearNum >= resolvedCurrentYear;
+          }).length;
+          const stretchYears =
+            remainingSeasonCount > 0 ? remainingSeasonCount * 2 + 1 : 3;
           warnings.push({
             severity: 'info',
-            message: `Stretched over ~${stretchYears} years`,
+            message: `Stretched over ${stretchYears} years`,
           });
         }
       }

--- a/src/features/architect/utils/mutationPipeline.compute.signings.playerOps.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.signings.playerOps.ts
@@ -11,6 +11,8 @@ import {
 } from '@/features/architect/utils/seasonFormat';
 import {
   allocateStandardWaiverDeadCapBySeason,
+  countRemainingContractSeasons,
+  getStretchProvisionYears,
   sumWaiverDeadCapAllocations,
 } from '@/features/architect/utils/waiverDeadCapAllocation';
 import {
@@ -57,7 +59,6 @@ export function computeWaiveResult({
   );
   const teamCode = currentState.teamCode || team.teamCode || null;
   const stretch = payload.stretch ?? false;
-  const stretchYears = Number(payload.stretchYears ?? 3);
   const buyout = payload.buyout ?? false;
 
   const playerId = payload.playerId || player.player_id || player.id;
@@ -93,6 +94,14 @@ export function computeWaiveResult({
   const remainingGuaranteedFromRows = sumWaiverDeadCapAllocations(
     standardDeadCapBySeason
   );
+  // CBA stretch term: dead salary spreads over (2 x seasons remaining) + 1,
+  // derived from the contract itself. Falls back to 3 only if the contract has
+  // no dated rows (guaranteedValue-only path) so the term can't be computed.
+  const remainingSeasonCount = countRemainingContractSeasons({
+    salaryRows: contractRows,
+    currentSeason: seasonId,
+  });
+  const stretchYears = getStretchProvisionYears(remainingSeasonCount) || 3;
   const guaranteedValueFallback = Number(contract?.guaranteedValue) || 0;
   const remainingSalary =
     remainingGuaranteedFromRows ||

--- a/src/features/architect/utils/tradeMachine/constants/cbaConstants.ts
+++ b/src/features/architect/utils/tradeMachine/constants/cbaConstants.ts
@@ -44,21 +44,22 @@ export const CBA_THRESHOLDS: Record<string, ThresholdMap> = {
  * This constant is kept for backwards compatibility but the authoritative
  * source is in src/features/architect/utils/tradeMachine/utils/salaryMatchingRules
  *
- * 2023 CBA tiered matching rules for over-cap teams below first apron:
- *  - Band 1: outgoing ≤ $6.5M → 200% + $250k
- *  - Band 2: $6.5M < outgoing ≤ $19.6M → outgoing + $7.5M
- *  - Band 3: outgoing > $19.6M → 125% + $250k
+ * 2023 CBA tiered matching rules for over-cap teams below first apron
+ * (2026-27 league year; the cushion is the Expanded Traded Player Exception):
+ *  - Band 1: outgoing ≤ $8.846M → 200% + $250k
+ *  - Band 2: $8.846M < outgoing ≤ $35.384M → outgoing + $9.096M (expanded TPE)
+ *  - Band 3: outgoing > $35.384M → 125% + $250k
  */
 export const SALARY_MATCHING_BANDS = {
-  // These values are DEPRECATED and may be incorrect
-  // Use SALARY_MATCHING_TIERS from salaryMatchingRules.js instead
-  FIRST_TIER_THRESHOLD: 6_500_000,   // Band 1 -> Band 2 boundary
-  SECOND_TIER_THRESHOLD: 19_600_000, // Band 2 -> Band 3 boundary
+  // These values are DEPRECATED. Use SALARY_MATCHING_TIERS from
+  // salaryMatchingRules.ts instead (the authoritative, ETPE-indexed source).
+  FIRST_TIER_THRESHOLD: 8_846_000,   // Band 1 -> Band 2 boundary (ETPE - $250k)
+  SECOND_TIER_THRESHOLD: 35_384_000, // Band 2 -> Band 3 boundary (4 x (ETPE - $250k))
   FIRST_TIER_MULTIPLIER: 2.0,        // Band 1: 200%
-  SECOND_TIER_MULTIPLIER: 1.0,       // Band 2: 100% + $7.5M bonus
+  SECOND_TIER_MULTIPLIER: 1.0,       // Band 2: 100% + expanded TPE bonus
   THIRD_TIER_MULTIPLIER: 1.25,       // Band 3: 125%
   FIRST_TIER_ADDITION: 250_000,      // Band 1: +$250k
-  SECOND_TIER_ADDITION: 7_500_000,   // Band 2: +$7.5M
+  SECOND_TIER_ADDITION: 9_096_000,   // Band 2: +expanded TPE (2026-27)
   THIRD_TIER_ADDITION: 250_000,      // Band 3: +$250k
 };
 

--- a/src/features/architect/utils/tradeMachine/utils/salaryMatchingRules.ts
+++ b/src/features/architect/utils/tradeMachine/utils/salaryMatchingRules.ts
@@ -11,8 +11,19 @@
  * RULES:
  *  The 2023 CBA salary matching tiers for over-cap teams below first apron:
  *  - Band 1: outgoing <= TIER_1_THRESHOLD -> 200% + $250k
- *  - Band 2: TIER_1_THRESHOLD < outgoing <= TIER_2_THRESHOLD -> outgoing + $7.5M
+ *  - Band 2: TIER_1_THRESHOLD < outgoing <= TIER_2_THRESHOLD -> outgoing + expanded TPE
  *  - Band 3: outgoing > TIER_2_THRESHOLD -> 125% + $250k
+ *
+ *  The Band 2 cushion is the Expanded Traded Player Exception (ETPE), an amount
+ *  indexed to the salary cap that grows each season. The tier boundaries are
+ *  derived from it so the piecewise function stays continuous:
+ *    TIER_1_THRESHOLD = ETPE - $250k       (Band 1 <-> Band 2 crossover)
+ *    TIER_2_THRESHOLD = 4 x (ETPE - $250k) (Band 2 <-> Band 3 crossover)
+ *  UPDATE ANNUALLY with the ETPE when the league year rolls (same maintenance
+ *  model as capProjections). 2026-27 ETPE = $9,096,000 (Hoops Rumors / SBC,
+ *  "Values of 2026/27 Exceptions" and "Understanding Trade Matching in the New
+ *  CBA", verified 2026-07-12); for reference the 2025-26 ETPE was $8,527,000.
+ *  Sanity check: $10M outgoing -> $19,096,000 allowable incoming.
  *
  *  Apron teams:
  *  - First apron: 100% matching (dollar-for-dollar)
@@ -60,16 +71,21 @@ function toFiniteNumber(value: unknown): number {
 }
 
 /**
- * 2023 CBA salary matching tier thresholds
- * These are the authoritative values - all other constants should derive from these
+ * 2023 CBA salary matching tier thresholds (2026-27 league year).
+ * These are the authoritative values - all other constants should derive from these.
+ *
+ * The single cap-indexed input is the Expanded Traded Player Exception (the Band
+ * 2 cushion); the two tier boundaries are derived from it so the piecewise
+ * matching function stays continuous. Update EXPANDED_TPE each league year.
  */
+const EXPANDED_TPE = 9_096_000; // 2026-27 Expanded Traded Player Exception
 export const SALARY_MATCHING_TIERS = {
-  TIER_1_THRESHOLD: 6_500_000,
-  TIER_2_THRESHOLD: 19_600_000,
+  TIER_1_THRESHOLD: EXPANDED_TPE - 250_000, // 8,846,000: Band 1 <-> Band 2 crossover
+  TIER_2_THRESHOLD: 4 * (EXPANDED_TPE - 250_000), // 35,384,000: Band 2 <-> Band 3 crossover
   BAND_1_MULTIPLIER: 2.0,
   BAND_1_BONUS: 250_000,
   BAND_2_MULTIPLIER: 1.0,
-  BAND_2_BONUS: 7_500_000,
+  BAND_2_BONUS: EXPANDED_TPE, // outgoing + expanded TPE
   BAND_3_MULTIPLIER: 1.25,
   BAND_3_BONUS: 250_000,
   APRON_MULTIPLIER: 1.0,
@@ -120,7 +136,7 @@ export const SALARY_MATCHING_RULE_LABELS: Record<SalaryMatchingRuleKey, string> 
     [SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_1]:
       'Over Cap (Band 1): 200% + $250k',
     [SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_2]:
-      'Over Cap (Band 2): 100% + $7.5M',
+      'Over Cap (Band 2): 100% + expanded TPE',
     [SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_3]:
       'Over Cap (Band 3): 125% + $250k',
     [SALARY_MATCHING_RULE_KEYS.FIRST_APRON]: 'First Apron: 100% matching',

--- a/src/features/architect/utils/tradeManager.ts
+++ b/src/features/architect/utils/tradeManager.ts
@@ -19,6 +19,8 @@ import { toEndYear } from '@/features/architect/utils/seasonFormat';
 import { computeTeamCapTotals } from '@/features/architect/utils/capTotals';
 import {
   allocateStandardWaiverDeadCapBySeason,
+  countRemainingContractSeasons,
+  getStretchProvisionYears,
   sumWaiverDeadCapAllocations,
 } from '@/features/architect/utils/waiverDeadCapAllocation';
 
@@ -215,7 +217,7 @@ export async function waivePlayer(
     throw new Error('worldId, teamCode, and playerId are required');
   }
 
-  const { stretch = false, stretchYears = 3 } = options;
+  const { stretch = false, stretchYears: explicitStretchYears } = options;
 
   // Load team and player states
   const teamState = (await getTeam(worldId, teamCode)) as TeamStateLike;
@@ -252,6 +254,19 @@ export async function waivePlayer(
     (Array.isArray(contract.salariesByYear) && contract.salariesByYear.length > 0
       ? 0
       : contract.guaranteedValue || 0);
+
+  // CBA stretch term: (2 x seasons remaining) + 1, derived from the contract.
+  // An explicit stretchYears option (if provided) overrides for callers/tests.
+  const remainingSeasonCount = countRemainingContractSeasons({
+    salaryRows: Array.isArray(contract.salariesByYear)
+      ? contract.salariesByYear
+      : [],
+    currentSeason,
+  });
+  const stretchYears =
+    typeof explicitStretchYears === 'number' && explicitStretchYears > 0
+      ? explicitStretchYears
+      : getStretchProvisionYears(remainingSeasonCount) || 3;
 
   if (stretch && remainingSalary > 0) {
     // Stretch over multiple years

--- a/src/features/architect/utils/waiverDeadCapAllocation.ts
+++ b/src/features/architect/utils/waiverDeadCapAllocation.ts
@@ -92,3 +92,41 @@ export function sumWaiverDeadCapAllocations(
 ): number {
   return allocations.reduce((sum, allocation) => sum + allocation.amount, 0);
 }
+
+/**
+ * Count the seasons remaining on a contract from the current season forward.
+ * This is the basis for the stretch-provision term: it counts contract rows
+ * whose season is the current season or later, regardless of guarantee status
+ * (the CBA term is based on seasons remaining on the contract, not just the
+ * guaranteed ones).
+ */
+export function countRemainingContractSeasons({
+  salaryRows,
+  currentSeason,
+}: {
+  salaryRows: readonly WaiverSalaryRowLike[];
+  currentSeason: string;
+}): number {
+  const currentSeasonEndYear = toEndYear(currentSeason);
+
+  if (typeof currentSeasonEndYear !== 'number') {
+    return 0;
+  }
+
+  return salaryRows.filter((row) => {
+    const seasonEndYear = getRowSeasonEndYear(row);
+    return (
+      typeof seasonEndYear === 'number' && seasonEndYear >= currentSeasonEndYear
+    );
+  }).length;
+}
+
+/**
+ * CBA stretch-provision term. When a waived player's remaining dead salary is
+ * stretched, it is spread over (2 × seasons remaining) + 1 seasons — e.g.
+ * 1 year left → 3, 2 → 5, 3 → 7. (CBA Article VII, Section 2; see Hoops Rumors
+ * "Glossary: Stretch Provision".) Returns 0 when no seasons remain to stretch.
+ */
+export function getStretchProvisionYears(remainingSeasonCount: number): number {
+  return remainingSeasonCount > 0 ? remainingSeasonCount * 2 + 1 : 0;
+}

--- a/src/tests/architect/editContractModal_closure.gate.test.ts
+++ b/src/tests/architect/editContractModal_closure.gate.test.ts
@@ -231,9 +231,13 @@ describe('Gate 5: World Compute Honors Buyout Fields (E1)', () => {
     readFileContent(MUTATION_PIPELINE_COMPUTE_SIGNINGS_PLAYEROPS_PATH);
 
   it('computeWaiveResult reads payload.buyoutAmount', () => {
-    // Pattern: payload.buyoutAmount in computeWaiveResult
+    // Pattern: payload.buyoutAmount in computeWaiveResult.
+    // Window widened from 1500 when the CBA stretch-term derivation
+    // (countRemainingContractSeasons / getStretchProvisionYears) was added
+    // ahead of the buyout block. Intent is unchanged: computeWaiveResult must
+    // still read the buyout amount off the payload.
     const readsBuyoutAmount =
-      /computeWaiveResult[\s\S]{0,1500}payload\.buyoutAmount/.test(content);
+      /computeWaiveResult[\s\S]{0,2500}payload\.buyoutAmount/.test(content);
     expect(readsBuyoutAmount).toBe(true);
   });
 

--- a/src/tests/architect/useCapValidation.behavior.test.ts
+++ b/src/tests/architect/useCapValidation.behavior.test.ts
@@ -442,6 +442,7 @@ describe('useCapValidation', () => {
       })
     );
 
+    // 2 seasons remain (2026, 2027), so the CBA stretch term is 2 x 2 + 1 = 5.
     expect(result.current.warnings).toEqual([
       {
         severity: 'info',
@@ -449,7 +450,7 @@ describe('useCapValidation', () => {
       },
       {
         severity: 'info',
-        message: 'Stretched over ~3 years',
+        message: 'Stretched over 5 years',
       },
     ]);
     expect(result.current.errors).toEqual([]);

--- a/src/tests/trade/goldenTrades.test.ts
+++ b/src/tests/trade/goldenTrades.test.ts
@@ -105,37 +105,37 @@ describe('Golden Trade Regression Tests', () => {
     it('GOLDEN-01: Band 1 boundary at TIER_1_THRESHOLD yields 200% + $250k', () => {
       const result = getSalaryMatchingResult({
         teamTotalSalary: 150_000_000, // over cap, below apron
-        outgoingSalary: SALARY_MATCHING_TIERS.TIER_1_THRESHOLD, // exactly tier 1 threshold ($6.5M)
+        outgoingSalary: SALARY_MATCHING_TIERS.TIER_1_THRESHOLD, // exactly tier 1 threshold ($8.846M)
         capSettings: DEFAULT_CAP_SETTINGS,
       });
 
-      // 6.5M * 2.0 + 250k = 13.25M
+      // 8.846M * 2.0 + 250k = 17.942M
       expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_1);
-      expect(result.allowableIncoming).toBe(13_250_000);
+      expect(result.allowableIncoming).toBe(17_942_000);
     });
 
-    it('GOLDEN-02: Band 2 boundary at TIER_2_THRESHOLD yields outgoing + $7.5M', () => {
+    it('GOLDEN-02: Band 2 boundary at TIER_2_THRESHOLD yields outgoing + expanded TPE', () => {
       const result = getSalaryMatchingResult({
         teamTotalSalary: 150_000_000,
-        outgoingSalary: SALARY_MATCHING_TIERS.TIER_2_THRESHOLD, // exactly tier 2 threshold ($19.6M)
+        outgoingSalary: SALARY_MATCHING_TIERS.TIER_2_THRESHOLD, // exactly tier 2 threshold ($35.384M)
         capSettings: DEFAULT_CAP_SETTINGS,
       });
 
-      // 19.6M + 7.5M = 27.1M
+      // 35.384M + 9.096M (2026-27 expanded TPE) = 44.48M
       expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_2);
-      expect(result.allowableIncoming).toBe(27_100_000);
+      expect(result.allowableIncoming).toBe(44_480_000);
     });
 
-    it('GOLDEN-03: Band 3 for $25M outgoing yields 125% + $250k', () => {
+    it('GOLDEN-03: Band 3 for $40M outgoing yields 125% + $250k', () => {
       const result = getSalaryMatchingResult({
         teamTotalSalary: 150_000_000,
-        outgoingSalary: 25_000_000, // above $19.6M
+        outgoingSalary: 40_000_000, // above $35.384M
         capSettings: DEFAULT_CAP_SETTINGS,
       });
 
-      // 25M * 1.25 + 250k = 31.5M
+      // 40M * 1.25 + 250k = 50.25M
       expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_3);
-      expect(result.allowableIncoming).toBe(31_500_000);
+      expect(result.allowableIncoming).toBe(50_250_000);
     });
   });
 

--- a/src/tests/trade/hardCap_salaryMatching.guardrail.test.ts
+++ b/src/tests/trade/hardCap_salaryMatching.guardrail.test.ts
@@ -94,7 +94,7 @@ describe('Hard-capped teams still follow salary matching', () => {
         hardCapped: true, // Hard capped at first apron
         teamTotalSalary: 150_000_000, // BUT salary is below first apron
         salaryIn: 17_500_000, // Within Band 2 allowable
-        salaryOut: 10_000_000, // Band 2: 10M + 7.5M = 17.5M allowable
+        salaryOut: 10_000_000, // Band 2: 10M + 9.096M = 19.096M allowable
         context: { capSettings: defaultCapSettings },
       };
 
@@ -102,7 +102,7 @@ describe('Hard-capped teams still follow salary matching', () => {
 
       // Should use Band 2 matching (not 100% matching)
       expect(result.details.ruleApplied).toContain('BAND');
-      expect(result.allowableIncoming).toBe(17_500_000); // Band 2: 10M + 7.5M
+      expect(result.allowableIncoming).toBe(19_096_000); // Band 2: 10M + 9.096M
       expect(result.passed).toBe(true);
     });
 
@@ -203,19 +203,19 @@ describe('Hard-capped teams still follow salary matching', () => {
         hardCapped: true,
         teamTotalSalary: 175_000_000, // 3M below first apron (hard cap at 178M)
         salaryIn: 12_000_000, // Under both ceilings
-        salaryOut: 10_000_000, // Band 2: allows 17.5M
+        salaryOut: 10_000_000, // Band 2: allows 19.096M
         context: { capSettings: defaultCapSettings },
       };
 
       const result = validateSalaryMatching(team, {});
 
-      // Salary match ceiling = 17.5M (Band 2)
-      expect(result.allowableIncoming).toBe(17_500_000);
+      // Salary match ceiling = 19.096M (Band 2)
+      expect(result.allowableIncoming).toBe(19_096_000);
 
       // Hard cap ceiling = 10M + 3M = 13M
       expect(result.hardCapIncomingCeiling).toBe(13_000_000);
 
-      // Effective = min(17.5M, 13M) = 13M
+      // Effective = min(19.096M, 13M) = 13M
       expect(result.effectiveAllowableIncoming).toBe(13_000_000);
     });
 
@@ -248,19 +248,19 @@ describe('Hard-capped teams still follow salary matching', () => {
         hardCapped: true,
         teamTotalSalary: 177_000_000, // 1M below first apron
         salaryIn: 11_000_000,
-        salaryOut: 10_000_000, // Band 2: allows 17.5M
+        salaryOut: 10_000_000, // Band 2: allows 19.096M
         context: { capSettings: defaultCapSettings },
       };
 
       const result = validateSalaryMatching(team, {});
 
-      // Salary match ceiling = 17.5M
-      expect(result.allowableIncoming).toBe(17_500_000);
+      // Salary match ceiling = 19.096M
+      expect(result.allowableIncoming).toBe(19_096_000);
 
       // Hard cap ceiling = 10M + 1M = 11M
       expect(result.hardCapIncomingCeiling).toBe(11_000_000);
 
-      // Effective = min(17.5M, 11M) = 11M
+      // Effective = min(19.096M, 11M) = 11M
       expect(result.effectiveAllowableIncoming).toBe(11_000_000);
 
       // Limiter should be hardCap

--- a/tests/e2e/architect-qa.spec.ts
+++ b/tests/e2e/architect-qa.spec.ts
@@ -2089,27 +2089,28 @@ test.describe('D-MQ: Architect Manual QA Checklist', () => {
         {
           timeout: 15000,
           message:
-            'waive-and-stretch should remove Austin Reaves and spread dead cap across three seasons',
+            'waive-and-stretch should remove Austin Reaves and spread dead cap across five seasons',
         }
       )
-      // Source-verified re-baseline for the current 2026-27 seeded world (was
-      // authored against a 2025-26 world). Austin Reaves' guaranteed salary is
-      // 2025-26 $14M / 2026-27 $15M / 2027-28 $16M (review_seed/basePlayers/
-      // austin_reaves.json). Waiving in a 2026-27 world:
+      // Source-verified for the current 2026-27 seeded world. Austin Reaves'
+      // guaranteed salary is 2025-26 $14M / 2026-27 $15M / 2027-28 $16M
+      // (review_seed/basePlayers/austin_reaves.json). Waiving in a 2026-27 world:
       //   - allocateStandardWaiverDeadCapBySeason drops the past 2025-26 row
       //     (seasonEndYear 2026 < current 2027), leaving $15M + $16M = $31M.
-      //   - computeWaiveResult stretches $31M over stretchYears=3 starting at
-      //     seasonId 2026-27: floor(31M/3)=10,333,333, remainder 1 → year 0
-      //     gets +1 (mutationPipeline.compute.signings.playerOps.ts:110-133).
-      // Product behavior is correct; only the pre-roll seasons/amounts drifted.
+      //   - 2 seasons remain on the contract (2026-27, 2027-28), so the CBA
+      //     stretch term is 2 x 2 + 1 = 5 years. computeWaiveResult spreads $31M
+      //     over 5 seasons from 2026-27: 31M / 5 = 6,200,000 exactly (remainder 0)
+      //     (mutationPipeline.compute.signings.playerOps.ts).
       .toEqual({
         hasAustinReaves: false,
         amountByYear: {
-          '2026-27': { amount: 10_333_334, isStretched: true },
-          '2027-28': { amount: 10_333_333, isStretched: true },
-          '2028-29': { amount: 10_333_333, isStretched: true },
+          '2026-27': { amount: 6_200_000, isStretched: true },
+          '2027-28': { amount: 6_200_000, isStretched: true },
+          '2028-29': { amount: 6_200_000, isStretched: true },
+          '2029-30': { amount: 6_200_000, isStretched: true },
+          '2030-31': { amount: 6_200_000, isStretched: true },
         },
-        notes: 'Stretched over 3 years',
+        notes: 'Stretched over 5 years',
       });
 
     await expect
@@ -2134,8 +2135,8 @@ test.describe('D-MQ: Architect Manual QA Checklist', () => {
               playerIds.includes(REVIEW_TRADE_LAL_OUTGOING_PLAYER.id) &&
               (metadata.stretched === true ||
                 mutationMetadata.stretched === true) &&
-              (metadata.stretchYears === 3 ||
-                mutationMetadata.stretchYears === 3)
+              (metadata.stretchYears === 5 ||
+                mutationMetadata.stretchYears === 5)
             );
           });
         },
@@ -2201,7 +2202,7 @@ test.describe('D-MQ: Architect Manual QA Checklist', () => {
 
     addAuditNote(
       testInfo,
-      'This proves the V1 Waive & Stretch path in browser review mode: Full Cap Table row overflow launches Waive & Stretch, the shared modal commits a stretched waiver, the receipt/count state updates, Austin Reaves leaves active roster surfaces, dead money is spread across three seasons in Full Cap Table, Team History and Compare read the committed stretched waivePlayer event, and reload preserves the saved-world state.'
+      'This proves the V1 Waive & Stretch path in browser review mode: Full Cap Table row overflow launches Waive & Stretch, the shared modal commits a stretched waiver, the receipt/count state updates, Austin Reaves leaves active roster surfaces, dead money is spread across five seasons in Full Cap Table, Team History and Compare read the committed stretched waivePlayer event, and reload preserves the saved-world state.'
     );
 
     await captureEvidence(page, testInfo, 'D-MQ-004C-waive-stretch-v1');

--- a/tests/salaryMatchingRules.test.ts
+++ b/tests/salaryMatchingRules.test.ts
@@ -61,7 +61,7 @@ describe('Unified Salary Matching Rules', () => {
         expect(result.allowableIncoming).toBe(13_250_000);
       });
 
-      it('Band 2: applies 100% + $7.5M for $6.5M < outgoing ≤ $19.6M', () => {
+      it('Band 2: applies outgoing + expanded TPE for $8.846M < outgoing ≤ $35.384M', () => {
         const result = getSalaryMatchingResult({
           teamTotalSalary: 150_000_000,
           outgoingSalary: 10_000_000,
@@ -69,11 +69,11 @@ describe('Unified Salary Matching Rules', () => {
         });
 
         expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_2);
-        // 10M + 7.5M = 17.5M
-        expect(result.allowableIncoming).toBe(17_500_000);
+        // 10M + 9.096M (2026-27 expanded TPE) = 19.096M
+        expect(result.allowableIncoming).toBe(19_096_000);
       });
 
-      it('Band 2: at threshold boundary $19.6M', () => {
+      it('Band 2: mid-range $19.6M outgoing', () => {
         const result = getSalaryMatchingResult({
           teamTotalSalary: 150_000_000,
           outgoingSalary: 19_600_000,
@@ -81,20 +81,20 @@ describe('Unified Salary Matching Rules', () => {
         });
 
         expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_2);
-        // 19.6M + 7.5M = 27.1M
-        expect(result.allowableIncoming).toBe(27_100_000);
+        // 19.6M + 9.096M = 28.696M
+        expect(result.allowableIncoming).toBe(28_696_000);
       });
 
-      it('Band 3: applies 125% + $250k for outgoing > $19.6M', () => {
+      it('Band 3: applies 125% + $250k for outgoing > $35.384M', () => {
         const result = getSalaryMatchingResult({
           teamTotalSalary: 150_000_000,
-          outgoingSalary: 25_000_000,
+          outgoingSalary: 40_000_000,
           capSettings: defaultCapSettings,
         });
 
         expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_3);
-        // 25M * 1.25 + 250k = 31.5M
-        expect(result.allowableIncoming).toBe(31_500_000);
+        // 40M * 1.25 + 250k = 50.25M
+        expect(result.allowableIncoming).toBe(50_250_000);
       });
     });
 
@@ -155,8 +155,8 @@ describe('Unified Salary Matching Rules', () => {
         capSettings: defaultCapSettings,
       });
 
-      // Band 2: 17.5M - 10M = 7.5M margin
-      expect(margin).toBe(7_500_000);
+      // Band 2: 19.096M - 10M = 9.096M margin
+      expect(margin).toBe(9_096_000);
     });
   });
 
@@ -168,8 +168,8 @@ describe('Unified Salary Matching Rules', () => {
         capSettings: defaultCapSettings,
       });
 
-      // Band 2: 10M + 7.5M = 17.5M
-      expect(ceiling).toBe(17_500_000);
+      // Band 2: 10M + 9.096M = 19.096M
+      expect(ceiling).toBe(19_096_000);
     });
   });
 
@@ -178,7 +178,7 @@ describe('Unified Salary Matching Rules', () => {
       const result = validateIncomingSalary({
         teamTotalSalary: 150_000_000,
         outgoingSalary: 10_000_000,
-        incomingSalary: 15_000_000, // below 17.5M allowable
+        incomingSalary: 15_000_000, // below 19.096M allowable
         capSettings: defaultCapSettings,
       });
 
@@ -190,7 +190,7 @@ describe('Unified Salary Matching Rules', () => {
       const result = validateIncomingSalary({
         teamTotalSalary: 150_000_000,
         outgoingSalary: 10_000_000,
-        incomingSalary: 20_000_000, // above 17.5M allowable
+        incomingSalary: 20_000_000, // above 19.096M allowable
         capSettings: defaultCapSettings,
       });
 
@@ -201,15 +201,15 @@ describe('Unified Salary Matching Rules', () => {
 
   describe('tier constants', () => {
     it('exports correct tier thresholds', () => {
-      expect(SALARY_MATCHING_TIERS.TIER_1_THRESHOLD).toBe(6_500_000);
-      expect(SALARY_MATCHING_TIERS.TIER_2_THRESHOLD).toBe(19_600_000);
+      expect(SALARY_MATCHING_TIERS.TIER_1_THRESHOLD).toBe(8_846_000);
+      expect(SALARY_MATCHING_TIERS.TIER_2_THRESHOLD).toBe(35_384_000);
     });
 
     it('exports correct band parameters', () => {
       expect(SALARY_MATCHING_TIERS.BAND_1_MULTIPLIER).toBe(2.0);
       expect(SALARY_MATCHING_TIERS.BAND_1_BONUS).toBe(250_000);
       expect(SALARY_MATCHING_TIERS.BAND_2_MULTIPLIER).toBe(1.0);
-      expect(SALARY_MATCHING_TIERS.BAND_2_BONUS).toBe(7_500_000);
+      expect(SALARY_MATCHING_TIERS.BAND_2_BONUS).toBe(9_096_000);
       expect(SALARY_MATCHING_TIERS.BAND_3_MULTIPLIER).toBe(1.25);
       expect(SALARY_MATCHING_TIERS.BAND_3_BONUS).toBe(250_000);
     });

--- a/tests/salaryMatchingUnification.test.ts
+++ b/tests/salaryMatchingUnification.test.ts
@@ -40,9 +40,9 @@ describe('UI and Validator Consistency (Phase 2 Verification)', () => {
       expectedRuleKey: SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_2,
     },
     {
-      name: 'Over-cap team Band 3 (outgoing > $19.6M)',
+      name: 'Over-cap team Band 3 (outgoing > $35.384M)',
       teamTotalSalary: 150_000_000,
-      salaryOut: 25_000_000,
+      salaryOut: 40_000_000,
       salaryIn: 30_000_000,
       expectedRuleKey: SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_3,
     },
@@ -104,40 +104,40 @@ describe('UI and Validator Consistency (Phase 2 Verification)', () => {
       expect(result.allowableIncoming).toBe(13_250_000);
     });
 
-    it('just above Band 1/2 boundary ($6.5M + 1) uses Band 2', () => {
+    it('just above Band 1/2 boundary ($8.846M + 1) uses Band 2', () => {
       const result = getSalaryMatchingResult({
         teamTotalSalary: 150_000_000,
-        outgoingSalary: 6_500_001,
+        outgoingSalary: 8_846_001,
         capSettings: defaultCapSettings,
       });
 
       expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_2);
-      // 6,500,001 + 7.5M = 14,000,001
-      expect(result.allowableIncoming).toBe(14_000_001);
+      // 8,846,001 + 9.096M (expanded TPE) = 17,942,001
+      expect(result.allowableIncoming).toBe(17_942_001);
     });
 
-    it('exact threshold at Band 2/3 boundary ($19.6M) uses Band 2', () => {
+    it('exact threshold at Band 2/3 boundary ($35.384M) uses Band 2', () => {
       const result = getSalaryMatchingResult({
         teamTotalSalary: 150_000_000,
-        outgoingSalary: 19_600_000,
+        outgoingSalary: 35_384_000,
         capSettings: defaultCapSettings,
       });
 
       expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_2);
-      // 19.6M + 7.5M = 27.1M
-      expect(result.allowableIncoming).toBe(27_100_000);
+      // 35.384M + 9.096M = 44.48M
+      expect(result.allowableIncoming).toBe(44_480_000);
     });
 
-    it('just above Band 2/3 boundary ($19.6M + 1) uses Band 3', () => {
+    it('just above Band 2/3 boundary ($35.384M + 1) uses Band 3', () => {
       const result = getSalaryMatchingResult({
         teamTotalSalary: 150_000_000,
-        outgoingSalary: 19_600_001,
+        outgoingSalary: 35_384_001,
         capSettings: defaultCapSettings,
       });
 
       expect(result.ruleKey).toBe(SALARY_MATCHING_RULE_KEYS.OVER_CAP_BAND_3);
-      // 19,600,001 * 1.25 + 250k = 24,750,001.25
-      expect(result.allowableIncoming).toBeCloseTo(24_750_001.25, 0);
+      // 35,384,001 * 1.25 + 250k = 44,480,001.25
+      expect(result.allowableIncoming).toBeCloseTo(44_480_001.25, 0);
     });
 
     it('exact at first apron threshold uses FIRST_APRON', () => {

--- a/tests/trade/matchingBands_2023.test.ts
+++ b/tests/trade/matchingBands_2023.test.ts
@@ -29,26 +29,26 @@ describe('2023 matching bands below first apron', () => {
     expect(edge).toBe(BAND1 * 2 + 250_000);
   });
 
-  it('Band B between BAND1 and BAND2: +7.5M', () => {
+  it('Band B between BAND1 and BAND2: + expanded TPE', () => {
     const { ceiling } = calculateAllowableIncoming({
       ...base,
       salaryOut: 10_000_000,
     });
-    expect(ceiling).toBe(17_500_000);
+    expect(ceiling).toBe(19_096_000); // 10M + 9.096M (2026-27 expanded TPE)
 
     const { ceiling: edge } = calculateAllowableIncoming({
       ...base,
       salaryOut: BAND2,
     });
-    expect(edge).toBe(BAND2 + 7_500_000);
+    expect(edge).toBe(BAND2 + 9_096_000);
   });
 
   it('Band C above BAND2: 125% + 250k', () => {
     const { ceiling } = calculateAllowableIncoming({
       ...base,
-      salaryOut: 25_000_000,
+      salaryOut: 40_000_000,
     });
-    expect(ceiling).toBe(31_500_000);
+    expect(ceiling).toBe(50_250_000);
   });
 });
 

--- a/tests/trade/salaryMatching.test.ts
+++ b/tests/trade/salaryMatching.test.ts
@@ -69,7 +69,7 @@ describe('salary matching validation', () => {
 
   it('validates allowable incoming margin', () => {
     const result = validateSalaryMatching(
-      makeTeam(10_000_000, 18_000_000, {
+      makeTeam(10_000_000, 20_000_000, {
         teamTotalSalary: 150_000_000,
         context: {
           capSettings: {
@@ -100,7 +100,7 @@ describe('salary matching validation', () => {
       })
     ) as SalaryMatchingResultWithEffective;
 
-    expect(result.allowableIncoming).toBe(17_500_000);
+    expect(result.allowableIncoming).toBe(19_096_000);
     expect(result.hardCapIncomingCeiling).toBe(11_000_000);
     expect(result.effectiveAllowableIncoming).toBe(11_000_000);
     expect(result.details.hardCapStatus?.hardCapType).toBe('FIRST_APRON');
@@ -153,7 +153,7 @@ describe('salary matching validation', () => {
       })
     ) as SalaryMatchingResultWithEffective;
 
-    expect(result.allowableIncoming).toBe(17_500_000);
+    expect(result.allowableIncoming).toBe(19_096_000);
     expect(result.hardCapIncomingCeiling).toBe(11_000_000);
     expect(result.effectiveAllowableIncoming).toBe(11_000_000);
     expect(result.passed).toBe(true);

--- a/tests/tradeHelpers.test.ts
+++ b/tests/tradeHelpers.test.ts
@@ -96,9 +96,10 @@ describe('calculateAllowableIncoming', () => {
       tpeAmount: 3_000_000,
     });
 
+    // Band 2 (10M outgoing): 10M + 9.096M expanded TPE = 19.096M, + 3M TPE = 22.096M
     expect(allowable).toEqual({
-      ceiling: 20_500_000,
-      margin: 10_500_000,
+      ceiling: 22_096_000,
+      margin: 12_096_000,
     });
   });
 });

--- a/tests/tradeSalaryMatching.test.ts
+++ b/tests/tradeSalaryMatching.test.ts
@@ -13,23 +13,23 @@ const capSettings = {
   secondApron: 182_794_000,
 };
 
-describe('CBA salary-matching tiers (2025)', () => {
+describe('CBA salary-matching tiers (2026-27)', () => {
   it('Band 1 – ≤ BAND1 uses 200% + $250k', () => {
     expect(getIncomingCeiling(150_000_000, 6_000_000, [], capSettings)).toBe(
       12_250_000
     ); // 6 M × 2.0 + 0.25 M
   });
 
-  it('Band 2 – between thresholds adds $7.5 M', () => {
+  it('Band 2 – between thresholds adds the expanded TPE', () => {
     expect(getIncomingCeiling(150_000_000, 10_000_000, [], capSettings)).toBe(
-      17_500_000
-    ); // 10 M + 7.5 M
+      19_096_000
+    ); // 10 M + 9.096 M (2026-27 expanded TPE)
   });
 
   it('Band 3 – above upper threshold uses 125% + $250k', () => {
-    expect(getIncomingCeiling(150_000_000, 20_000_000, [], capSettings)).toBe(
-      25_250_000
-    ); // 20 M × 1.25 + 0.25 M
+    expect(getIncomingCeiling(150_000_000, 40_000_000, [], capSettings)).toBe(
+      50_250_000
+    ); // 40 M × 1.25 + 0.25 M
   });
 
   it('Second-apron teams capped at 100 %', () => {
@@ -59,7 +59,8 @@ describe('calculateAllowableIncoming returns *margin*', () => {
       [],
       capSettings
     );
-    expect(margin).toBe(7_500_000); // 14.5 M ceiling – 7 M outgoing
+    // $7M outgoing is in Band 1 (≤ $8.846M): 7M × 2 + 0.25M = 14.25M ceiling.
+    expect(margin).toBe(7_250_000); // 14.25 M ceiling – 7 M outgoing
   });
 });
 /**************** END SCSP™ BLOCK: tradeSalaryMatching.test.js  *************/

--- a/tests/tradeValidator.test.ts
+++ b/tests/tradeValidator.test.ts
@@ -63,7 +63,7 @@ describe('tradeValidator', () => {
       isBYC: true,
       previousSalary: 8_000_000,
     };
-    const incomingPlayer = makePlayer('Bstar', 18_000_000);
+    const incomingPlayer = makePlayer('Bstar', 20_000_000);
     teamA.players.push(bycPlayer);
     teamB.players.push(incomingPlayer);
 
@@ -86,15 +86,18 @@ describe('tradeValidator', () => {
       },
     });
 
-    expect(rawSalaryResult.allowableIncoming).toBeGreaterThan(18_000_000);
+    // Raw (un-BYC) 20M outgoing would allow the 20M incoming, but BYC drops
+    // matchOutgoing to 10M so the Band 2 ceiling (10M + 9.096M = 19.096M) is
+    // exceeded — proving BYC recompute happens before legality.
+    expect(rawSalaryResult.allowableIncoming).toBeGreaterThan(20_000_000);
     expect(result.legal).toBe(false);
     expect(bycPlayer.matchOutgoing).toBe(10_000_000);
     expect(bycPlayer.matchIncoming).toBe(20_000_000);
     expect(result.teamResults[0].salaryOut).toBe(10_000_000);
     expect(result.teamResults[0].salaryOut).not.toBe(20_000_000);
-    expect(result.teamResults[0].salaryIn).toBe(18_000_000);
+    expect(result.teamResults[0].salaryIn).toBe(20_000_000);
     expect(result.teamResults[0].rules.salaryMatching.allowableIncoming).toBe(
-      17_500_000
+      19_096_000
     );
     expect(result.teamResults[0].rules.salaryMatching.passed).toBe(false);
     expect(issueTexts(result.teamResults[0].violations)).toEqual(
@@ -145,7 +148,7 @@ describe('tradeValidator', () => {
     expect(bycPlayer.previousSalary).toBe(10_000_000);
     expect(bycPlayer.matchOutgoing).toBe(15_000_000);
     expect(result.teamResults[0].rules.salaryMatching.allowableIncoming).toBe(
-      22_500_000
+      24_096_000
     );
     expect(result.teamResults[0].rules.salaryMatching.passed).toBe(true);
   });

--- a/tests/validators/salaryMatching.test.ts
+++ b/tests/validators/salaryMatching.test.ts
@@ -29,13 +29,13 @@ describe('validateSalaryMatching', () => {
     });
 
     it('enforces outgoing matching rules when over cap', () => {
-      // Band 2 (10M outgoing): allowable = 10M + $7.5M = $17.5M
-      // Testing with 18M incoming which exceeds the $17.5M allowable
+      // Band 2 (10M outgoing): allowable = 10M + $9.096M (expanded TPE) = $19.096M
+      // Testing with 20M incoming which exceeds the $19.096M allowable
       const result = validateSalaryMatching(
         makeTeam({
           teamTotalSalary: 150_000_000,
           salaryOut: 10_000_000,
-          salaryIn: 18_000_000, // This exceeds allowable (10M + $7.5M = $17.5M)
+          salaryIn: 20_000_000, // exceeds allowable (10M + $9.096M = $19.096M)
         })
       );
       expect(result.passed).toBe(false);

--- a/work/architect-completion/ARCHITECT_ACCURACY_ASSESSMENT.md
+++ b/work/architect-completion/ARCHITECT_ACCURACY_ASSESSMENT.md
@@ -1,0 +1,234 @@
+# Architect — Accuracy & Reliability Assessment
+
+> **UPDATE 2026-07-12 (post-assessment):** The two engine bugs found below
+> (waive-and-stretch length #20, trade-matching tier boundaries #25) have since
+> been **FIXED** in code, with the pinning tests corrected to CBA-true values.
+> See the "FIXES APPLIED" section at the end. The body below is the original
+> read-only diagnostic, preserved as the record of what was found.
+
+**Original assessment was a read-only diagnostic. No data, emulator, scrape, push, or Firestore pipeline was run.**
+
+- **Date:** 2026-07-12
+- **Repo state:** branch `main`, commit `9b771ec8`
+- **Scope:** Is Architect *accurate*, and how far can it be trusted today? Three layers — league constants (code), cap engine (code), and real base data (scraped).
+- **Every real-world NBA number below is cited to a public source with a date. No figure is asserted from memory.**
+
+---
+
+## ONE-LINE VERDICT
+
+**No — not yet reliable as "accurate" for real decisions.** The *machine* is in good shape (constants perfect, engine mostly correct), but the **single biggest risk is the stale base data**: the real rosters and contracts are last season's (2025‑26), scraped ~June 6–7 2026, so they predate the entire 2026 draft and free agency. A user will assume the base mirrors today's NBA; it does not, and nothing on screen warns them. Two engine bugs (below) compound it.
+
+To keep the two questions separate, as the owner asked:
+
+- **The machine (constants + engine): mostly-with-caveats.** All 14 hand-typed 2026‑27 league constants are exactly right. The engine's core math (team salary, cap space, tax/apron status, standard waive, buyout, minimum-salary cap hit) is correct. **Two specific rules are wrong:** waive‑and‑stretch length, and the trade salary‑matching tier boundaries. Both are code bugs, not data.
+- **The data: no (stale).** Correct as of the 2025‑26 season, not the current 2026‑27 offseason. This is the deferred refresh the owner already knows about — but it is the dominant accuracy gap.
+
+---
+
+## What I verified vs. what I couldn't
+
+- **Fully verified (no database needed):** Layer 1 (constants) and Layer 2 (engine). These live entirely in the repo and were checked line-by-line and by hand.
+- **Deferred, honestly:** Layer 3 (spot-checking real rosters against 2026‑27 public sources). The only real data reachable in this environment is the **stale 2025‑26 local snapshot**; live production can't be read without running a Firestore script (out of scope, read-only). Comparing a 2025‑26 snapshot against 2026‑27 reality would only re-measure staleness, not correctness. See Layer 3 below for exactly what access would close it.
+
+---
+
+## LAYER 0 — Where the data comes from, and how fresh it is (plain language)
+
+**The tool has two completely separate "brains," and only one of them is fresh.**
+
+1. **The rulebook (cap numbers + math): current and hand-maintained in code.** The salary cap, luxury tax, both aprons, the exceptions, and the minimum-salary scale are typed into source files by hand and are correct for 2026‑27 (Layer 1). The math that uses them is also code (Layer 2). None of this needs a database.
+
+2. **The league itself (who's on which team, and their contracts): scraped, and currently stale.**
+
+**Where it comes from.** Two scrapers feed the "base league":
+   - **SalarySwish** → each team's cap sheet: roster, salaries, cap holds, and trade/signing exceptions (`team-scrape/team-data/`).
+   - **RealGM** → draft-pick ownership, separately (`team-scrape/draft-picks/`).
+   These are merged and "staged" into Firestore-ready files under `team-scrape/shared/firestore_staging/_artifacts/output/baseTeams/` (all 30 teams present), validated against the app's schema, then **pushed to production Firestore** (`architect_baseTeams` / `architect_basePlayers`) by a manual admin script (`team:push` / `push_staged_teams.ts --confirmProject`).
+   > The scrapers' own README calls this pipeline **"EXPERIMENTAL / WORK IN PROGRESS … Use at your own risk … Data accuracy has not been fully validated against official sources … Manual verification and cleanup of output is required."** That is the authors' own caveat, not mine.
+
+**Production vs. emulator — do they stay in sync? No.** Production (what real users see) is updated only by the manual push above. The local **emulator is seeded separately** (`emu:reseed:baseTeams`, `emu:seed:base-players`) and currently holds a **fictional QA world** (players like "Grant Holloway," "Marcus Vance"). The two never auto-sync. **The emulator must not be used to judge accuracy** — it's fake by design, and I did not touch it.
+
+**How to check what's actually live in production (without changing anything).** Read one `architect_baseTeams` document from live Firestore and look at its `season` and source timestamp — via the Firebase console, or a read-only script such as `scripts/firebase-utils/inspect-firestore.js` / `pull-firestore.js` (needs `serviceAccountKey.json`; requires the emulator env to be OFF). I did **not** run these — they touch production.
+
+**How stale, from what's checkable in the repo.** The local scraped/staged files are the clearest signal:
+   - Team cap files (`team-scrape/team-data/output/team_*.json`): last written **June 6, 2026**, tagged **`"season": "2025-26"`**.
+   - Staged base-team payloads (`.../output/baseTeams/LAL.json`): written **June 7, 2026**, active roster season **`"2025-26"`** (with future contract years running out to 2028‑29, which is normal for multi-year deals).
+   - Example: the staged Lakers roster still lists the 2025‑26 group (LeBron James, Luka Dončić, Deandre Ayton, Marcus Smart, Adou Thiero, etc.).
+
+   **Meaning:** the base reflects the **end of the 2025‑26 season**, captured ~5 weeks before the world's "today" (2026‑07‑12) and **before the 2026 offseason** — so it is missing the entire 2026 draft class, all 2026 free-agency signings, and any 2026 offseason trades. Note the mismatch this creates: the app applies **2026‑27** cap rules (correct) on top of **2025‑26** rosters (stale). Whether production currently serves this exact June‑7 snapshot or something else can only be confirmed by the read step above.
+
+---
+
+## FULL CHECK TABLE
+
+**Root cause key:** DATA = fix by refreshing scraped data; ENGINE = fix in code. Source values verified 2026‑07‑12.
+
+### Layer 1 — League constants (`capProjections.ts` `'2026-27'`; `minimumSalaryScales.ts` `'2026-27'`)
+
+| # | What was compared | Code value | Source value | Result | Sev. | Cause |
+|---|---|---|---|---|---|---|
+| 1 | Salary cap | 164,961,000 | 164,961,000 | **PASS** | — | — |
+| 2 | Luxury tax line | 200,428,000 | 200,428,000 | **PASS** | — | — |
+| 3 | First apron | 209,015,000 | 209,015,000 | **PASS** | — | — |
+| 4 | Second apron | 221,686,000 | 221,686,000 | **PASS** | — | — |
+| 5 | Minimum team salary (floor) | 148,465,000 | 148,465,000 | **PASS** | — | — |
+| 6 | Non-taxpayer (full) MLE | 15,044,000 | 15,044,000 | **PASS** | — | — |
+| 7 | Taxpayer MLE | 6,064,000 | 6,064,000 | **PASS** | — | — |
+| 8 | Room MLE | 9,366,000 | 9,366,000 | **PASS** | — | — |
+| 9 | Bi-annual exception (BAE) | 5,477,000 | 5,477,000 | **PASS** | — | — |
+| 10 | Min scale — rookie (0 yr) | 1,357,763 | 1,357,763 | **PASS** | — | — |
+| 11 | Min scale — 1 yr | 2,185,116 | 2,185,116 | **PASS** | — | — |
+| 12 | Min scale — 2 yr | 2,449,421 | 2,449,421 | **PASS** | — | — |
+| 13 | Min scale — 5 yr | 2,845,883 | 2,845,883 | **PASS** | — | — |
+| 14 | Min scale — 10+ yr | 3,876,529 | 3,876,529 | **PASS** | — | — |
+
+**Layer 1 result: 14/14 exact.** The hand-typed 2026‑27 rulebook is accurate. (Sources: cap/tax/apron/floor — NBA.com & Hoops Rumors, 2026‑06‑30/07‑01; exceptions — Hoops Rumors "Values Of 2026/27 Mid‑Level, Bi‑Annual Exceptions," Jul 2026; minimums — Hoops Rumors "NBA Minimum Salaries For 2026/27," Luke Adams, 2026‑07‑01. Links at bottom.)
+
+> Note on the BAE: an automated search summary initially claimed the BAE was \$3.382M, which would have been a mismatch. Fetching the actual Hoops Rumors article confirmed **\$5,477,000** (3.32% of the cap) — the code is correct; the summary was wrong. Flagging so the check isn't misread as a near-miss.
+
+### Layer 2 — Cap engine (worked by hand)
+
+| # | Rule | What the code does | CBA-correct behavior | Result | Sev. | Cause |
+|---|---|---|---|---|---|---|
+| 15 | Team salary total | players + dead money + active unsigned cap holds + empty-roster charges (`computeTeamCapTotals`) | Same definition | **PASS** | — | ENGINE |
+| 16 | Cap space | cap − team salary | Same | **PASS** | — | ENGINE |
+| 17 | Over-tax / apron status | over tax if `> tax`; first apron if `≥ 1st apron`; second apron if `> 2nd apron` | Correct (boundary uses strict/│non-strict; a $1 edge nuance only) | **PASS** | low | ENGINE |
+| 18 | Empty-roster charge | rookie minimum × slots below the 14-man minimum | Each empty slot below the minimum is charged one rookie minimum | **PASS** | — | ENGINE |
+| 19 | Standard waive (no stretch) | remaining **guaranteed** salary booked as dead cap, by season | Same | **PASS** | — | ENGINE |
+| 20 | **Waive-and-stretch length** | **fixed 3 years** in every live path | **2 × (years remaining) + 1** | **WRONG** | **HIGH** | ENGINE |
+| 21 | Buyout | dead cap = remaining guaranteed − agreed givebacks | Correct structure | **PASS**\* | — | ENGINE |
+| 22 | Minimum-salary cap hit (3+ YOS) | counts at the **2-year** minimum (`scale[2]`) | Correct — league reimburses the difference on 1-yr min deals | **PASS** | — | ENGINE |
+| 23 | Trade matching — apron teams | 100% (dollar-for-dollar) | 100% from 2024‑25 on | **PASS** | — | ENGINE |
+| 24 | Trade matching — multipliers/bonuses (below apron) | 200%+$250k / +$7.5M / 125%+$250k | Same | **PASS** | — | ENGINE |
+| 25 | **Trade matching — tier boundaries (below apron)** | **$6.5M and $19.6M** | **$7.5M and $29M** | **WRONG** | **MED-HIGH** | ENGINE |
+
+\* Buyout math is structurally correct, but if the user also stretches the buyout, it inherits bug #20 (spread over a fixed 3 years).
+
+### Layer 3 — Real base data
+
+| # | What would be compared | Reachable now? | Result | Cause |
+|---|---|---|---|---|
+| 26 | ~5–6 real teams' rosters, marquee contracts, and team salary/tax/apron totals vs. a 2026‑27 public source | No — only the **stale 2025‑26** local snapshot is reachable; live prod needs a read script (out of scope) | **CAN'T-VERIFY — deferred to owner's chosen refresh cutoff** | DATA |
+
+---
+
+## The two engine bugs, in plain language (with worked examples)
+
+### Bug #20 — Waive-and-stretch always spreads over 3 years
+
+**What it should do.** When a team waives a player and "stretches" the dead money, the CBA spreads it over **twice the years remaining, plus one**. (Real example: Milwaukee stretching Damian Lillard — 3 years / ~$21.8M left → paid over **7** years, ~$3.1M/yr. Source: Hoops Rumors Stretch Provision glossary + Forbes, Jul 2025.)
+
+**What the tool does.** Every live path spreads it over **exactly 3 years**, regardless of contract length. The code that *does* implement the correct `2 × years + 1` formula (`contractUtils.stretchContract`) exists but **is never called — it's dead code.**
+
+**Worked example (3 years, $21M left):**
+- Tool: $21M ÷ **3** = **$7.0M/yr for 3 years**.
+- CBA: 2×3+1 = **7** years → $21M ÷ 7 = **$3.0M/yr for 7 years**.
+- The tool **more than doubles** the near-term dead-cap hit and ends it **4 years early** — the exact opposite of how a GM uses the stretch (to *minimize* near-term hit). It's correct **only** when a contract has exactly **1 year left** (2×1+1 = 3, by coincidence).
+
+**Tests don't catch it — they lock in the bug.** `tradeManager.test.ts` and `architect-qa.spec.ts` assert `stretchYears: 3` and "Stretched over 3 years." The validation message helper is even written as `Math.ceil(remaining / (remaining / 3))`, which always equals 3. So the suite *enforces* the wrong behavior; green tests here do **not** mean accurate.
+
+### Bug #25 — Trade salary-matching uses the wrong tier boundaries
+
+**What it should do.** For a team below the first apron, the CBA below-apron tiers are: outgoing **≤ $7.5M** → 200%+$250k; **$7.5M–$29M** → outgoing+$7.5M; **> $29M** → 125%+$250k. (Source: Hoops Rumors "Salary-Matching Rules for Trades," fetched 2026‑07‑12.)
+
+**What the tool does.** The multipliers and bonuses are right, but the **boundaries are wrong: $6.5M and $19.6M** (the *old* 2017‑CBA breakpoints) instead of **$7.5M and $29M**. It's a mismatched hybrid — new formula, old thresholds.
+
+**Worked example (team below apron sends out $20.0M, wants back $27.0M):**
+- CBA (Tier 2, $7.5M–$29M): allowed = 20.0 + 7.5 = **$27.5M** → **$27.0M is LEGAL**.
+- Tool ($20M > its $19.6M cutoff → Band 3): allowed = 1.25×20 + 0.25 = **$25.25M** → **tool BLOCKS the legal trade.**
+- **Direction of error:** mostly **too strict** for mid/large outgoing salaries (~$19.6M–$29M), wrongly rejecting legal trades by up to ~$2.3M of incoming salary; marginally **too lenient** (+$250k) in the $6.5M–$7.5M band. Trades are a core feature, so this misleads users building otherwise-legal deals.
+
+**Tests don't catch it.** The "golden" trade tests assert behavior *at the code's own* `TIER_1_THRESHOLD` / `TIER_2_THRESHOLD` constants — they verify the formula fires at $6.5M/$19.6M, never that $6.5M/$19.6M are the correct CBA numbers. Same pattern: tests pin *some* value, not the *correct* value.
+
+**Low-severity latent note (not an active bug):** the legacy `CBA_THRESHOLDS` table has no 2026‑27 row and a slightly-off 2024‑25 cap ($141.0M vs. the actual $140.588M). For the active season this is inert — cap/tax/apron come from `capProjections`, max salaries are computed as %-of-cap (25/30/35%), and the rookie minimum is taken from the official scale before this table is consulted. Worth tidying, but it does not affect 2026‑27 answers today.
+
+---
+
+## TO REACH THE OWNER'S BAR
+
+*"A fully functional, usable tool that others can use with complete reliability that it is accurate."* Two independent things must be true. Keeping them separate, as asked:
+
+### A) The machine (constants + engine) — close, two fixes away
+
+1. **Fix waive-and-stretch to spread over `2 × years remaining + 1`** (Bug #20). Wire in the already-correct helper; retire the fixed-3 assumption; update the tests that currently assert "3 years" so they assert the CBA term. *Highest-leverage engine fix — it's flatly wrong for any multi-year contract and today's tests defend the wrong answer.*
+2. **Fix the trade-matching tier boundaries to $7.5M / $29M** (Bug #25), and update the golden tests to check against the CBA figure rather than the code's own constant.
+3. **Decide whether the below-apron matching thresholds and other fixed CBA dollar figures are meant to escalate**, and document it. (Public sources didn't state escalation either way; treat as an open question, not a defect.)
+4. **Housekeeping (low):** give `CBA_THRESHOLDS` a 2026‑27 row or retire it, and correct the historical 2024‑25 cap, so no future season silently falls back to stale numbers.
+
+### B) The data (real base league) — the dominant gap, and the deferred one
+
+5. **Refresh the base to the current 2026‑27 league** at the owner's chosen cutoff. Today's base is the 2025‑26 season as of ~June 6–7 2026 — it predates the 2026 draft and free agency. *Even a perfect engine on last season's rosters produces confidently wrong answers, and nothing on screen tells the user the base is stale.* (Deferred by design — not to be run now.)
+6. **Show data provenance in the product:** a visible "rosters current as of <date>" stamp. The base is meant to *be reality*; when it can't be, the tool should say so rather than imply currency.
+7. **Validate the refreshed base against a public source** before trusting it — the scraper's own README warns its output "has not been fully validated against official sources" and "requires manual verification." A handful of real teams (an over-the-apron team, a cap-space team, a mid team) checked against Spotrac/RealGM would catch scraper drift. **This is the Layer 3 spot-check I deferred; to run it I'd need either the live `architect_baseTeams`/`architect_basePlayers` read (via console or a read-only script) or a refreshed non-fictional snapshot — treated as a fixed cutoff, never the emulator's QA world.**
+
+**Bottom line for a non-technical reader:** the calculator is trustworthy and its rulebook is bang-on for 2026‑27, with two math rules to fix (how long a waived contract stretches, and how much salary a mid-to-large trade can take back). But it's currently doing that good math on **last season's league**, and nothing warns the user. Fix the two rules, refresh the roster data at your chosen moment, and stamp the data date on screen — then it can be relied on.
+
+---
+
+## Sources (accessed 2026‑07‑12)
+
+- NBA.com — *NBA sets salary cap for 2026‑27 season at $164.961 million*: https://www.nba.com/news/nba-salary-cap-2026-27-season
+- Hoops Rumors — *Salary Cap, Tax Line Set For 2026/27 NBA Season* (Jun 2026): https://www.hoopsrumors.com/2026/06/salary-cap-tax-line-set-for-2026-27-nba-season.html
+- Bleacher Report — *2026‑27 NBA Salary Cap, 1st and 2nd Aprons, Luxury Tax Levels Revealed* (Jun 2026): https://bleacherreport.com/articles/25448479-2026-27-nba-salary-cap-1st-and-2nd-aprons-luxury-tax-levels-revealed-fa
+- Hoops Rumors — *Values Of 2026/27 Mid‑Level, Bi‑Annual Exceptions* (Jul 2026): https://www.hoopsrumors.com/2026/07/values-of-2026-27-mid-level-bi-annual-exceptions.html
+- Hoops Rumors — *NBA Minimum Salaries For 2026/27* (Luke Adams, 2026‑07‑01): https://www.hoopsrumors.com/2026/07/nba-minimum-salaries-for-2026-27.html
+- Hoops Rumors — *Salary‑Matching Rules For Trades During 2023/24 Season* (Sep 2023): https://www.hoopsrumors.com/2023/09/salary-matching-rules-for-trades-during-2023-24-season.html
+- Hoops Rumors — *Glossary: Stretch Provision* (Aug 2024): https://www.hoopsrumors.com/2024/08/hoops-rumors-glossary-stretch-provision-3.html
+- Forbes — *Why the Milwaukee Bucks Used the Stretch Provision on Damian Lillard* (Shane Young, 2025‑07‑01): https://www.forbes.com/sites/shaneyoung/2025/07/01/why-the-milwaukee-bucks-used-the-stretch-provision-on-damian-lillard/
+
+## FIXES APPLIED (2026-07-12)
+
+Both engine bugs are fixed. The league constants (Layer 1) needed no change — they were already correct. The data-freshness gap (Layer 3 / section B) is untouched and still deferred to the owner's chosen refresh cutoff.
+
+### Fix 1 — Waive-and-stretch now uses the real CBA term
+
+**Plain language:** waiving-and-stretching a player used to always spread the dead money over 3 years. It now spreads it over the correct term — **twice the seasons remaining, plus one** — so a 2-year contract stretches over 5 years and a 3-year contract over 7, instead of being crammed into 3.
+
+- New shared helpers in `waiverDeadCapAllocation.ts`: `countRemainingContractSeasons()` and `getStretchProvisionYears()` (`n × 2 + 1`). One formula, one place.
+- Wired into **every** live path, each of which previously hardcoded 3: the world path (`computeWaiveResult`), the local UI path (`handleWaiveContract`), the persisted metadata, and the validation message (which literally always printed "~3 years" via `Math.ceil(x / (x/3))`).
+- Legacy `tradeManager.waivePlayer` now computes the same term by default.
+- The pre-existing correct helper (`contractUtils.stretchContract`) was dead code; the live paths now implement the same rule.
+
+**Worked example (the e2e case):** Austin Reaves, $31M guaranteed across 2 remaining seasons. Was: $10.33M/yr for 3 years. Now: **$6.2M/yr for 5 years** (2×2+1).
+
+### Fix 2 — Trade salary-matching now uses the real 2026-27 tiers
+
+**Plain language:** the tool was using the *old* (pre-2023) tier boundaries with the *new* formula — a mismatched hybrid that wrongly blocked legal trades. It now uses the correct 2026-27 numbers.
+
+The single cap-indexed input is the **Expanded Traded Player Exception (ETPE) = $9,096,000** for 2026-27; both tier boundaries derive from it so the piecewise function stays continuous:
+
+| | Was (wrong) | Now (2026-27) |
+| --- | --- | --- |
+| Band 1 → 2 boundary | $6,500,000 | **$8,846,000** (ETPE − $250k) |
+| Band 2 → 3 boundary | $19,600,000 | **$35,384,000** (4 × (ETPE − $250k)) |
+| Band 2 cushion | $7,500,000 | **$9,096,000** (the ETPE) |
+
+Sanity check against the public source's own example: **$10M outgoing → $19,096,000 allowable incoming.** ✅
+
+> **Important maintenance note:** unlike the old hardcoded figures, these are **cap-indexed and must be updated each league year** — same annual-maintenance model as `capProjections`. Only `EXPANDED_TPE` needs changing; the boundaries derive from it. (For reference, the 2025-26 ETPE was $8,527,000.) This resolves the "do these escalate?" open question from the original report: **yes, they escalate.**
+
+### Tests: re-pinned to CBA truth, not to the code's own values
+
+The original report's sharpest finding was that the tests *defended the bugs* — they asserted the code's own constants rather than the real CBA figures, so green tests certified nothing. That is now corrected across 12 test files:
+
+- Salary-matching band assertions re-derived from the real ETPE (e.g. $10M outgoing: $17.5M → **$19,096,000**).
+- Band 3 cases that used $25M outgoing were genuinely **Band 2** under the correct rules — those tests were moved above the real $35.384M boundary so they still exercise Band 3.
+- Boundary tests re-anchored to the true crossovers ($8.846M / $35.384M).
+- Stretch tests now assert the CBA term (5 years for the 2-remaining-season case) instead of the hardcoded 3.
+
+**Validation run:** `npm run typecheck` clean; trade/matching/waive scope **684/684 pass (76 files)**; `npm run test:architect` **3555 tests pass**. E2E waive-and-stretch expectations updated (not executed here — needs the review harness).
+
+### Still open (unchanged by these fixes)
+
+- **The data.** Base rosters are still the 2025-26 season, scraped ~June 6-7 2026, pre-2026-draft and pre-free-agency. This remains the single biggest risk to "others can rely on it," and is the owner's deferred refresh call.
+- **Low-severity housekeeping.** The legacy `CBA_THRESHOLDS` table still has no 2026-27 row and a slightly-off 2024-25 cap; inert today (cap lines come from `capProjections`, max salaries are %-of-cap), but worth tidying.
+
+---
+
+## Files inspected (evidence trail)
+
+- Constants: `src/features/architect/utils/capProjections.ts`; `src/features/architect/data/minimumSalaryScales.ts`; `.../data/rookieScale.ts`; `.../utils/tradeMachine/constants/cbaConstants.ts`
+- Engine: `.../utils/capRulesProfile/capRulesProfile.ts`; `.../tradeMachine/utils/capSettingsProvider.ts`; `.../tradeMachine/utils/salaryMatchingRules.ts`; `.../utils/capTotals/computeTeamCapTotals.ts`; `.../utils/waiverDeadCapAllocation.ts`; `.../utils/mutationPipeline.compute.signings.playerOps.ts`; `.../GMDashboard/hooks/useArchitectActions.contractActions.ts`; `.../hooks/useCapValidation.ts`; `.../utils/contractUtils.ts`; `.../utils/playerRulesProfile/minimumSalaryRules.ts`; `.../utils/hardCapUtils.ts`
+- Pipeline/freshness: `team-scrape/README.md`; `team-scrape/shared/firestore_staging/README.md`; `team-scrape/team-data/output/*.json`; `team-scrape/shared/firestore_staging/_artifacts/output/baseTeams/*.json`; `package.json` scripts
+- Tests reviewed for pinning: `src/tests/trade/goldenTrades.test.ts`; `tests/architect/tradeManager.test.ts`; `tests/e2e/architect-qa.spec.ts`


### PR DESCRIPTION
Fixes BZE-253

Found by the Architect accuracy assessment (`work/architect-completion/ARCHITECT_ACCURACY_ASSESSMENT.md`, included in this PR). The assessment verified all 14 hand-typed 2026-27 league constants as **exactly correct** (cap, tax, both aprons, floor, all three MLEs, BAE, full minimum scale) and found the engine correct on team salary, cap space, tax/apron status, standard waive, buyout, and minimum cap hit — but **wrong on two rules**. Both are ENGINE bugs (code), not DATA. Constants are unchanged.

## Bug 1 — Waive-and-stretch always spread over 3 years

The CBA spreads stretched dead money over **(2 × seasons remaining) + 1**. Every live path hardcoded **3**, so it was only correct for a contract with exactly 1 year left.

A 3-year / $21M contract showed **$7.0M/yr for 3 years** instead of the correct **$3.0M/yr for 7 years** — more than double the near-term dead-cap hit, ending 4 years early. That's the opposite of what a GM uses the stretch for.

The correct helper (`contractUtils.stretchContract`) already existed but was **dead code — never called**.

New shared helpers `countRemainingContractSeasons()` / `getStretchProvisionYears()` in `waiverDeadCapAllocation.ts`, wired into every path that had independently hardcoded 3: `computeWaiveResult` (world), `handleWaiveContract` (local UI), the persisted metadata, the validation message (which used `Math.ceil(x / (x/3))` — it could only ever return 3), and legacy `tradeManager.waivePlayer`.

## Bug 2 — Trade salary-matching used the wrong tier boundaries

Below-apron matching used the *pre-2023* tier boundaries with the *post-2023* formula — a mismatched hybrid that **wrongly blocked legal trades**.

The Band 2 cushion is the **Expanded Traded Player Exception**, which is **cap-indexed and escalates each league year** — not a fixed CBA constant. Both boundaries now derive from it, keeping the piecewise function continuous:

| | Was (wrong) | Now (2026-27) |
| --- | --- | --- |
| Band 1 → 2 boundary | $6,500,000 | **$8,846,000** (ETPE − $250k) |
| Band 2 → 3 boundary | $19,600,000 | **$35,384,000** (4 × (ETPE − $250k)) |
| Band 2 cushion | $7,500,000 | **$9,096,000** (the ETPE) |

Verified against the public source's own worked example: **$10M outgoing → $19,096,000 allowable incoming.** ✅

## Tests previously pinned the bugs

The sharpest finding of the assessment: the suite asserted **the code's own constants**, not the real CBA figures — so green tests certified nothing. The stretch tests literally asserted `stretchYears: 3` and `"Stretched over ~3 years"`.

Re-pinned to CBA truth across 13 test files:
- Band assertions re-derived from the real ETPE ($10M outgoing: $17.5M → **$19,096,000**).
- Several "Band 3" cases used $25M outgoing, which is genuinely **Band 2** under correct rules — moved above the real $35.384M boundary so they still exercise Band 3.
- Boundary tests re-anchored to the true crossovers.
- Stretch tests now assert the CBA term (5 years for a 2-remaining-season contract) instead of the hardcoded 3.
- One brittle source-text guardrail regex-scanned for the buyout field within 1500 chars of `computeWaiveResult`; widened the window rather than contort the code around the pin (guardrail intent preserved).

## ⚠️ Annual maintenance

`EXPANDED_TPE` in `salaryMatchingRules.ts` now joins `capProjections` as a value that **must be refreshed each league year**. Only that one number changes; both boundaries derive from it. (2025-26 was $8,527,000.)

## Behavior note

Already-saved worlds keep their stored dead-cap schedules — this changes how *new* waives are computed, it does not retroactively recompute persisted ones.

## Not in scope

Base data freshness (rosters are still the 2025-26 season, scraped ~June 6–7 2026, pre-2026-draft/FA). That remains the dominant accuracy gap, deferred to the owner's chosen refresh cutoff.

## Validation

- `npm run typecheck` — clean
- `npm run test:architect` — **3555/3555 pass (305 files)**
- trade/matching/waive scope — **670/670 pass (75 files)**
- E2E waive-and-stretch expectations updated but **not executed** (needs the review harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Waive-and-stretch calculations now distribute dead cap over the correct number of seasons based on the remaining contract.
  * Stretch warnings now display the accurate duration.
  * Updated 2026–27 salary-matching rules use expanded TPE thresholds for more accurate trade legality and incoming-salary limits.
  * Trade validation, hard-cap ceilings, and related calculations now reflect the revised matching bands.
* **Tests**
  * Updated regression and end-to-end coverage for corrected stretch and salary-matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->