### PR TITLE
BZE-268: build the dated independent salary-ledger spine

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -323,6 +323,7 @@ utils/
     index.ts
   capTotals/
     computeTeamCapTotals.ts
+    datedSalaryLedgers.ts
     deadMoneyForYear.ts
     hardCapSnapshotOverlay.ts
     index.ts
@@ -562,5 +563,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-07-12T01:06:12.231Z*
+*Generated on: 2026-08-08T01:38:57.252Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/utils/capTotals/computeTeamCapTotals.ts
+++ b/src/features/architect/utils/capTotals/computeTeamCapTotals.ts
@@ -1,9 +1,15 @@
 /**
  * FILE: src/features/architect/utils/capTotals/computeTeamCapTotals.ts
- * PURPOSE: Single source of truth for canonical team cap totals computation.
+ * PURPOSE: Temporary compatibility owner for the legacy shared cap-allocation total.
  * OWNERSHIP: Feature: architect
  *
- * INCLUDED IN CANONICAL TOTALS:
+ * BZE-268 COMPATIBILITY BOUNDARY:
+ * - Existing consumers still receive the historical shared allocation snapshot.
+ * - This module is not authoritative for independent Apron or Tax Salary.
+ * - New governed work must use datedSalaryLedgers.ts and supply each ledger's
+ *   own inputs. Consumer migration is intentionally outside BZE-268.
+ *
+ * INCLUDED IN LEGACY COMPATIBILITY TOTALS:
  * - Player salaries/cap hits for standard roster contracts
  * - Dead money
  * - Active unsigned cap holds
@@ -11,7 +17,7 @@
  * - Salary cap / tax / apron thresholds
  * - Delta outputs versus those thresholds
  *
- * EXCLUDED FROM CANONICAL TOTALS:
+ * EXCLUDED FROM LEGACY COMPATIBILITY TOTALS:
  * - Exception state, usage display, or exception-card presentation
  * - Trade exception (TPE) state or display
  * - Hard-cap trigger state and human-readable reason text
@@ -230,7 +236,7 @@ function computeCanonicalTotalCapAllocations({
 }
 
 /**
- * Canonical Cap Sheet totals owner.
+ * Legacy Cap Sheet compatibility totals owner.
  *
  * Use computeTeamCapTotals(...) when a caller needs totalCapAllocations,
  * dead money, cap holds, incomplete roster charges, cap/tax/apron thresholds,
@@ -322,8 +328,8 @@ export function createCanonicalTeamTotalsSnapshot(
   selectedYear: number,
   options: CapTotalsOptions = {}
 ): ComputedTeamCapTotalsSnapshot {
-  // Downstream snapshot shaping consumes the canonical totals SSOT rather than
-  // acting as an alternate compute owner.
+  // Temporary BZE-268 compatibility path: preserve historical aliases for
+  // unmigrated consumers. These aliases are not governed Apron/Tax ledgers.
   const canonicalTotals = computeTeamCapTotals(
     teamCapSheet,
     selectedYear,

--- a/src/features/architect/utils/capTotals/datedSalaryLedgers.ts
+++ b/src/features/architect/utils/capTotals/datedSalaryLedgers.ts
@@ -1,0 +1,362 @@
+/**
+ * FILE: src/features/architect/utils/capTotals/datedSalaryLedgers.ts
+ * PURPOSE: Governed, dated spine for independent Team, Apron, and Tax Salary ledgers.
+ * OWNERSHIP: Feature: architect/cap totals
+ *
+ * BZE-268 intentionally stops at the ledger boundary. Callers must supply
+ * independently derived line items for each ledger; this module does not infer
+ * missing CBA adjustments, borrow another ledger's total, or fall back to the
+ * runtime date or a different Salary Cap Year.
+ */
+
+export const SALARY_LEDGER_KINDS = [
+  'team-salary',
+  'apron-team-salary',
+  'tax-salary',
+] as const;
+
+export type SalaryLedgerKind = (typeof SALARY_LEDGER_KINDS)[number];
+export type SalaryLedgerStatus = 'complete' | 'needs-input' | 'not-evaluated';
+
+export interface SalaryLedgerTeamContext {
+  teamId: string;
+  teamCode?: string;
+}
+
+export interface DatedSalaryLedgerContext {
+  /** ISO-8601 date/time with an explicit Z or UTC offset. */
+  asOfDate: string;
+  /** End year of the Salary Cap Year, e.g. 2026 for 2025-26. */
+  salaryCapYear: number;
+  team: SalaryLedgerTeamContext;
+}
+
+export interface SalaryLedgerLineItem<K extends SalaryLedgerKind> {
+  id: string;
+  ledger: K;
+  label: string;
+  /** Signed dollars: additions are positive and subtractions are negative. */
+  amount: number;
+  /** Inclusive effective instant. */
+  effectiveFrom: string;
+  /** Exclusive effective instant. Omit for an open-ended line. */
+  effectiveUntil?: string | null;
+  canonLeafIds: readonly string[];
+  source: {
+    authority: 'canon' | 'team-state' | 'external-determination';
+    reference: string;
+  };
+}
+
+export type SalaryLedgerInput<K extends SalaryLedgerKind> =
+  | {
+      status: 'ready';
+      lineItems: readonly SalaryLedgerLineItem<K>[];
+    }
+  | {
+      status: 'needs-input';
+      missingInputs: readonly string[];
+      reason: string;
+    }
+  | {
+      status: 'not-evaluated';
+      reason: string;
+    };
+
+export type EvaluatedSalaryLedgerLineItem<K extends SalaryLedgerKind> =
+  SalaryLedgerLineItem<K> & {
+    included: boolean;
+    exclusionReason: 'not-yet-effective' | 'no-longer-effective' | null;
+  };
+
+export type SalaryLedgerResult<K extends SalaryLedgerKind> =
+  | {
+      kind: K;
+      status: 'complete';
+      total: number;
+      lineItems: EvaluatedSalaryLedgerLineItem<K>[];
+    }
+  | {
+      kind: K;
+      status: 'needs-input';
+      total: null;
+      lineItems: [];
+      missingInputs: string[];
+      reason: string;
+    }
+  | {
+      kind: K;
+      status: 'not-evaluated';
+      total: null;
+      lineItems: [];
+      reason: string;
+    };
+
+export interface DatedSalaryLedgerRequest {
+  context?: Partial<DatedSalaryLedgerContext> | null;
+  ledgers?: {
+    teamSalary?: SalaryLedgerInput<'team-salary'>;
+    apronTeamSalary?: SalaryLedgerInput<'apron-team-salary'>;
+    taxSalary?: SalaryLedgerInput<'tax-salary'>;
+  } | null;
+}
+
+export interface DatedSalaryLedgerEvaluation {
+  status: SalaryLedgerStatus;
+  context: DatedSalaryLedgerContext | null;
+  ledgers: {
+    teamSalary: SalaryLedgerResult<'team-salary'>;
+    apronTeamSalary: SalaryLedgerResult<'apron-team-salary'>;
+    taxSalary: SalaryLedgerResult<'tax-salary'>;
+  };
+}
+
+const ZONED_ISO_DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isZonedDateTime(value: unknown): value is string {
+  return (
+    isNonEmptyString(value) &&
+    ZONED_ISO_DATE_TIME.test(value) &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function resolveContext(
+  context: DatedSalaryLedgerRequest['context']
+):
+  | { context: DatedSalaryLedgerContext; missingInputs: [] }
+  | { context: null; missingInputs: string[] } {
+  const missingInputs: string[] = [];
+
+  if (!isZonedDateTime(context?.asOfDate)) {
+    missingInputs.push('context.asOfDate');
+  }
+  if (!Number.isInteger(context?.salaryCapYear)) {
+    missingInputs.push('context.salaryCapYear');
+  }
+  if (!isNonEmptyString(context?.team?.teamId)) {
+    missingInputs.push('context.team.teamId');
+  }
+
+  if (missingInputs.length > 0) {
+    return { context: null, missingInputs };
+  }
+
+  const teamCode = isNonEmptyString(context?.team?.teamCode)
+    ? context.team.teamCode.trim()
+    : undefined;
+
+  return {
+    context: {
+      asOfDate: context!.asOfDate!,
+      salaryCapYear: context!.salaryCapYear!,
+      team: {
+        teamId: context!.team!.teamId!.trim(),
+        ...(teamCode ? { teamCode } : {}),
+      },
+    },
+    missingInputs: [],
+  };
+}
+
+function validateLineItems<K extends SalaryLedgerKind>(
+  kind: K,
+  lineItems: readonly SalaryLedgerLineItem<K>[]
+): string[] {
+  const missingInputs: string[] = [];
+  const seenIds = new Set<string>();
+
+  lineItems.forEach((item, index) => {
+    const path = `ledgers.${kind}.lineItems[${index}]`;
+    if (!isNonEmptyString(item.id) || seenIds.has(item.id)) {
+      missingInputs.push(`${path}.id`);
+    } else {
+      seenIds.add(item.id);
+    }
+    if (item.ledger !== kind) missingInputs.push(`${path}.ledger`);
+    if (!isNonEmptyString(item.label)) missingInputs.push(`${path}.label`);
+    if (!Number.isFinite(item.amount)) missingInputs.push(`${path}.amount`);
+    if (!isZonedDateTime(item.effectiveFrom)) {
+      missingInputs.push(`${path}.effectiveFrom`);
+    }
+    if (item.effectiveUntil != null && !isZonedDateTime(item.effectiveUntil)) {
+      missingInputs.push(`${path}.effectiveUntil`);
+    }
+    if (
+      isZonedDateTime(item.effectiveFrom) &&
+      isZonedDateTime(item.effectiveUntil) &&
+      Date.parse(item.effectiveUntil) <= Date.parse(item.effectiveFrom)
+    ) {
+      missingInputs.push(`${path}.effectiveUntil`);
+    }
+    if (
+      !Array.isArray(item.canonLeafIds) ||
+      item.canonLeafIds.length === 0 ||
+      item.canonLeafIds.some((leafId) => !isNonEmptyString(leafId))
+    ) {
+      missingInputs.push(`${path}.canonLeafIds`);
+    }
+    if (!isNonEmptyString(item.source?.reference)) {
+      missingInputs.push(`${path}.source.reference`);
+    }
+  });
+
+  return missingInputs;
+}
+
+function incompleteLedger<K extends SalaryLedgerKind>(
+  kind: K,
+  missingInputs: readonly string[],
+  reason: string
+): SalaryLedgerResult<K> {
+  return {
+    kind,
+    status: 'needs-input',
+    total: null,
+    lineItems: [],
+    missingInputs: [...missingInputs],
+    reason,
+  };
+}
+
+function evaluateLedger<K extends SalaryLedgerKind>(
+  kind: K,
+  asOfDate: string,
+  input: SalaryLedgerInput<K> | undefined
+): SalaryLedgerResult<K> {
+  if (!input) {
+    return incompleteLedger(
+      kind,
+      [`ledgers.${kind}`],
+      `No ${kind} input was supplied.`
+    );
+  }
+  if (input.status === 'needs-input') {
+    return incompleteLedger(kind, input.missingInputs, input.reason);
+  }
+  if (input.status === 'not-evaluated') {
+    return {
+      kind,
+      status: 'not-evaluated',
+      total: null,
+      lineItems: [],
+      reason: input.reason,
+    };
+  }
+
+  const missingInputs = validateLineItems(kind, input.lineItems);
+  if (missingInputs.length > 0) {
+    return incompleteLedger(
+      kind,
+      missingInputs,
+      `The ${kind} line items are incomplete or invalid.`
+    );
+  }
+
+  const asOfTime = Date.parse(asOfDate);
+  const lineItems = input.lineItems.map((item) => {
+    const effectiveFrom = Date.parse(item.effectiveFrom);
+    const effectiveUntil = item.effectiveUntil
+      ? Date.parse(item.effectiveUntil)
+      : null;
+    const exclusionReason: EvaluatedSalaryLedgerLineItem<K>['exclusionReason'] =
+      asOfTime < effectiveFrom
+        ? 'not-yet-effective'
+        : effectiveUntil != null && asOfTime >= effectiveUntil
+          ? 'no-longer-effective'
+          : null;
+
+    return {
+      ...item,
+      canonLeafIds: [...item.canonLeafIds],
+      source: { ...item.source },
+      included: exclusionReason === null,
+      exclusionReason,
+    };
+  });
+
+  return {
+    kind,
+    status: 'complete',
+    total: lineItems.reduce(
+      (sum, lineItem) => sum + (lineItem.included ? lineItem.amount : 0),
+      0
+    ),
+    lineItems,
+  };
+}
+
+function aggregateStatus(
+  results: readonly SalaryLedgerResult<SalaryLedgerKind>[]
+): SalaryLedgerStatus {
+  if (results.some((result) => result.status === 'needs-input')) {
+    return 'needs-input';
+  }
+  if (results.some((result) => result.status === 'not-evaluated')) {
+    return 'not-evaluated';
+  }
+  return 'complete';
+}
+
+/**
+ * Evaluate the three salary meanings without substituting one for another.
+ * Missing governed context makes every ledger unavailable; no runtime or
+ * season fallback is consulted.
+ */
+export function evaluateDatedSalaryLedgers(
+  request: DatedSalaryLedgerRequest
+): DatedSalaryLedgerEvaluation {
+  const contextResult = resolveContext(request.context);
+  if (!contextResult.context) {
+    const reason =
+      'Dated salary ledgers require an explicit zoned asOfDate, Salary Cap Year, and team.';
+    const ledgers = {
+      teamSalary: incompleteLedger(
+        'team-salary',
+        contextResult.missingInputs,
+        reason
+      ),
+      apronTeamSalary: incompleteLedger(
+        'apron-team-salary',
+        contextResult.missingInputs,
+        reason
+      ),
+      taxSalary: incompleteLedger(
+        'tax-salary',
+        contextResult.missingInputs,
+        reason
+      ),
+    };
+
+    return { status: 'needs-input', context: null, ledgers };
+  }
+
+  const ledgers = {
+    teamSalary: evaluateLedger(
+      'team-salary',
+      contextResult.context.asOfDate,
+      request.ledgers?.teamSalary
+    ),
+    apronTeamSalary: evaluateLedger(
+      'apron-team-salary',
+      contextResult.context.asOfDate,
+      request.ledgers?.apronTeamSalary
+    ),
+    taxSalary: evaluateLedger(
+      'tax-salary',
+      contextResult.context.asOfDate,
+      request.ledgers?.taxSalary
+    ),
+  };
+
+  return {
+    status: aggregateStatus(Object.values(ledgers)),
+    context: contextResult.context,
+    ledgers,
+  };
+}

--- a/src/features/architect/utils/capTotals/datedSalaryLedgers.ts
+++ b/src/features/architect/utils/capTotals/datedSalaryLedgers.ts
@@ -15,8 +15,16 @@ export const SALARY_LEDGER_KINDS = [
   'tax-salary',
 ] as const;
 
+const SALARY_LEDGER_SOURCE_AUTHORITIES = [
+  'canon',
+  'team-state',
+  'external-determination',
+] as const;
+
 export type SalaryLedgerKind = (typeof SALARY_LEDGER_KINDS)[number];
 export type SalaryLedgerStatus = 'complete' | 'needs-input' | 'not-evaluated';
+type SalaryLedgerSourceAuthority =
+  (typeof SALARY_LEDGER_SOURCE_AUTHORITIES)[number];
 
 export interface SalaryLedgerTeamContext {
   teamId: string;
@@ -43,7 +51,7 @@ export interface SalaryLedgerLineItem<K extends SalaryLedgerKind> {
   effectiveUntil?: string | null;
   canonLeafIds: readonly string[];
   source: {
-    authority: 'canon' | 'team-state' | 'external-determination';
+    authority: SalaryLedgerSourceAuthority;
     reference: string;
   };
 }
@@ -118,11 +126,46 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function hasValidCalendarDate(value: string): boolean {
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+
+  if (month < 1 || month > 12 || day < 1) return false;
+
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+
+  return day <= daysInMonth[month - 1];
+}
+
 function isZonedDateTime(value: unknown): value is string {
   return (
     isNonEmptyString(value) &&
     ZONED_ISO_DATE_TIME.test(value) &&
+    hasValidCalendarDate(value) &&
     Number.isFinite(Date.parse(value))
+  );
+}
+
+function isSalaryLedgerSourceAuthority(
+  value: unknown
+): value is SalaryLedgerSourceAuthority {
+  return SALARY_LEDGER_SOURCE_AUTHORITIES.some(
+    (authority) => authority === value
   );
 }
 
@@ -200,6 +243,9 @@ function validateLineItems<K extends SalaryLedgerKind>(
       item.canonLeafIds.some((leafId) => !isNonEmptyString(leafId))
     ) {
       missingInputs.push(`${path}.canonLeafIds`);
+    }
+    if (!isSalaryLedgerSourceAuthority(item.source?.authority)) {
+      missingInputs.push(`${path}.source.authority`);
     }
     if (!isNonEmptyString(item.source?.reference)) {
       missingInputs.push(`${path}.source.reference`);

--- a/src/features/architect/utils/capTotals/datedSalaryLedgers.ts
+++ b/src/features/architect/utils/capTotals/datedSalaryLedgers.ts
@@ -119,6 +119,25 @@ export interface DatedSalaryLedgerEvaluation {
   };
 }
 
+/**
+ * Request property name that owns each ledger kind. Missing-input paths are
+ * built from this map so a caller can navigate a returned path directly on the
+ * request object. Typing it against the request interface makes the two drift
+ * apart a compile error rather than a silently unnavigable path.
+ */
+const SALARY_LEDGER_REQUEST_KEYS: Record<
+  SalaryLedgerKind,
+  keyof NonNullable<DatedSalaryLedgerRequest['ledgers']>
+> = {
+  'team-salary': 'teamSalary',
+  'apron-team-salary': 'apronTeamSalary',
+  'tax-salary': 'taxSalary',
+};
+
+function ledgerRequestPath(kind: SalaryLedgerKind): string {
+  return `ledgers.${SALARY_LEDGER_REQUEST_KEYS[kind]}`;
+}
+
 const ZONED_ISO_DATE_TIME =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
 
@@ -213,9 +232,10 @@ function validateLineItems<K extends SalaryLedgerKind>(
 ): string[] {
   const missingInputs: string[] = [];
   const seenIds = new Set<string>();
+  const ledgerPath = ledgerRequestPath(kind);
 
   lineItems.forEach((item, index) => {
-    const path = `ledgers.${kind}.lineItems[${index}]`;
+    const path = `${ledgerPath}.lineItems[${index}]`;
     if (!isNonEmptyString(item.id) || seenIds.has(item.id)) {
       missingInputs.push(`${path}.id`);
     } else {
@@ -275,10 +295,12 @@ function evaluateLedger<K extends SalaryLedgerKind>(
   asOfDate: string,
   input: SalaryLedgerInput<K> | undefined
 ): SalaryLedgerResult<K> {
+  const ledgerPath = ledgerRequestPath(kind);
+
   if (!input) {
     return incompleteLedger(
       kind,
-      [`ledgers.${kind}`],
+      [ledgerPath],
       `No ${kind} input was supplied.`
     );
   }
@@ -293,6 +315,17 @@ function evaluateLedger<K extends SalaryLedgerKind>(
       lineItems: [],
       reason: input.reason,
     };
+  }
+
+  // A ready ledger with nothing in it is unevaluated input, not a $0 total.
+  // A real zero must be carried by an evidenced zero-dollar line item so the
+  // amount keeps its own Canon traceability and source authority.
+  if (!Array.isArray(input.lineItems) || input.lineItems.length === 0) {
+    return incompleteLedger(
+      kind,
+      [`${ledgerPath}.lineItems`],
+      `The ${kind} ledger was marked ready with no line items; a zero total must be supplied as an evidenced zero-dollar line item.`
+    );
   }
 
   const missingInputs = validateLineItems(kind, input.lineItems);

--- a/src/features/architect/utils/capTotals/index.ts
+++ b/src/features/architect/utils/capTotals/index.ts
@@ -19,3 +19,20 @@ export {
 } from './computeTeamCapTotals';
 // updated: Wave 3 retained export default on computeTeamCapTotals for smoke-test compat; barrel must re-export it
 export { default } from './computeTeamCapTotals';
+
+export {
+  SALARY_LEDGER_KINDS,
+  evaluateDatedSalaryLedgers,
+} from './datedSalaryLedgers';
+export type {
+  DatedSalaryLedgerContext,
+  DatedSalaryLedgerEvaluation,
+  DatedSalaryLedgerRequest,
+  EvaluatedSalaryLedgerLineItem,
+  SalaryLedgerInput,
+  SalaryLedgerKind,
+  SalaryLedgerLineItem,
+  SalaryLedgerResult,
+  SalaryLedgerStatus,
+  SalaryLedgerTeamContext,
+} from './datedSalaryLedgers';

--- a/src/tests/architect/capSheetFull_ssot_parity_guardrails.test.ts
+++ b/src/tests/architect/capSheetFull_ssot_parity_guardrails.test.ts
@@ -11,8 +11,8 @@
  *    1. CapSheetFull.tsx imports computeTeamCapTotals
  *    2. CapSheetFull.tsx does NOT contain local reduce salary summation
  *    2D. CapSheetFull.tsx declares explicit multi-year hierarchy surfaces
- *    3. computeTeamCapTotals.ts declares explicit included/excluded ownership lists
- *    4. computeTeamCapTotals.ts declares canonical-owner usage fence
+ *    3. computeTeamCapTotals.ts declares the legacy compatibility ownership list
+ *    4. legacy totals and governed dated ledgers have an explicit usage fence
  *    5. calculateTeamCapHit(...) is fenced as player-only validation math
  *    6. useCapValidation.ts declares validation-only cap-math ownership
  *    7. capLegalityValidation.ts declares action-specific validation ownership
@@ -49,6 +49,11 @@ const CAP_SHEET_FULL_PATH = path.resolve(
 const COMPUTE_TOTALS_PATH = path.resolve(
   __dirname,
   '../../features/architect/utils/capTotals/computeTeamCapTotals.ts'
+);
+
+const DATED_SALARY_LEDGERS_PATH = path.resolve(
+  __dirname,
+  '../../features/architect/utils/capTotals/datedSalaryLedgers.ts'
 );
 
 const CAP_HELPERS_PATH = path.resolve(
@@ -155,6 +160,10 @@ function createMultiYearPlayers(
 describe('CapSheetFull SSOT Parity — Source-Scan Guardrails', () => {
   const capSheetFullSource = fs.readFileSync(CAP_SHEET_FULL_PATH, 'utf-8');
   const computeTotalsSource = fs.readFileSync(COMPUTE_TOTALS_PATH, 'utf-8');
+  const datedSalaryLedgersSource = fs.readFileSync(
+    DATED_SALARY_LEDGERS_PATH,
+    'utf-8'
+  );
   const capHelpersSource = fs.readFileSync(CAP_HELPERS_PATH, 'utf-8');
   const useCapValidationSource = fs.readFileSync(
     USE_CAP_VALIDATION_PATH,
@@ -216,18 +225,34 @@ describe('CapSheetFull SSOT Parity — Source-Scan Guardrails', () => {
     expect(capSheetFullSource).toContain('Canonical yearly total');
   });
 
-  it('TEST 3: computeTeamCapTotals declares explicit included/excluded ownership lists', () => {
-    expect(computeTotalsSource).toContain('INCLUDED IN CANONICAL TOTALS');
-    expect(computeTotalsSource).toContain('EXCLUDED FROM CANONICAL TOTALS');
+  it('TEST 3: computeTeamCapTotals declares the legacy compatibility ownership list', () => {
+    expect(computeTotalsSource).toContain('BZE-268 COMPATIBILITY BOUNDARY');
+    expect(computeTotalsSource).toContain(
+      'INCLUDED IN LEGACY COMPATIBILITY TOTALS'
+    );
+    expect(computeTotalsSource).toContain(
+      'EXCLUDED FROM LEGACY COMPATIBILITY TOTALS'
+    );
   });
 
-  it('TEST 4: computeTeamCapTotals declares canonical-owner usage fence', () => {
-    expect(computeTotalsSource).toContain('Canonical Cap Sheet totals owner.');
+  it('TEST 4: legacy totals and governed dated ledgers have an explicit usage fence', () => {
+    expect(computeTotalsSource).toContain(
+      'Legacy Cap Sheet compatibility totals owner.'
+    );
     expect(computeTotalsSource).toContain(
       'Use computeTeamCapTotals(...) when a caller needs totalCapAllocations,'
     );
     expect(computeTotalsSource).toContain(
       'Do not use computeTeamCapTotals(...) for player-only validation/projection'
+    );
+    expect(datedSalaryLedgersSource).toContain(
+      "borrow another ledger's total"
+    );
+    expect(datedSalaryLedgersSource).toContain(
+      'runtime date or a different Salary Cap Year'
+    );
+    expect(datedSalaryLedgersSource).toContain(
+      'export function evaluateDatedSalaryLedgers('
     );
   });
 

--- a/tests/architect/capTotals/datedSalaryLedgers.test.ts
+++ b/tests/architect/capTotals/datedSalaryLedgers.test.ts
@@ -5,6 +5,24 @@ import {
   type SalaryLedgerLineItem,
 } from '@/features/architect/utils/capTotals';
 
+/**
+ * Walk a returned missing-input path against the request it describes. A path
+ * that does not resolve is not an audit trail, so the tests assert navigability
+ * rather than only string equality.
+ */
+function resolvePath(root: unknown, path: string): unknown {
+  return path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .reduce<unknown>(
+      (node, segment) =>
+        node == null
+          ? undefined
+          : (node as Record<string, unknown>)[segment],
+      root
+    );
+}
+
 const CONTEXT = {
   asOfDate: '2026-04-13T12:00:00-04:00',
   salaryCapYear: 2026,
@@ -233,7 +251,7 @@ describe('BZE-268 dated independent salary-ledger spine', () => {
         status: 'needs-input',
         total: null,
         lineItems: [],
-        missingInputs: [`ledgers.team-salary.lineItems[0].${field}`],
+        missingInputs: [`ledgers.teamSalary.lineItems[0].${field}`],
       });
     }
   );
@@ -287,7 +305,7 @@ describe('BZE-268 dated independent salary-ledger spine', () => {
     expect(result.ledgers.apronTeamSalary).toMatchObject({
       status: 'needs-input',
       total: null,
-      missingInputs: ['ledgers.apron-team-salary.lineItems[0].ledger'],
+      missingInputs: ['ledgers.apronTeamSalary.lineItems[0].ledger'],
     });
   });
 
@@ -314,9 +332,7 @@ describe('BZE-268 dated independent salary-ledger spine', () => {
         status: 'needs-input',
         total: null,
         lineItems: [],
-        missingInputs: [
-          'ledgers.team-salary.lineItems[0].source.authority',
-        ],
+        missingInputs: ['ledgers.teamSalary.lineItems[0].source.authority'],
       });
     }
   );
@@ -340,4 +356,110 @@ describe('BZE-268 dated independent salary-ledger spine', () => {
       expect(result.ledgers.teamSalary.status).toBe('complete');
     }
   );
+
+  it('reports missing-input paths that resolve on the actual request object', () => {
+    const request = buildCanonFixture();
+    request.ledgers!.apronTeamSalary = {
+      status: 'ready',
+      lineItems: [
+        {
+          ...excludedPerformanceBonus,
+          label: '',
+        },
+      ],
+    };
+
+    const result = evaluateDatedSalaryLedgers(request);
+    const [missingPath] = (
+      result.ledgers.apronTeamSalary as { missingInputs: string[] }
+    ).missingInputs;
+
+    expect(missingPath).toBe('ledgers.apronTeamSalary.lineItems[0].label');
+    // The path is only useful if a caller can walk it back to the input it names.
+    expect(resolvePath(request, missingPath)).toBe('');
+    expect(resolvePath(request, 'ledgers.apronTeamSalary.lineItems[0].id')).toBe(
+      'apron-excluded-performance-bonus'
+    );
+  });
+
+  it('names the request property, not the ledger kind, for an omitted ledger', () => {
+    const result = evaluateDatedSalaryLedgers({
+      context: CONTEXT,
+      ledgers: { teamSalary: { status: 'ready', lineItems: [teamSalaryBase] } },
+    });
+
+    expect(result.status).toBe('needs-input');
+    expect(result.ledgers.apronTeamSalary).toMatchObject({
+      status: 'needs-input',
+      total: null,
+      missingInputs: ['ledgers.apronTeamSalary'],
+    });
+    expect(result.ledgers.taxSalary).toMatchObject({
+      status: 'needs-input',
+      total: null,
+      missingInputs: ['ledgers.taxSalary'],
+    });
+    expect(resolvePath(CONTEXT, 'salaryCapYear')).toBe(2026);
+  });
+
+  it('refuses to report a ready ledger with no line items as a complete $0', () => {
+    const request = buildCanonFixture();
+    request.ledgers!.taxSalary = { status: 'ready', lineItems: [] };
+
+    const result = evaluateDatedSalaryLedgers(request);
+
+    expect(result.status).toBe('needs-input');
+    expect(result.ledgers.taxSalary).toMatchObject({
+      kind: 'tax-salary',
+      status: 'needs-input',
+      total: null,
+      lineItems: [],
+      missingInputs: ['ledgers.taxSalary.lineItems'],
+    });
+    expect(result.ledgers.taxSalary.total).not.toBe(0);
+    // The other ledgers still evaluate independently.
+    expect(result.ledgers.teamSalary.total).toBe(150_000_000);
+    expect(result.ledgers.apronTeamSalary.total).toBe(151_000_000);
+  });
+
+  it('reports a genuine zero only from an evidenced zero-dollar line item', () => {
+    const request = buildCanonFixture();
+    request.ledgers!.taxSalary = {
+      status: 'ready',
+      lineItems: [
+        {
+          ...taxSalaryBaseline,
+          id: 'tax-evidenced-zero',
+          label: 'Tax Salary baseline evidenced at zero',
+          amount: 0,
+        },
+      ],
+    };
+
+    const result = evaluateDatedSalaryLedgers(request);
+
+    expect(result.status).toBe('complete');
+    expect(result.ledgers.taxSalary).toMatchObject({
+      status: 'complete',
+      total: 0,
+    });
+    expect(result.ledgers.taxSalary.lineItems).toMatchObject([
+      { id: 'tax-evidenced-zero', amount: 0, included: true },
+    ]);
+  });
+
+  it('does not crash or total a ready ledger whose line items are absent', () => {
+    const request = buildCanonFixture();
+    request.ledgers!.teamSalary = {
+      status: 'ready',
+    } as unknown as (typeof request.ledgers)['teamSalary'];
+
+    const result = evaluateDatedSalaryLedgers(request);
+
+    expect(result.ledgers.teamSalary).toMatchObject({
+      status: 'needs-input',
+      total: null,
+      missingInputs: ['ledgers.teamSalary.lineItems'],
+    });
+  });
 });

--- a/tests/architect/capTotals/datedSalaryLedgers.test.ts
+++ b/tests/architect/capTotals/datedSalaryLedgers.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateDatedSalaryLedgers,
+  type DatedSalaryLedgerRequest,
+  type SalaryLedgerLineItem,
+} from '@/features/architect/utils/capTotals';
+
+const CONTEXT = {
+  asOfDate: '2026-04-13T12:00:00-04:00',
+  salaryCapYear: 2026,
+  team: { teamId: 'TEAM-R7-001', teamCode: 'R7A' },
+} as const;
+
+const teamSalaryBase: SalaryLedgerLineItem<'team-salary'> = {
+  id: 'team-salary-base',
+  ledger: 'team-salary',
+  label: 'Team Salary at the evaluation instant',
+  amount: 150_000_000,
+  effectiveFrom: '2025-07-01T00:00:00-04:00',
+  canonLeafIds: ['CBA2-A01.1', 'CBA2-C01.1'],
+  source: { authority: 'team-state', reference: 'TEAM-R7-001@v1' },
+};
+
+const apronSalaryBase: SalaryLedgerLineItem<'apron-team-salary'> = {
+  id: 'apron-team-salary-base',
+  ledger: 'apron-team-salary',
+  label: 'Apron Team Salary baseline',
+  amount: 150_000_000,
+  effectiveFrom: '2025-07-01T00:00:00-04:00',
+  canonLeafIds: ['CBA2-A01.1', 'CBA2-C07.1'],
+  source: { authority: 'canon', reference: 'EV2-0186' },
+};
+
+const excludedPerformanceBonus: SalaryLedgerLineItem<'apron-team-salary'> = {
+  id: 'apron-excluded-performance-bonus',
+  ledger: 'apron-team-salary',
+  label: 'Performance bonus excluded from Salary',
+  amount: 1_000_000,
+  effectiveFrom: '2025-07-01T00:00:00-04:00',
+  canonLeafIds: ['CBA2-C07.2'],
+  source: {
+    authority: 'canon',
+    reference: 'EV2-0187 / CBA2-SC-026(a)',
+  },
+};
+
+const taxSalaryBaseline: SalaryLedgerLineItem<'tax-salary'> = {
+  id: 'tax-last-game-baseline',
+  ledger: 'tax-salary',
+  label: 'Team Salary at start of last Regular Season game',
+  amount: 200_000_000,
+  effectiveFrom: '2026-04-12T19:00:00-04:00',
+  canonLeafIds: ['CBA2-A01.1', 'CBA2-C08.1'],
+  source: {
+    authority: 'canon',
+    reference: 'EV2-0197 / CBA2-SC-027(a)',
+  },
+};
+
+const postBaselineContractEvent: SalaryLedgerLineItem<'tax-salary'> = {
+  id: 'tax-post-baseline-contract-event',
+  ledger: 'tax-salary',
+  label: 'Post-baseline contract Tax Salary effect',
+  amount: 2_000_000,
+  effectiveFrom: '2026-04-13T12:00:00-04:00',
+  canonLeafIds: ['CBA2-C08.2'],
+  source: {
+    authority: 'canon',
+    reference: 'EV2-0198 / CBA2-SC-027(b)',
+  },
+};
+
+function buildCanonFixture(
+  asOfDate = CONTEXT.asOfDate
+): DatedSalaryLedgerRequest {
+  return {
+    context: { ...CONTEXT, asOfDate },
+    ledgers: {
+      teamSalary: { status: 'ready', lineItems: [teamSalaryBase] },
+      apronTeamSalary: {
+        status: 'ready',
+        lineItems: [apronSalaryBase, excludedPerformanceBonus],
+      },
+      taxSalary: {
+        status: 'ready',
+        lineItems: [taxSalaryBaseline, postBaselineContractEvent],
+      },
+    },
+  };
+}
+
+describe('BZE-268 dated independent salary-ledger spine', () => {
+  it('keeps Team, Apron, and Tax Salary independent for one team and date', () => {
+    const result = evaluateDatedSalaryLedgers(buildCanonFixture());
+
+    expect(result.status).toBe('complete');
+    expect(result.context).toEqual(CONTEXT);
+    expect(result.ledgers.teamSalary).toMatchObject({
+      kind: 'team-salary',
+      status: 'complete',
+      total: 150_000_000,
+    });
+    expect(result.ledgers.apronTeamSalary).toMatchObject({
+      kind: 'apron-team-salary',
+      status: 'complete',
+      total: 151_000_000,
+    });
+    expect(result.ledgers.taxSalary).toMatchObject({
+      kind: 'tax-salary',
+      status: 'complete',
+      total: 202_000_000,
+    });
+    expect(
+      new Set([
+        result.ledgers.teamSalary.total,
+        result.ledgers.apronTeamSalary.total,
+        result.ledgers.taxSalary.total,
+      ]).size
+    ).toBe(3);
+    expect(result.ledgers.teamSalary.lineItems).not.toBe(
+      result.ledgers.apronTeamSalary.lineItems
+    );
+    expect(result.ledgers.apronTeamSalary.lineItems).not.toBe(
+      result.ledgers.taxSalary.lineItems
+    );
+  });
+
+  it('evaluates line-item effectiveness at the caller-supplied instant', () => {
+    const beforeEvent = evaluateDatedSalaryLedgers(
+      buildCanonFixture('2026-04-13T11:59:59-04:00')
+    );
+    const atEvent = evaluateDatedSalaryLedgers(buildCanonFixture());
+
+    expect(beforeEvent.ledgers.taxSalary).toMatchObject({
+      status: 'complete',
+      total: 200_000_000,
+      lineItems: [
+        { id: 'tax-last-game-baseline', included: true },
+        {
+          id: 'tax-post-baseline-contract-event',
+          included: false,
+          exclusionReason: 'not-yet-effective',
+        },
+      ],
+    });
+    expect(atEvent.ledgers.taxSalary).toMatchObject({
+      status: 'complete',
+      total: 202_000_000,
+      lineItems: [
+        { id: 'tax-last-game-baseline', included: true },
+        {
+          id: 'tax-post-baseline-contract-event',
+          included: true,
+          exclusionReason: null,
+        },
+      ],
+    });
+  });
+
+  it('returns needs-input instead of substituting runtime date, season, or team', () => {
+    const result = evaluateDatedSalaryLedgers({
+      context: {
+        asOfDate: '2026-04-13T12:00:00',
+        team: { teamId: '' },
+      },
+      ledgers: buildCanonFixture().ledgers,
+    });
+
+    expect(result.status).toBe('needs-input');
+    expect(result.context).toBeNull();
+    expect(result.ledgers.teamSalary).toMatchObject({
+      status: 'needs-input',
+      total: null,
+      lineItems: [],
+      missingInputs: [
+        'context.asOfDate',
+        'context.salaryCapYear',
+        'context.team.teamId',
+      ],
+    });
+    expect(result.ledgers.apronTeamSalary.total).toBeNull();
+    expect(result.ledgers.taxSalary.total).toBeNull();
+  });
+
+  it('preserves per-ledger needs-input and not-evaluated states', () => {
+    const result = evaluateDatedSalaryLedgers({
+      context: CONTEXT,
+      ledgers: {
+        teamSalary: { status: 'ready', lineItems: [teamSalaryBase] },
+        apronTeamSalary: {
+          status: 'needs-input',
+          missingInputs: ['excludedPerformanceBonuses'],
+          reason: 'Apron adjustments have not been supplied.',
+        },
+        taxSalary: {
+          status: 'not-evaluated',
+          reason: 'Last Regular Season game baseline is not registered.',
+        },
+      },
+    });
+
+    expect(result.status).toBe('needs-input');
+    expect(result.ledgers.teamSalary.total).toBe(150_000_000);
+    expect(result.ledgers.apronTeamSalary).toMatchObject({
+      status: 'needs-input',
+      total: null,
+      missingInputs: ['excludedPerformanceBonuses'],
+    });
+    expect(result.ledgers.taxSalary).toMatchObject({
+      status: 'not-evaluated',
+      total: null,
+    });
+  });
+
+  it('rejects a line item assigned to the wrong ledger kind', () => {
+    const result = evaluateDatedSalaryLedgers({
+      context: CONTEXT,
+      ledgers: {
+        teamSalary: { status: 'ready', lineItems: [teamSalaryBase] },
+        apronTeamSalary: {
+          status: 'ready',
+          lineItems: [
+            teamSalaryBase as unknown as SalaryLedgerLineItem<'apron-team-salary'>,
+          ],
+        },
+        taxSalary: { status: 'ready', lineItems: [taxSalaryBaseline] },
+      },
+    });
+
+    expect(result.ledgers.teamSalary.total).toBe(150_000_000);
+    expect(result.ledgers.apronTeamSalary).toMatchObject({
+      status: 'needs-input',
+      total: null,
+      missingInputs: ['ledgers.apron-team-salary.lineItems[0].ledger'],
+    });
+  });
+});

--- a/tests/architect/capTotals/datedSalaryLedgers.test.ts
+++ b/tests/architect/capTotals/datedSalaryLedgers.test.ts
@@ -182,6 +182,62 @@ describe('BZE-268 dated independent salary-ledger spine', () => {
     expect(result.ledgers.taxSalary.total).toBeNull();
   });
 
+  it.each([
+    '2026-02-30T12:00:00Z',
+    '2026-04-31T12:00:00-04:00',
+    '2025-02-29T12:00:00Z',
+  ])('rejects an impossible governed context date: %s', (asOfDate) => {
+    const result = evaluateDatedSalaryLedgers(buildCanonFixture(asOfDate));
+
+    expect(result).toMatchObject({
+      status: 'needs-input',
+      context: null,
+      ledgers: {
+        teamSalary: {
+          status: 'needs-input',
+          total: null,
+          missingInputs: ['context.asOfDate'],
+        },
+      },
+    });
+  });
+
+  it('accepts a valid leap-day governed context date', () => {
+    const result = evaluateDatedSalaryLedgers(
+      buildCanonFixture('2024-02-29T12:00:00Z')
+    );
+
+    expect(result.status).toBe('complete');
+    expect(result.context?.asOfDate).toBe('2024-02-29T12:00:00Z');
+  });
+
+  it.each([
+    ['effectiveFrom', '2026-02-30T12:00:00Z'],
+    ['effectiveUntil', '2025-02-29T12:00:00Z'],
+  ] as const)(
+    'rejects an impossible line-item %s date with its exact input path',
+    (field, value) => {
+      const invalidLineItem = {
+        ...teamSalaryBase,
+        [field]: value,
+      } as SalaryLedgerLineItem<'team-salary'>;
+      const request = buildCanonFixture();
+      request.ledgers!.teamSalary = {
+        status: 'ready',
+        lineItems: [invalidLineItem],
+      };
+
+      const result = evaluateDatedSalaryLedgers(request);
+
+      expect(result.ledgers.teamSalary).toMatchObject({
+        status: 'needs-input',
+        total: null,
+        lineItems: [],
+        missingInputs: [`ledgers.team-salary.lineItems[0].${field}`],
+      });
+    }
+  );
+
   it('preserves per-ledger needs-input and not-evaluated states', () => {
     const result = evaluateDatedSalaryLedgers({
       context: CONTEXT,
@@ -234,4 +290,54 @@ describe('BZE-268 dated independent salary-ledger spine', () => {
       missingInputs: ['ledgers.apron-team-salary.lineItems[0].ledger'],
     });
   });
+
+  it.each([undefined, 'spreadsheet-export'])(
+    'rejects a runtime-decoded source authority of %s with its exact input path',
+    (authority) => {
+      const invalidLineItem = {
+        ...teamSalaryBase,
+        source: {
+          ...(authority === undefined ? {} : { authority }),
+          reference: 'TEAM-R7-001@decoded',
+        },
+      } as unknown as SalaryLedgerLineItem<'team-salary'>;
+      const request = buildCanonFixture();
+      request.ledgers!.teamSalary = {
+        status: 'ready',
+        lineItems: [invalidLineItem],
+      };
+
+      const result = evaluateDatedSalaryLedgers(request);
+
+      expect(result.status).toBe('needs-input');
+      expect(result.ledgers.teamSalary).toMatchObject({
+        status: 'needs-input',
+        total: null,
+        lineItems: [],
+        missingInputs: [
+          'ledgers.team-salary.lineItems[0].source.authority',
+        ],
+      });
+    }
+  );
+
+  it.each(['canon', 'team-state', 'external-determination'] as const)(
+    'accepts the governed source authority: %s',
+    (authority) => {
+      const request = buildCanonFixture();
+      request.ledgers!.teamSalary = {
+        status: 'ready',
+        lineItems: [
+          {
+            ...teamSalaryBase,
+            source: { authority, reference: 'TEAM-R7-001@validated' },
+          },
+        ],
+      };
+
+      const result = evaluateDatedSalaryLedgers(request);
+
+      expect(result.ledgers.teamSalary.status).toBe('complete');
+    }
+  );
 });


### PR DESCRIPTION
Fixes BZE-268

## Scope

Adds the bounded governed foundation for independently evaluated Team Salary, Apron Team Salary, and Tax Salary. The new path requires a zoned `asOfDate`, explicit Salary Cap Year, and team identity; returns auditable dated line items; and preserves `complete`, `needs-input`, and `not-evaluated` states without runtime-date, prior-season, or cross-ledger fallback.

Existing consumers remain behaviorally unchanged behind an explicitly temporary legacy compatibility boundary. This PR does not migrate consumers, redesign UI, persist new state, or implement the full apron/tax rule families.

## Governed sources

All Canon claims below are verified against these exact refs, not against the quarantined historical Canon on `main`.

- **Accepted Canon candidate:** [`docs/reference/cba/ARCHITECT_CBA_CANON.md` @ `6cf8aaf3`](https://github.com/Bet-Zero/scoutzero/blob/6cf8aaf358c158a88e630e8a7336f7e9c3febc17/docs/reference/cba/ARCHITECT_CBA_CANON.md)
- **Accepted Canon SHA-256:** `23fe883f6f1aec7799fc3396bef404c250fd26beefa705582a5307766ad7ff76` (independently recomputed on the fetched blob; matches)
- **R9 acceptance record:** [`ARCHITECT_CBA_CANON_V2_R9_INDEPENDENT_ACCEPTANCE.md` @ `4b21456d`](https://github.com/Bet-Zero/scoutzero/blob/4b21456d491f9593edc2961afae47ef64ae28e32/work/architect-completion/ARCHITECT_CBA_CANON_V2_R9_INDEPENDENT_ACCEPTANCE.md)
- **Accepted Phase 2 register:** [`ARCHITECT_CBA_CANON_V2_PHASE2_IMPLEMENTATION_GAPS.json` @ `19dc84fc`](https://github.com/Bet-Zero/scoutzero/blob/19dc84fc4050ce9cf749136dae1f9854adc72ef7/work/architect-completion/ARCHITECT_CBA_CANON_V2_PHASE2_IMPLEMENTATION_GAPS.json)
- **Accepted Phase 2 summary:** [`ARCHITECT_CBA_CANON_V2_PHASE2_AUDIT_SUMMARY.md` @ `4b21456d`](https://github.com/Bet-Zero/scoutzero/blob/4b21456d491f9593edc2961afae47ef64ae28e32/work/architect-completion/ARCHITECT_CBA_CANON_V2_PHASE2_AUDIT_SUMMARY.md)

The accepted register carries `record_count: 815` active v2 LEAF identities and the same Canon SHA-256, confirming this PR and the register describe one edition.

## Reviewer note — Canon edition

A prior FOCUSED REJECT raised identifier and cardinality findings against the `CBA2-*` traceability in this PR. Both were artifacts of reading the **quarantined historical Canon on `main`**, not the accepted edition, and neither is a defect here:

- The quarantined Canon on `main` is edition v1.1, uses historical `CBA-*` IDs, and contains **zero** `CBA2-*` and **zero** `EV2-*` identifiers. Any `CBA2-*` ID will appear "nonexistent" when checked against it.
- Cardinality differs by edition. On `main`: `CBA-C07.1–.10` (10) and `CBA-C08.1–.5` (5). In the accepted Canon: `CBA2-C07.1–.11` (11) and `CBA2-C08.1–.8` (8) — exactly as cited below.

Review this PR against the accepted Canon candidate `6cf8aaf3` above. The `CBA2-*` traceability, audit lineage, and register references are intentional and are not to be rewritten to historical `CBA-*` IDs.

## Canon traceability

- **Exact Canon leaves fully closed product-wide: none.** No leaf is claimed closed by this foundation-only tranche.
- Scoped obligation established: `CBA2-A01.1` non-substitution for the three governed ledger contracts; the leaf remains open product-wide until legacy consumers and the other named salary quantities migrate.
- Dependencies prepared but still open: `CBA2-C07.1` through `.11`, `CBA2-C08.1` through `.8`, `CBA2-L01.1`, and `CBA2-S01.9`.

Canon-derived fixture traceability (verified leaf-by-leaf against `6cf8aaf3`):

| Fixture line item | Evidence / scenario | Canon leaf |
| --- | --- | --- |
| Apron Team Salary baseline | `EV2-0186` | `CBA2-C07.1` |
| Excluded performance bonus, apron adjustment (i) | `EV2-0187` / `CBA2-SC-026(a)` | `CBA2-C07.2` |
| Tax baseline at last Regular Season game start | `EV2-0197` / `CBA2-SC-027(a)` | `CBA2-C08.1` |
| Post-baseline contract Tax Salary effect | `EV2-0198` / `CBA2-SC-027(b)` | `CBA2-C08.2` |

Together these prove one team at one date can carry three different totals, and that a post-baseline item activates only at its explicit instant.

## Open dependency — salary-cap-year / date / calendar reconciliation

`CBA2-L01.1` requires an as-of date, a Salary Cap Year, **and a matching calendar version**, with absent inputs returning unavailable rather than defaulting to runtime today. `CBA2-S01.9` requires official and projected values to remain separate records with distinct authority labels, and an unavailable value to stay unavailable rather than inherit a prior Season amount.

This foundation supplies only the caller-supplied as-of date and Salary Cap Year, and refuses to substitute a runtime date. It does **not** reconcile the salary-cap-year, date, and season-calendar model, and does not resolve official-versus-projected value authority. Both leaves remain **open**; the accepted Phase 2 register records each as `incorrect` / High.

The season-calendar registry is deliberately **not** built in BZE-268. Treat this reconciliation as an explicitly open downstream dependency, not as work completed here.

## Corrections in this revision

Two confirmed defects from independent review, repaired in `55ddde0d`:

1. **Missing-input paths named the ledger kind, not the request property.** Paths were built as `ledgers.team-salary...`, which does not exist on the request; the real properties are `ledgers.teamSalary`, `ledgers.apronTeamSalary`, and `ledgers.taxSalary`. Paths (including line-item paths) now derive from a `SALARY_LEDGER_REQUEST_KEYS` map typed against `DatedSalaryLedgerRequest['ledgers']`, so kind/property drift becomes a compile error rather than a silently unnavigable path.
2. **A `ready` ledger with no line items returned `complete` with total `$0`.** That presented unevaluated input as an evidenced zero. It now returns `needs-input` with the real request path `ledgers.<property>.lineItems`, and the same guard covers an absent `lineItems` array. A genuine zero is still expressible as an evidenced zero-dollar line item, which retains its own Canon leaf IDs and source authority.

Five focused regression tests were added: missing-input paths resolve when walked against the actual request object; an omitted ledger names the request property; a `ready`/empty ledger never reports a complete `$0`; an evidenced zero-dollar line item still totals `0` with `complete`; and an absent `lineItems` array degrades to `needs-input` without throwing.

No `CBA2-*` traceability was removed, no historical `CBA-*` IDs were substituted, the audit lineage was not merged, and no Canon or register content was imported into application code.

## Validation

All counts below were measured on `55ddde0d` and replace the earlier, stale figures.

- `npm run test:node -- --reporter=dot tests/architect/capTotals/datedSalaryLedgers.test.ts src/tests/architect/capSheetFull_ssot_parity_guardrails.test.ts` — **42/42 passed** (2 files; 21 ledger + 21 guardrail). Previously reported as 26/26; the measured pre-repair baseline was 37, so that figure was already understated.
- `npm run test:diff -- --reporter=dot` — TARGETED tier, 7 files, **108/108 passed**.
- `npm run test:architect -- --reporter=dot` — 306 files, **3,576/3,576 passed** in 163.08s.
- `npm run typecheck` — passed.
- `npm run validate:project` — passed.
- `git diff --check` — passed.
- `npx eslint` on both changed files — clean, 0 findings.
- Architect cast-gate (`scripts/architect-cast-gate.mjs`) — PASS, 37 files / 104 tracked violations, no change vs baseline.
- Pre-push docs-sync gate — `npm run docs` regenerated nothing; `docs/` clean.

## Skipped checks and limitations

- Browser QA, `npm run build`, and `npm run test:ui` skipped: no visible behavior, route, or component change.
- Persistence/reload proof skipped: no saved-state contract changed.
- Schema generation/check skipped: no Zod or Firestore schema changed.
- Full suite skipped because the required `RUN FULL SUITE` authorization was not present.
- `graphify update .` was attempted; its safety gate refused to replace the Canon-commit graph with a graph containing 81 fewer nodes. No graph files changed, and `--force` was not used because that would delete unrelated pinned Canon graph content.

Independent review must rerun the targeted Canon proof **against the accepted Canon candidate `6cf8aaf3`** and verify the named leaves before merge. Do not merge or close BZE-268 from this handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date-aware salary ledger evaluation for Team, Apron, and Tax Salary totals.
  * Supports independent ledger totals, effective-date handling, validation, and clear exclusion or evaluation statuses.
  * Exposed salary ledger evaluation capabilities for broader application use.

* **Bug Fixes**
  * Missing-input messages now name the actual request field, so a reported path can be located directly in the request.
  * A ledger marked ready but containing no entries no longer reports a completed total of $0; it now reports that input is still required.

* **Documentation**
  * Updated Architect hierarchy documentation to include the new salary ledger capability.

* **Tests**
  * Added comprehensive coverage for dated evaluations, validation, ledger independence, and required input states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
