### PR TITLE
BZE-269: Restore green main by re-pinning five stale CI assertions

### DIFF
--- a/tests/entitlements/entitlementWarnings.test.ts
+++ b/tests/entitlements/entitlementWarnings.test.ts
@@ -141,7 +141,7 @@ describe('entitlementWarnings', () => {
     it('preserves exact badge mappings, keys, and color classes', () => {
       expect(getEntitlementKindBadge('pick_ownership')).toEqual({
         label: 'Own',
-        colorClass: 'bg-blue-600/30 text-blue-300',
+        colorClass: 'bg-cockpit-info/20 text-cockpit-info',
       });
       expect(Object.keys(getEntitlementKindBadge('pick_ownership'))).toEqual([
         'label',
@@ -150,22 +150,22 @@ describe('entitlementWarnings', () => {
 
       expect(getEntitlementKindBadge('conveyance_right')).toEqual({
         label: 'Conditional',
-        colorClass: 'bg-purple-600/30 text-purple-300',
+        colorClass: 'bg-cockpit-info/20 text-cockpit-info',
       });
       expect(getEntitlementKindBadge('swap_right')).toEqual({
         label: 'Swap Option',
-        colorClass: 'bg-amber-600/30 text-amber-300',
+        colorClass: 'bg-cockpit-watch/20 text-cockpit-watch',
       });
     });
 
     it('preserves unknown badge fallback behavior exactly', () => {
       expect(getEntitlementKindBadge('mystery_kind')).toEqual({
         label: 'mystery_kind',
-        colorClass: 'bg-white/10 text-white/60',
+        colorClass: 'bg-cockpit-raised text-cockpit-text-secondary',
       });
       expect(getEntitlementKindBadge(undefined)).toEqual({
         label: 'Unknown',
-        colorClass: 'bg-white/10 text-white/60',
+        colorClass: 'bg-cockpit-raised text-cockpit-text-secondary',
       });
     });
   });

--- a/tests/entitlements/formatEntitlement.test.ts
+++ b/tests/entitlements/formatEntitlement.test.ts
@@ -19,7 +19,7 @@ describe('formatEntitlement', () => {
     it('preserves exact tag mappings, keys, and color classes', () => {
       expect(getEntitlementKindTag('pick_ownership')).toEqual({
         label: 'Own',
-        colorClass: 'bg-green-600/30 text-green-400',
+        colorClass: 'bg-cockpit-safe/20 text-cockpit-safe',
       });
       expect(Object.keys(getEntitlementKindTag('pick_ownership'))).toEqual([
         'label',
@@ -28,22 +28,22 @@ describe('formatEntitlement', () => {
 
       expect(getEntitlementKindTag('conveyance_right')).toEqual({
         label: 'Conditional',
-        colorClass: 'bg-amber-600/30 text-amber-400',
+        colorClass: 'bg-cockpit-watch/20 text-cockpit-watch',
       });
       expect(getEntitlementKindTag('swap_right')).toEqual({
         label: 'Swap Option',
-        colorClass: 'bg-purple-600/30 text-purple-400',
+        colorClass: 'bg-cockpit-info/20 text-cockpit-info',
       });
     });
 
     it('preserves unknown fallback behavior exactly', () => {
       expect(getEntitlementKindTag('mystery_kind')).toEqual({
         label: 'mystery_kind',
-        colorClass: 'bg-gray-600/30 text-gray-400',
+        colorClass: 'bg-cockpit-raised text-cockpit-text-muted',
       });
       expect(getEntitlementKindTag(undefined)).toEqual({
         label: 'Unknown',
-        colorClass: 'bg-gray-600/30 text-gray-400',
+        colorClass: 'bg-cockpit-raised text-cockpit-text-muted',
       });
     });
   });

--- a/tests/salaryMargin.test.ts
+++ b/tests/salaryMargin.test.ts
@@ -114,7 +114,15 @@ describe('Salary Margin Utilities', () => {
         },
       };
 
-      expect(getAllowableIncomingMargin(team)).toBe(14_000_000);
+      // Base margin comes from the 2023 CBA Band 2 rule (outgoing + expanded
+      // TPE). For $10,000,000 outgoing the public source's own worked example
+      // gives $19,096,000 allowable incoming, i.e. a $9,096,000 base margin
+      // (2026-27 ETPE). On top of that only the USED buckets are added:
+      //   used TPE:       $3,000,000 (matchIncoming) + $2,000,000 (tpeAmount)
+      //   FA exception:   $1,500,000
+      //   MATCH player:   not added (absorbed by the base band)
+      // 9,096,000 + 5,000,000 + 1,500,000 = 15,596,000
+      expect(getAllowableIncomingMargin(team)).toBe(15_596_000);
     });
   });
 


### PR DESCRIPTION
Restores `main` to a green `Full Build, Test & Validate` baseline. **Assertion-only** — no production code, Canon, or audit artifact touched.

## Independently established root cause

The "stale after the cockpit-token migration" framing covers only 4 of the 5. The `salaryMargin` failure is numeric and has a **separate** cause. Both are sweeps that missed files outside the scope their originating commit validated.

### 1. `tests/salaryMargin.test.ts` — 1 failure (not a token issue)

BZE-253 (`388ae98b`) corrected the 2023 CBA Band 2 cushion from an incorrect hardcoded `$7,500,000` to the cap-indexed **Expanded Traded Player Exception**, `$9,096,000` for 2026-27 — externally sourced (Hoops Rumors / SBC) and recorded in `work/architect-completion/ARCHITECT_ACCURACY_ASSESSMENT.md`. That commit re-pinned **13** test/spec files (**9** of them under root `tests/`); this one was not among them and still encoded the pre-fix constant.

Current source behavior is authoritative and matches the public source's own worked example ($10M outgoing → $19,096,000 incoming):

| Component | Amount |
| --- | --- |
| Base margin (Band 2) | `$9,096,000` |
| Used TPE (`$3M` matchIncoming + `$2M` tpeAmount) | `$5,000,000` |
| FA exception | `$1,500,000` |
| **Total** | **`$15,596,000`** |

The stale `14_000_000` = the old `$7.5M` cushion + the same `$6.5M` of used buckets.

The constant is deliberately **not** imported into the test. Importing it would recreate precisely the self-certifying pin BZE-253 called out — where green tests certified nothing because they asserted the code's own constants back at it. The expected value is written as the CBA-derived figure with the derivation spelled out in a comment.

### 2. `tests/entitlements/*` — 4 failures (token migration)

BZE-235 (`2974a726`) migrated the Trade Machine palette to cockpit tokens and moved two visual-class guardrails with the design, but these two files live under root `tests/` and were outside the TM component scope that commit validated.

Verified this is a stale expectation and **not** a broken migration: all six token classes resolve to real colors defined in `tailwind.config.js` (`safe #34D399`, `watch #FBBF24`, `info #60A5FA`, `raised #1A1F29`, `text-muted`/`text-secondary`).

**No product or CBA defect found.** Both changes were deliberate, sourced, and already merged; only the expectations lagged.

## Files and assertions changed

| File | Change |
| --- | --- |
| `tests/salaryMargin.test.ts` | `14_000_000` → `15_596_000`, plus derivation comment |
| `tests/entitlements/formatEntitlement.test.ts` | 5 `colorClass` assertions → cockpit tokens |
| `tests/entitlements/entitlementWarnings.test.ts` | 5 `colorClass` assertions → cockpit tokens |

All **10** entitlement `colorClass` assertion calls/literals were updated — **5 per file** — though only 4 surfaced in CI, because `toEqual` aborts its block at the first mismatch and the later ones were never reached. Those 10 assertions cover **8** switch branches: in each file the `default` branch is asserted twice (once for an unknown kind, once for `undefined`).

**Guardrail intent preserved:** labels, key order (`['label','colorClass']`), and unknown-kind fallback behavior remain pinned exactly as before. Only the color values move with the shipped design.

## Validation

Reproduced all 5 failures locally on `2bbad9c2` before editing (identical to both cited runs). Targeted rerun after repair: **27/27 pass** across the three files (was 5 failed / 22 passed).

Full local equivalent of `Full Build, Test & Validate`:

| Step | Result |
| --- | --- |
| `npm run typecheck` | clean |
| `npm run lint:architect-gate` | PASS — 104 tracked violations, no change vs baseline |
| `vitest run -c vitest.node.config.js` | **447 files / 4730 tests passed**, 1 file + 8 tests skipped |
| `vitest run -c vitest.ui.config.js` | **141 files / 1179 tests passed** |
| `npm run validate:project` | PASS |
| `npm run build` | OK (38.3s) |

Zero failures. The passing count rose from CI's 4725 to 4730 — exactly the 5 repaired tests, no collateral movement.

**Skipped:** browser QA (assertion-only change, no runtime or visual surface touched) and `graphify update` (no module structure change). Neither carries risk for this diff.

## Observation (not fixed here — out of scope)

In `getEntitlementKindBadge`, `pick_ownership` and `conveyance_right` now both map to `bg-cockpit-info/20 text-cockpit-info`; they were visually distinct (blue vs purple) pre-migration. This follows BZE-235's documented `purple → info` mapping and the cockpit palette has no purple, so it is a deliberate consequence of an owner-reviewed visual pass — not a regression introduced here. Flagging it only because the two badges no longer read apart at a glance. Changing it would be a cockpit visual redesign, explicitly out of scope for this issue.

Fixes BZE-269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated entitlement badges and tags with Cockpit-themed colors for ownership, conveyance, swap, and fallback states.

* **Bug Fixes**
  * Corrected salary margin calculations for TPE and free-agent exception scenarios, including applicable amounts used in the calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
