### PR TITLE
BZE-276: Enforce governed declined Rookie Scale option limits at signing

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -310,6 +310,7 @@ utils/
     actionValidators.ts
     constants.ts
     extension.ts
+    governedPriorTeamOptionSigning.ts
     schema.ts
     signing.contractValidators.ts
     signing.helpers.ts
@@ -605,5 +606,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-08-11T22:24:04.406Z*
+*Generated on: 2026-08-12T04:57:54.607Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
+++ b/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
@@ -919,7 +919,8 @@ export const CapSheetFull = ({
             <span className="mr-auto truncate text-[13px] font-bold tracking-tight text-white">
               {hold.playerName || hold.playerId}
             </span>
-            {onSignAndTradeFreeAgent ? (
+            {onSignAndTradeFreeAgent &&
+            !isGovernedPriorTeamOptionHold(hold) ? (
               <button
                 data-testid="cap-sheet-full-fa-sign-and-trade-button"
                 data-action-exposure-classification="V1 supported"

--- a/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
+++ b/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
@@ -46,6 +46,7 @@ import type { GovernedOptionDecisionAvailability } from '@/features/architect/ut
 import {
   getHoldLookupKeys,
   getPlayerLookupKeys,
+  isGovernedPriorTeamOptionHold,
   resolvedHoldAmount,
   useGovernedCapHoldResolution,
   type CapHoldLike,
@@ -776,7 +777,14 @@ export const CapSheetFull = ({
       (entry) => !hasVisibleRow(entry)
     );
     const main = renderable
-      .filter((entry) => entry.rights.placement === 'main')
+      .filter(
+        (entry) =>
+          entry.rights.placement === 'main' ||
+          // BZE-275 ends the declined rookie contract and removes the player
+          // from the roster. Its linked ceiling hold is still the Prior Team's
+          // signing decision; the save boundary authenticates both markers.
+          isGovernedPriorTeamOptionHold(entry.hold)
+      )
       .sort(
         (a, b) =>
           resolvedHoldAmount(b) - resolvedHoldAmount(a)

--- a/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
+++ b/src/features/architect/capSheet/CapSheetFull/CapSheetFull.tsx
@@ -895,6 +895,11 @@ export const CapSheetFull = ({
       rights.projectionStatus === 'available' ||
       rights.projectionStatus === 'legacy';
     const holdEndYear = toEndYear(hold.season);
+    const hasGovernedPriorTeamOptionAssertion =
+      isGovernedPriorTeamOptionHold(hold) ||
+      hold.priorTeamOfferCeiling !== undefined ||
+      (typeof hold.governedContractEventId === 'string' &&
+        hold.governedContractEventId.trim().length > 0);
     return (
       <div
         key={`fa-${hold.playerId ?? hold.playerName}-${idx}`}
@@ -920,7 +925,7 @@ export const CapSheetFull = ({
               {hold.playerName || hold.playerId}
             </span>
             {onSignAndTradeFreeAgent &&
-            !isGovernedPriorTeamOptionHold(hold) ? (
+            !hasGovernedPriorTeamOptionAssertion ? (
               <button
                 data-testid="cap-sheet-full-fa-sign-and-trade-button"
                 data-action-exposure-classification="V1 supported"

--- a/src/features/architect/capSheet/CapSheetFull/useGovernedCapHoldResolution.ts
+++ b/src/features/architect/capSheet/CapSheetFull/useGovernedCapHoldResolution.ts
@@ -23,6 +23,8 @@ export type CapHoldLike = {
   amount?: NumericLike;
   type?: string | null;
   isSigned?: boolean | null;
+  priorTeamOfferCeiling?: NumericLike;
+  governedContractEventId?: string | null;
 };
 
 export type ResolvedCapHoldEntry = {
@@ -57,6 +59,19 @@ const toEndYear = (value: unknown): number | null => {
     ? numericYear
     : null;
 };
+
+const hasFiniteNumericValue = (value: NumericLike): boolean => {
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'string' || !value.trim()) return false;
+  return Number.isFinite(Number(value.replace(/[$,]/g, '').trim()));
+};
+
+export const isGovernedPriorTeamOptionHold = (
+  hold: CapHoldLike
+): boolean =>
+  typeof hold.governedContractEventId === 'string' &&
+  hold.governedContractEventId.trim().length > 0 &&
+  hasFiniteNumericValue(hold.priorTeamOfferCeiling);
 
 const toStartYear = (value: unknown): number | null => {
   const endYear = toEndYear(value);

--- a/src/features/architect/capSheet/CapSheetFull/useGovernedCapHoldResolution.ts
+++ b/src/features/architect/capSheet/CapSheetFull/useGovernedCapHoldResolution.ts
@@ -60,18 +60,13 @@ const toEndYear = (value: unknown): number | null => {
     : null;
 };
 
-const hasFiniteNumericValue = (value: NumericLike): boolean => {
-  if (typeof value === 'number') return Number.isFinite(value);
-  if (typeof value !== 'string' || !value.trim()) return false;
-  return Number.isFinite(Number(value.replace(/[$,]/g, '').trim()));
-};
-
 export const isGovernedPriorTeamOptionHold = (
   hold: CapHoldLike
 ): boolean =>
   typeof hold.governedContractEventId === 'string' &&
   hold.governedContractEventId.trim().length > 0 &&
-  hasFiniteNumericValue(hold.priorTeamOfferCeiling);
+  typeof hold.priorTeamOfferCeiling === 'number' &&
+  Number.isFinite(hold.priorTeamOfferCeiling);
 
 const toStartYear = (value: unknown): number | null => {
   const endYear = toEndYear(value);

--- a/src/features/architect/utils/capLegalityValidation.ts
+++ b/src/features/architect/utils/capLegalityValidation.ts
@@ -49,6 +49,7 @@ export * from './capLegalityValidation/schema';
 export * from './capLegalityValidation/signing';
 export * from './capLegalityValidation/extension';
 export * from './capLegalityValidation/actionValidators';
+export * from './capLegalityValidation/governedPriorTeamOptionSigning';
 import {
   validateWaive,
   validateOptionDecision,

--- a/src/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning.ts
+++ b/src/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning.ts
@@ -33,6 +33,17 @@ import type {
 const AUTHORITY_RULE = 'governed_rookie_option_signing_record_invalid';
 const CEILING_RULE = 'governed_rookie_option_offer_exceeds_ceiling';
 
+function toExactCents(amount: number): number | null {
+  const scaled = amount * 100;
+  const cents = Math.round(scaled);
+  const floatingPointTolerance =
+    Number.EPSILON * Math.max(1, Math.abs(scaled)) * 4;
+  return Number.isSafeInteger(cents) &&
+    Math.abs(scaled - cents) <= floatingPointTolerance
+    ? cents
+    : null;
+}
+
 type AuthorityFailureKind =
   | 'missing'
   | 'duplicate'
@@ -322,7 +333,8 @@ function inspectRookieScaleDecline({
   if (
     typeof declinedSalary !== 'number' ||
     !Number.isFinite(declinedSalary) ||
-    declinedSalary < 0
+    declinedSalary < 0 ||
+    toExactCents(declinedSalary) === null
   ) {
     return {
       status: 'invalid',
@@ -363,10 +375,6 @@ function formatMoney(amount: number): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
-}
-
-function toCents(amount: number): number {
-  return Math.round(amount * 100);
 }
 
 export function validateGovernedPriorTeamOptionSigning({
@@ -586,9 +594,20 @@ export function validateGovernedPriorTeamOptionSigning({
   }
 
   const governedOfferAmount = firstYearSalary + firstYearUnlikely;
-  const governedOfferCents =
-    toCents(firstYearSalary) + toCents(firstYearUnlikely);
-  const declinedSalaryCents = toCents(decline.declinedSalary);
+  const firstYearSalaryCents = toExactCents(firstYearSalary);
+  const firstYearUnlikelyCents = toExactCents(firstYearUnlikely);
+  const declinedSalaryCents = toExactCents(decline.declinedSalary);
+  if (
+    firstYearSalaryCents === null ||
+    firstYearUnlikelyCents === null ||
+    declinedSalaryCents === null
+  ) {
+    return blocked(
+      'malformed',
+      'Salary, Unlikely Bonuses, and the declined option ceiling must be exact cent-denominated amounts.'
+    );
+  }
+  const governedOfferCents = firstYearSalaryCents + firstYearUnlikelyCents;
   if (governedOfferCents > declinedSalaryCents) {
     return {
       valid: false,

--- a/src/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning.ts
+++ b/src/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning.ts
@@ -365,6 +365,10 @@ function formatMoney(amount: number): string {
   });
 }
 
+function toCents(amount: number): number {
+  return Math.round(amount * 100);
+}
+
 export function validateGovernedPriorTeamOptionSigning({
   team,
   player,
@@ -377,6 +381,9 @@ export function validateGovernedPriorTeamOptionSigning({
   const playerId = playerIdOf(player);
   const teamId = teamIdOf(team);
   const worldId = String(worldIdInput ?? '').trim();
+  if (!teamId || !playerId) {
+    return blocked('missing', 'Team or player identity is missing.');
+  }
   const playerHolds = (team.capHolds || []).filter(
     (hold) => holdPlayerId(hold) === playerId
   );
@@ -495,8 +502,8 @@ export function validateGovernedPriorTeamOptionSigning({
   }
 
   const decline = applicable[0];
-  if (!worldId || !teamId || !playerId) {
-    return blocked('missing', 'World, team, or player identity is missing.');
+  if (!worldId) {
+    return blocked('missing', 'World identity is missing.');
   }
   if (dateDefaulted || !/^\d{4}-\d{2}-\d{2}$/.test(asOfDate || '')) {
     return blocked(
@@ -579,7 +586,10 @@ export function validateGovernedPriorTeamOptionSigning({
   }
 
   const governedOfferAmount = firstYearSalary + firstYearUnlikely;
-  if (governedOfferAmount > decline.declinedSalary) {
+  const governedOfferCents =
+    toCents(firstYearSalary) + toCents(firstYearUnlikely);
+  const declinedSalaryCents = toCents(decline.declinedSalary);
+  if (governedOfferCents > declinedSalaryCents) {
     return {
       valid: false,
       violations: [

--- a/src/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning.ts
+++ b/src/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning.ts
@@ -1,0 +1,606 @@
+/**
+ * Governed CBA2-C16.7 enforcement for a Prior Team re-signing after it
+ * declines a Rookie Scale Team Option.
+ *
+ * This validator is pure. It consumes the saved-world cap hold and immutable
+ * contract-event ledger that BZE-275 created, authenticates their relationship,
+ * and compares only first-year Salary plus Unlikely Bonuses to the declined
+ * Salary. It deliberately does not generalize into other option or signing
+ * routes.
+ */
+
+import { ContractEventLedgerPayloadZ } from '@/schemas/contractEventLedger';
+import type { ContractEventRecord } from '@/schemas/contractEventLedger';
+import {
+  createContractEventLedger,
+  walkChain,
+  type LifecycleEventLedger,
+} from '@/features/architect/utils/contractHistory';
+import { canonicalStringify } from '@/features/architect/utils/contractSource/deterministicDigest';
+import {
+  toEndYear,
+  toSeasonCode,
+} from '@/features/architect/utils/seasonFormat';
+import type {
+  CapLegalityViolation,
+  MutationCapHold,
+  MutationContract,
+  MutationPlayer,
+  MutationTeam,
+  MutationValidationResult,
+} from './schema';
+
+const AUTHORITY_RULE = 'governed_rookie_option_signing_record_invalid';
+const CEILING_RULE = 'governed_rookie_option_offer_exceeds_ceiling';
+
+type AuthorityFailureKind =
+  | 'missing'
+  | 'duplicate'
+  | 'malformed'
+  | 'unauthenticated'
+  | 'mismatch'
+  | 'stale';
+
+type GovernedDecline = {
+  ledger: LifecycleEventLedger;
+  event: ContractEventRecord;
+  declinedSalary: number;
+  salaryCapYear: number;
+};
+
+export type ValidateGovernedPriorTeamOptionSigningParams = {
+  team: MutationTeam;
+  player: MutationPlayer;
+  contract: MutationContract | null | undefined;
+  worldId?: string | null;
+  year: number;
+  asOfDate?: string | null;
+  dateDefaulted?: boolean;
+};
+
+function playerIdOf(player: MutationPlayer): string {
+  return String(player.playerId || player.player_id || player.id || '').trim();
+}
+
+function teamIdOf(team: MutationTeam): string {
+  return String(team.teamCode || team.code || '').trim();
+}
+
+function holdPlayerId(hold: MutationCapHold): string {
+  return String(hold.playerId ?? '').trim();
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function rawLedgerIsRelated(
+  value: unknown,
+  playerId: string,
+  linkedEventIds: ReadonlySet<string>
+): boolean {
+  const record = asRecord(value);
+  const events = record?.events;
+  if (!Array.isArray(events)) return false;
+  return events.some((entry) => {
+    const event = asRecord(entry);
+    if (!event) return false;
+    return (
+      String(event.playerId ?? '').trim() === playerId ||
+      linkedEventIds.has(String(event.eventId ?? '').trim())
+    );
+  });
+}
+
+function authorityMessage(kind: AuthorityFailureKind): string {
+  switch (kind) {
+    case 'missing':
+      return 'This re-signing needs its linked declined-option record before the offer can be checked. No changes were saved.';
+    case 'duplicate':
+      return 'This re-signing has more than one declined-option record or cap hold. Resolve the duplicate before continuing. No changes were saved.';
+    case 'stale':
+      return 'This re-signing cannot proceed because the declined-option record is no longer the current Contract event. No changes were saved.';
+    case 'malformed':
+      return 'This re-signing cannot proceed because the declined-option record is incomplete. No changes were saved.';
+    case 'unauthenticated':
+      return 'This re-signing cannot proceed because the declined-option record has no authenticated author. No changes were saved.';
+    case 'mismatch':
+      return 'This re-signing cannot proceed because the declined-option record no longer matches this player, Prior Team, Contract, Season, or amount. No changes were saved.';
+  }
+}
+
+function blocked(
+  kind: AuthorityFailureKind,
+  detail: string
+): MutationValidationResult {
+  const violation: CapLegalityViolation = {
+    rule: AUTHORITY_RULE,
+    message: authorityMessage(kind),
+    severity: 'error',
+    failureKind: kind,
+    detail,
+  };
+  return { valid: false, violations: [violation], warnings: [] };
+}
+
+function allowed(): MutationValidationResult {
+  return { valid: true, violations: [], warnings: [] };
+}
+
+function currentContractChain(
+  ledger: LifecycleEventLedger,
+  event: ContractEventRecord
+): ContractEventRecord[] | null {
+  return walkChain(
+    ledger.events.filter(
+      (entry) =>
+        entry.recordStatus === 'current' &&
+        entry.worldId === event.worldId &&
+        entry.contractId === event.contractId
+    )
+  );
+}
+
+function inspectRookieScaleDecline({
+  ledger,
+  event,
+  worldId,
+  teamId,
+  playerId,
+}: {
+  ledger: LifecycleEventLedger;
+  event: ContractEventRecord;
+  worldId: string;
+  teamId: string;
+  playerId: string;
+}):
+  | { status: 'not-applicable' }
+  | { status: 'invalid'; kind: AuthorityFailureKind; detail: string }
+  | { status: 'applicable'; decline: GovernedDecline } {
+  if (event.eventKind !== 'option-decline') {
+    return { status: 'not-applicable' };
+  }
+
+  if (event.resultingState.terms.isRookieScale !== true) {
+    return { status: 'not-applicable' };
+  }
+
+  if (!event.authoringIdentity?.trim()) {
+    return {
+      status: 'invalid',
+      kind: 'unauthenticated',
+      detail: 'The governed option decline has no authenticated author identity.',
+    };
+  }
+
+  if (
+    event.worldId !== worldId ||
+    event.teamId !== teamId ||
+    event.playerId !== playerId
+  ) {
+    return {
+      status: 'invalid',
+      kind: 'mismatch',
+      detail:
+        'The linked option event has a different world, team, or player identity.',
+    };
+  }
+
+  if (ledger.ledgerId !== `${worldId}:${event.contractId}:contract`) {
+    return {
+      status: 'invalid',
+      kind: 'mismatch',
+      detail:
+        'The Contract ledger identity does not match the linked Contract.',
+    };
+  }
+
+  if (
+    ledger.events.some(
+      (entry) =>
+        entry.contractId !== event.contractId ||
+        entry.worldId !== worldId ||
+        entry.teamId !== teamId ||
+        entry.playerId !== playerId
+    )
+  ) {
+    return {
+      status: 'invalid',
+      kind: 'mismatch',
+      detail:
+        'The linked ledger mixes Contract, world, team, or player identities.',
+    };
+  }
+
+  const chain = currentContractChain(ledger, event);
+  if (!chain) {
+    return {
+      status: 'invalid',
+      kind: 'malformed',
+      detail: 'The linked Contract event chain cannot be replayed as one line.',
+    };
+  }
+
+  const eventIndex = chain.findIndex(
+    (entry) =>
+      entry.eventId === event.eventId &&
+      entry.eventVersion === event.eventVersion
+  );
+  if (eventIndex < 0) {
+    return {
+      status: 'invalid',
+      kind: 'missing',
+      detail: 'The linked event is not a current event in its Contract chain.',
+    };
+  }
+  if (eventIndex !== chain.length - 1) {
+    return {
+      status: 'invalid',
+      kind: 'stale',
+      detail: 'A later Contract event succeeds the linked option decline.',
+    };
+  }
+
+  const predecessor = chain[eventIndex - 1];
+  if (
+    !predecessor ||
+    event.predecessorEventId !== predecessor.eventId ||
+    event.predecessorContractVersion !== predecessor.resultingContractVersion ||
+    event.resultingContractVersion !== predecessor.resultingContractVersion + 1
+  ) {
+    return {
+      status: 'invalid',
+      kind: 'malformed',
+      detail:
+        'The option decline does not consume the immediately preceding Contract version.',
+    };
+  }
+
+  const predecessorState = predecessor.resultingState;
+  const resultingState = event.resultingState;
+  const predecessorSalaries = predecessorState.terms.salaries;
+  const resultingSalaries = resultingState.terms.salaries;
+  const optionIndex = resultingSalaries.length;
+  const declinedRow = predecessorSalaries[optionIndex];
+  const declinedYear = toEndYear(declinedRow?.season);
+
+  if (
+    predecessorState.terms.isRookieScale !== true ||
+    predecessorState.terms.contractLength !== 4 ||
+    predecessorSalaries.length !== 4 ||
+    (optionIndex !== 2 && optionIndex !== 3) ||
+    !declinedRow ||
+    declinedRow.option !== 'TO' ||
+    declinedRow.optionHolder !== 'team' ||
+    declinedRow.optionUsed !== null ||
+    !Number.isInteger(declinedYear)
+  ) {
+    return {
+      status: 'invalid',
+      kind: 'malformed',
+      detail:
+        'The predecessor Contract does not establish the declined third- or fourth-Season Rookie Scale Team Option.',
+    };
+  }
+
+  if (
+    resultingState.terms.contractLength !== resultingSalaries.length ||
+    canonicalStringify(resultingSalaries) !==
+      canonicalStringify(predecessorSalaries.slice(0, optionIndex))
+  ) {
+    return {
+      status: 'invalid',
+      kind: 'mismatch',
+      detail:
+        'The resulting Contract is not the exact prefix created by the option decline.',
+    };
+  }
+
+  const contractEndsAt = declinedRow.optionDecisionTerms?.contractEndsAt.value;
+  const expectedEventId = `${event.contractId}:to:${toSeasonCode(
+    declinedYear as number
+  )}:decline:v${event.resultingContractVersion}`;
+  const freeAgency = resultingState.terms.freeAgency;
+  if (
+    contractEndsAt !== event.effectiveAt ||
+    event.eventId !== expectedEventId ||
+    freeAgency.type !== 'UFA' ||
+    freeAgency.year !== declinedYear ||
+    freeAgency.hasOption !== false
+  ) {
+    return {
+      status: 'invalid',
+      kind: 'mismatch',
+      detail:
+        'The decline decision, effective boundary, event identity, or resulting Free Agency Season conflicts with the Contract.',
+    };
+  }
+
+  const declinedSalary = declinedRow.salary;
+  if (
+    typeof declinedSalary !== 'number' ||
+    !Number.isFinite(declinedSalary) ||
+    declinedSalary < 0
+  ) {
+    return {
+      status: 'invalid',
+      kind: 'malformed',
+      detail:
+        'The declined option Salary is not established as a finite amount.',
+    };
+  }
+
+  return {
+    status: 'applicable',
+    decline: {
+      ledger,
+      event,
+      declinedSalary,
+      salaryCapYear: declinedYear as number,
+    },
+  };
+}
+
+function findEventMatches(
+  ledgers: readonly LifecycleEventLedger[],
+  eventId: string
+): Array<{ ledger: LifecycleEventLedger; event: ContractEventRecord }> {
+  return ledgers.flatMap((ledger) =>
+    ledger.events
+      .filter(
+        (event) => event.recordStatus === 'current' && event.eventId === eventId
+      )
+      .map((event) => ({ ledger, event }))
+  );
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function validateGovernedPriorTeamOptionSigning({
+  team,
+  player,
+  contract,
+  worldId: worldIdInput,
+  year,
+  asOfDate,
+  dateDefaulted = false,
+}: ValidateGovernedPriorTeamOptionSigningParams): MutationValidationResult {
+  const playerId = playerIdOf(player);
+  const teamId = teamIdOf(team);
+  const worldId = String(worldIdInput ?? '').trim();
+  const playerHolds = (team.capHolds || []).filter(
+    (hold) => holdPlayerId(hold) === playerId
+  );
+  const linkedEventIds = new Set(
+    playerHolds
+      .map((hold) => String(hold.governedContractEventId ?? '').trim())
+      .filter(Boolean)
+  );
+  const assertedGovernedHold = playerHolds.some(
+    (hold) =>
+      hold.priorTeamOfferCeiling !== undefined ||
+      String(hold.governedContractEventId ?? '').trim().length > 0
+  );
+
+  const rawLedgers = Array.isArray(team.contractEventLedgers)
+    ? team.contractEventLedgers
+    : [];
+  const ledgers: LifecycleEventLedger[] = [];
+  for (const rawLedger of rawLedgers) {
+    const related = rawLedgerIsRelated(rawLedger, playerId, linkedEventIds);
+    const parsed = ContractEventLedgerPayloadZ.safeParse(rawLedger);
+    if (!parsed.success) {
+      if (related || assertedGovernedHold) {
+        return blocked(
+          'malformed',
+          'A related Contract ledger payload is malformed.'
+        );
+      }
+      continue;
+    }
+    try {
+      ledgers.push(createContractEventLedger(parsed.data));
+    } catch (error) {
+      if (related || assertedGovernedHold) {
+        return blocked(
+          'malformed',
+          error instanceof Error
+            ? error.message
+            : 'A related Contract event chain is malformed.'
+        );
+      }
+    }
+  }
+
+  const linkedMatches = [...linkedEventIds].flatMap((eventId) =>
+    findEventMatches(ledgers, eventId)
+  );
+  if (assertedGovernedHold && linkedEventIds.size === 0) {
+    return blocked(
+      'missing',
+      'The cap hold does not identify its governed Contract event.'
+    );
+  }
+  if (linkedEventIds.size > 1 || linkedMatches.length > 1) {
+    return blocked(
+      'duplicate',
+      'The cap hold resolves to more than one current Contract event.'
+    );
+  }
+  if (assertedGovernedHold && linkedMatches.length === 0) {
+    return blocked('missing', 'The linked Contract event is missing.');
+  }
+
+  const applicable: GovernedDecline[] = [];
+  for (const ledger of ledgers) {
+    for (const event of ledger.events) {
+      if (
+        event.recordStatus !== 'current' ||
+        event.playerId !== playerId ||
+        event.eventKind !== 'option-decline' ||
+        event.resultingState.terms.isRookieScale !== true
+      ) {
+        continue;
+      }
+      const inspected = inspectRookieScaleDecline({
+        ledger,
+        event,
+        worldId,
+        teamId,
+        playerId,
+      });
+      if (inspected.status === 'invalid') {
+        return blocked(inspected.kind, inspected.detail);
+      }
+      if (inspected.status === 'applicable') applicable.push(inspected.decline);
+    }
+  }
+
+  if (applicable.length > 1) {
+    return blocked(
+      'duplicate',
+      'More than one current Rookie Scale option decline applies to this player.'
+    );
+  }
+
+  if (applicable.length === 0) {
+    const linked = linkedMatches[0];
+    if (linked) {
+      const inspected = inspectRookieScaleDecline({
+        ...linked,
+        worldId,
+        teamId,
+        playerId,
+      });
+      if (inspected.status === 'invalid') {
+        return blocked(inspected.kind, inspected.detail);
+      }
+    }
+    if (playerHolds.some((hold) => hold.priorTeamOfferCeiling !== undefined)) {
+      return blocked(
+        'mismatch',
+        'A Prior Team offer ceiling is present without an applicable Rookie Scale option decline.'
+      );
+    }
+    return allowed();
+  }
+
+  const decline = applicable[0];
+  if (!worldId || !teamId || !playerId) {
+    return blocked('missing', 'World, team, or player identity is missing.');
+  }
+  if (dateDefaulted || !/^\d{4}-\d{2}-\d{2}$/.test(asOfDate || '')) {
+    return blocked(
+      'missing',
+      'An explicit governed Team Plan date is required.'
+    );
+  }
+  if (decline.event.effectiveAt.slice(0, 10) > (asOfDate as string)) {
+    return blocked(
+      'stale',
+      'The option decline is not yet effective at the Team Plan date.'
+    );
+  }
+  if (year !== decline.salaryCapYear) {
+    return blocked(
+      'stale',
+      'The option decline belongs to a different Salary Cap Year.'
+    );
+  }
+
+  if (playerHolds.length !== 1) {
+    return blocked(
+      playerHolds.length === 0 ? 'missing' : 'duplicate',
+      'The player must have exactly one cap hold for the governed decline.'
+    );
+  }
+  const hold = playerHolds[0];
+  if (hold.active !== true || hold.isSigned === true) {
+    return blocked('stale', 'The linked cap hold is not active and unsigned.');
+  }
+  if (hold.governedContractEventId !== decline.event.eventId) {
+    return blocked(
+      'mismatch',
+      'The cap hold links to a different Contract event.'
+    );
+  }
+  if (hold.priorTeamOfferCeiling !== decline.declinedSalary) {
+    return blocked(
+      'mismatch',
+      'The cap-hold ceiling does not equal the declined option Salary.'
+    );
+  }
+  const expectedHoldSeason = toSeasonCode(decline.salaryCapYear);
+  if (hold.season !== expectedHoldSeason) {
+    return blocked(
+      'mismatch',
+      'The cap-hold Season does not match the declined option Season.'
+    );
+  }
+  const governedFreeAgentAmount =
+    decline.event.resultingState.terms.freeAgency.capHold;
+  if (
+    typeof governedFreeAgentAmount !== 'number' ||
+    !Number.isFinite(governedFreeAgentAmount) ||
+    hold.amount !== governedFreeAgentAmount
+  ) {
+    return blocked(
+      'mismatch',
+      'The cap-hold amount does not match the governed Free Agent Amount.'
+    );
+  }
+
+  const firstYear = contract?.salariesByYear?.[0];
+  const firstYearSalary = firstYear?.salary;
+  const firstYearUnlikely = firstYear?.incentives?.unlikely ?? 0;
+  if (
+    !firstYear ||
+    toEndYear(firstYear.season) !== year ||
+    typeof firstYearSalary !== 'number' ||
+    !Number.isFinite(firstYearSalary) ||
+    firstYearSalary < 0 ||
+    typeof firstYearUnlikely !== 'number' ||
+    !Number.isFinite(firstYearUnlikely) ||
+    firstYearUnlikely < 0
+  ) {
+    return blocked(
+      'malformed',
+      'The proposed first-year Salary or Unlikely Bonuses are missing or invalid.'
+    );
+  }
+
+  const governedOfferAmount = firstYearSalary + firstYearUnlikely;
+  if (governedOfferAmount > decline.declinedSalary) {
+    return {
+      valid: false,
+      violations: [
+        {
+          rule: CEILING_RULE,
+          message: `This offer exceeds the Prior Team's ${formatMoney(
+            decline.declinedSalary
+          )} limit after declining the Rookie Scale Team Option. First-year Salary plus Unlikely Bonuses is ${formatMoney(
+            governedOfferAmount
+          )}. No changes were saved.`,
+          severity: 'error',
+          firstYearSalary,
+          firstYearUnlikelyBonuses: firstYearUnlikely,
+          governedOfferAmount,
+          priorTeamOfferCeiling: decline.declinedSalary,
+          canonLeafId: 'CBA2-C16.7',
+        },
+      ],
+      warnings: [],
+    };
+  }
+
+  return allowed();
+}

--- a/src/features/architect/utils/contractHistory/contractHistoryFence.ts
+++ b/src/features/architect/utils/contractHistory/contractHistoryFence.ts
@@ -130,11 +130,12 @@ export const FENCED_HISTORY_SCHEMA_MODULE =
 
 /**
  * Explicit governed consumers. BZE-274 initializes the pinned baselines;
- * BZE-275 is the first bounded workflow migration and owns option authority,
- * atomic persistence, and branch identity rewriting.
+ * BZE-275 owns option authority, atomic persistence, and branch identity
+ * rewriting; BZE-276 consumes that authority at the Prior Team signing gate.
  */
 export const GOVERNED_CONTRACT_HISTORY_CONSUMERS = Object.freeze([
   'src/features/architect/utils/contractSource/contractSourceRelease.ts',
+  'src/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning.ts',
   'src/features/architect/utils/optionDecisions/contractOverlaySetDigest.ts',
   'src/features/architect/utils/optionDecisions/governedOptionDecision.ts',
   'src/features/architect/utils/optionDecisions/worldOptionDecisionAuthority.ts',

--- a/src/features/architect/utils/mutationPipeline.read.normalizeData.capData.ts
+++ b/src/features/architect/utils/mutationPipeline.read.normalizeData.capData.ts
@@ -46,6 +46,12 @@ export function normalizeCurrentStateCapHold(
   const notes = toOptionalTrimmedString(record.notes);
   const active = toOptionalBoolean(record.active);
   const reason = toOptionalTrimmedString(record.reason);
+  const priorTeamOfferCeiling = toOptionalNumber(
+    record.priorTeamOfferCeiling
+  );
+  const governedContractEventId = toOptionalTrimmedString(
+    record.governedContractEventId
+  );
 
   if (playerId !== undefined) normalized.playerId = playerId;
   if (playerName !== undefined) normalized.playerName = playerName;
@@ -57,6 +63,12 @@ export function normalizeCurrentStateCapHold(
   if (notes !== undefined) normalized.notes = notes;
   if (active !== undefined) normalized.active = active;
   if (reason !== undefined) normalized.reason = reason;
+  if (priorTeamOfferCeiling !== undefined) {
+    normalized.priorTeamOfferCeiling = priorTeamOfferCeiling;
+  }
+  if (governedContractEventId !== undefined) {
+    normalized.governedContractEventId = governedContractEventId;
+  }
 
   return normalized;
 }

--- a/src/features/architect/utils/mutationPipeline.ts
+++ b/src/features/architect/utils/mutationPipeline.ts
@@ -529,6 +529,7 @@ export async function applyWorldMutation({
         seasonId,
         asOfDate,
         dateDefaulted,
+        worldId,
       });
 
       if (!validationResult.valid) {

--- a/src/features/architect/utils/mutationPipeline.validate.ts
+++ b/src/features/architect/utils/mutationPipeline.validate.ts
@@ -23,6 +23,7 @@ export function validateMutation({
   seasonId,
   asOfDate,
   dateDefaulted,
+  worldId,
 }: {
   mutationType: string;
   payload: MutationPayloadLike;
@@ -31,6 +32,7 @@ export function validateMutation({
   seasonId: string;
   asOfDate?: string | null;
   dateDefaulted?: boolean;
+  worldId?: string | null;
 }): {
   valid: boolean;
   error?: string;
@@ -116,6 +118,7 @@ export function validateMutation({
           seasonId,
           asOfDate,
           dateDefaulted,
+          worldId,
         });
 
         return {

--- a/src/features/architect/utils/nonTradeMutationValidationStage.ts
+++ b/src/features/architect/utils/nonTradeMutationValidationStage.ts
@@ -530,7 +530,24 @@ export function validateNonTradeMutationStage({
   dateDefaulted?: boolean;
   worldId?: string | null;
 }): StageValidationResult {
-  const currentYear = toEndYear(seasonId) ?? new Date().getFullYear();
+  const salaryCapYear = toEndYear(seasonId);
+  if (mutationType === 'signFreeAgent' && salaryCapYear === null) {
+    const message =
+      'The signing Salary Cap Year could not be derived. No changes were saved.';
+    return {
+      valid: false,
+      error: message,
+      violations: [
+        JSON.stringify({
+          rule: 'governed_signing_salary_cap_year_missing',
+          message,
+          severity: 'error',
+        }),
+      ],
+      warnings: [],
+    };
+  }
+  const currentYear = salaryCapYear ?? new Date().getFullYear();
   const pipelineWarnings = buildPipelineWarnings({
     asOfDate,
     dateDefaulted,

--- a/src/features/architect/utils/nonTradeMutationValidationStage.ts
+++ b/src/features/architect/utils/nonTradeMutationValidationStage.ts
@@ -18,6 +18,9 @@ import {
   validateDeadCap,
   validateExceptions,
 } from '@/features/architect/utils/capLegalityValidation';
+import {
+  validateGovernedPriorTeamOptionSigning,
+} from '@/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning';
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
 import type {
   ArchitectMutationOfferSheet,
@@ -177,6 +180,8 @@ function validateSigningSideMutation({
   currentState,
   currentYear,
   asOfDate,
+  worldId,
+  dateDefaulted,
   pipelineWarnings,
 }: {
   mutationType: string;
@@ -184,9 +189,23 @@ function validateSigningSideMutation({
   currentState: MutationCurrentState;
   currentYear: number;
   asOfDate?: string | null;
+  worldId?: string | null;
+  dateDefaulted?: boolean;
   pipelineWarnings: Array<Record<string, unknown>>;
 }): StageValidationResult {
   const { team, player } = requireTeamAndPlayerState(currentState, mutationType);
+  const governedOptionSigningResult =
+    mutationType === 'signFreeAgent'
+      ? validateGovernedPriorTeamOptionSigning({
+          team,
+          player,
+          contract: payload.contract,
+          worldId,
+          year: currentYear,
+          asOfDate,
+          dateDefaulted,
+        })
+      : { valid: true, violations: [], warnings: [] };
   const result = validateSigning({
     team,
     player,
@@ -199,11 +218,18 @@ function validateSigningSideMutation({
   });
 
   return formatValidatorResult({
-    valid: result.valid,
-    violations: result.violations,
+    valid: governedOptionSigningResult.valid && result.valid,
+    violations: [
+      ...governedOptionSigningResult.violations,
+      ...result.violations,
+    ],
     warnings:
       mutationType === 'signFreeAgent'
-        ? [...result.warnings, ...pipelineWarnings]
+        ? [
+            ...governedOptionSigningResult.warnings,
+            ...result.warnings,
+            ...pipelineWarnings,
+          ]
         : result.warnings,
   });
 }
@@ -493,6 +519,7 @@ export function validateNonTradeMutationStage({
   seasonId,
   asOfDate,
   dateDefaulted,
+  worldId,
 }: {
   mutationType: string;
   payload: MutationPayloadLike;
@@ -501,6 +528,7 @@ export function validateNonTradeMutationStage({
   seasonId: string;
   asOfDate?: string | null;
   dateDefaulted?: boolean;
+  worldId?: string | null;
 }): StageValidationResult {
   const currentYear = toEndYear(seasonId) ?? new Date().getFullYear();
   const pipelineWarnings = buildPipelineWarnings({
@@ -517,6 +545,8 @@ export function validateNonTradeMutationStage({
         currentState,
         currentYear,
         asOfDate,
+        worldId,
+        dateDefaulted,
         pipelineWarnings,
       });
 

--- a/src/features/architect/utils/nonTradeMutationValidationStage.ts
+++ b/src/features/architect/utils/nonTradeMutationValidationStage.ts
@@ -125,13 +125,14 @@ function toStrictSalaryCapYear(seasonId: string): number | null {
   const normalized = seasonId.trim();
   if (/^\d{4}$/.test(normalized)) {
     const year = Number(normalized);
-    return year >= 1900 ? year : null;
+    return year >= 1900 && year <= 9999 ? year : null;
   }
 
   const seasonMatch = normalized.match(/^(\d{4})-(\d{2})$/);
   if (!seasonMatch) return null;
   const startYear = Number(seasonMatch[1]);
   const endYear = startYear + 1;
+  if (startYear < 1900 || endYear > 9999) return null;
   return String(endYear).slice(-2) === seasonMatch[2] ? endYear : null;
 }
 

--- a/src/features/architect/utils/nonTradeMutationValidationStage.ts
+++ b/src/features/architect/utils/nonTradeMutationValidationStage.ts
@@ -121,6 +121,20 @@ function buildPipelineWarnings({
   return pipelineWarnings;
 }
 
+function toStrictSalaryCapYear(seasonId: string): number | null {
+  const normalized = seasonId.trim();
+  if (/^\d{4}$/.test(normalized)) {
+    const year = Number(normalized);
+    return year >= 1900 ? year : null;
+  }
+
+  const seasonMatch = normalized.match(/^(\d{4})-(\d{2})$/);
+  if (!seasonMatch) return null;
+  const startYear = Number(seasonMatch[1]);
+  const endYear = startYear + 1;
+  return String(endYear).slice(-2) === seasonMatch[2] ? endYear : null;
+}
+
 function requireTeamState(
   currentState: MutationCurrentState,
   mutationType: string
@@ -530,7 +544,10 @@ export function validateNonTradeMutationStage({
   dateDefaulted?: boolean;
   worldId?: string | null;
 }): StageValidationResult {
-  const salaryCapYear = toEndYear(seasonId);
+  const salaryCapYear =
+    mutationType === 'signFreeAgent'
+      ? toStrictSalaryCapYear(seasonId)
+      : toEndYear(seasonId);
   if (mutationType === 'signFreeAgent' && salaryCapYear === null) {
     const message =
       'The signing Salary Cap Year could not be derived. No changes were saved.';

--- a/src/shared/components/EditContractModal.DetailsForm.tsx
+++ b/src/shared/components/EditContractModal.DetailsForm.tsx
@@ -51,6 +51,7 @@ type ContractDetailsFormProps = {
     raisePct: number | null | undefined
   ) => number[];
   toSalaryInputs: (series: number[], years: number) => string[];
+  onTermsChange: () => void;
 };
 
 export const ContractDetailsForm = ({
@@ -83,6 +84,7 @@ export const ContractDetailsForm = ({
   clampFirstYearToGuardrails,
   buildSalarySeries,
   toSalaryInputs,
+  onTermsChange,
 }: ContractDetailsFormProps) => (
   <>
     {['signNew', 'resign', 'extend', 'signAndTrade'].includes(selectedAction) && (
@@ -256,6 +258,7 @@ export const ContractDetailsForm = ({
                     disabled={!isActive}
                     value={salaryInputs[idx] || ''}
                     onChange={(e) => {
+                      onTermsChange();
                       const raw = e.target.value.replace(/[^0-9]/g, '');
                       const parsed = Number(raw);
                       const nextSalaries = (() => {

--- a/src/shared/components/EditContractModal.tsx
+++ b/src/shared/components/EditContractModal.tsx
@@ -1036,6 +1036,7 @@ export const EditContractModal = ({
             clampFirstYearToGuardrails={clampFirstYearToGuardrails}
             buildSalarySeries={buildSalarySeries}
             toSalaryInputs={toSalaryInputs}
+            onTermsChange={() => setSaveError('')}
           />
 
           {/* === Validation Warnings === */}

--- a/src/tests/architect/freeAgency_fixpack_e1.pipeline.behavior.test.ts
+++ b/src/tests/architect/freeAgency_fixpack_e1.pipeline.behavior.test.ts
@@ -172,6 +172,7 @@ describe('FREE_AGENCY_FIXPACK_E1 pipeline closure behaviors', () => {
       },
     };
     const player = {
+      player_id: playerId,
       displayName: 'Test Player',
       contract: {
         salariesByYear: [],

--- a/tests/architect/capSheetFull.governedRights.integration.test.tsx
+++ b/tests/architect/capSheetFull.governedRights.integration.test.tsx
@@ -66,6 +66,34 @@ const team = {
 afterEach(cleanup);
 
 describe('Full Cap Table governed rights consumer', () => {
+  it('keeps a linked declined Rookie Scale option hold in the Prior Team signing lane after roster exit', () => {
+    render(
+      <CapSheetFull
+        teamCapSheet={{
+          ...team,
+          players: [],
+          capHolds: [
+            {
+              ...team.capHolds[0],
+              priorTeamOfferCeiling: 12_000_000,
+              governedContractEventId: 'governed-option-decline-event',
+            },
+          ],
+        } as never}
+        currentYear={2027}
+        playersMap={{ [RIGHTS_FIXTURE_PLAYER_ID]: PLAYER }}
+        governedRightsContext={governedContext}
+      />
+    );
+
+    expect(
+      screen.getByTestId('cap-sheet-full-fa-decision-row')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('cap-sheet-full-fa-resign-cell')
+    ).toBeInTheDocument();
+  });
+
   it('renders the replayed Bird tier and Free Agent Amount instead of snapshot fallbacks', () => {
     const renounceCapHold = vi.fn();
     render(

--- a/tests/architect/capSheetFull.governedRights.integration.test.tsx
+++ b/tests/architect/capSheetFull.governedRights.integration.test.tsx
@@ -174,6 +174,43 @@ describe('Full Cap Table governed rights consumer', () => {
     expect(signAndTrade).toHaveBeenCalledWith(PLAYER);
   });
 
+  it.each([
+    [
+      'ceiling-only',
+      {
+        priorTeamOfferCeiling: 12_000_000,
+        governedContractEventId: undefined,
+      },
+    ],
+    [
+      'event-only',
+      {
+        priorTeamOfferCeiling: undefined,
+        governedContractEventId: 'governed-option-decline-event',
+      },
+    ],
+  ])('hides Sign & Trade for a %s governed assertion', (_label, markers) => {
+    render(
+      <CapSheetFull
+        teamCapSheet={{
+          ...team,
+          capHolds: [{ ...team.capHolds[0], ...markers }],
+        } as never}
+        currentYear={2027}
+        playersMap={{ [RIGHTS_FIXTURE_PLAYER_ID]: PLAYER }}
+        governedRightsContext={governedContext}
+        onSignAndTradeFreeAgent={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByTestId('cap-sheet-full-fa-decision-row')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('cap-sheet-full-fa-sign-and-trade-button')
+    ).not.toBeInTheDocument();
+  });
+
   it('renders the replayed Bird tier and Free Agent Amount instead of snapshot fallbacks', () => {
     const renounceCapHold = vi.fn();
     render(

--- a/tests/architect/capSheetFull.governedRights.integration.test.tsx
+++ b/tests/architect/capSheetFull.governedRights.integration.test.tsx
@@ -66,7 +66,9 @@ const team = {
 afterEach(cleanup);
 
 describe('Full Cap Table governed rights consumer', () => {
-  it('keeps a linked declined Rookie Scale option hold in the Prior Team signing lane after roster exit', () => {
+  it('keeps a governed option hold actionable without exposing Sign & Trade', () => {
+    const signAndTrade = vi.fn();
+    const renounceCapHold = vi.fn();
     render(
       <CapSheetFull
         teamCapSheet={{
@@ -83,6 +85,8 @@ describe('Full Cap Table governed rights consumer', () => {
         currentYear={2027}
         playersMap={{ [RIGHTS_FIXTURE_PLAYER_ID]: PLAYER }}
         governedRightsContext={governedContext}
+        onSignAndTradeFreeAgent={signAndTrade}
+        onRenounceCapHold={renounceCapHold}
       />
     );
 
@@ -92,6 +96,20 @@ describe('Full Cap Table governed rights consumer', () => {
     expect(
       screen.getByTestId('cap-sheet-full-fa-resign-cell')
     ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('cap-sheet-full-fa-sign-and-trade-button')
+    ).not.toBeInTheDocument();
+    expect(signAndTrade).not.toHaveBeenCalled();
+
+    const absolve = screen.getByTestId('cap-sheet-full-fa-absolve-button');
+    expect(absolve).toBeEnabled();
+    fireEvent.click(absolve);
+    expect(renounceCapHold).toHaveBeenCalledWith(
+      expect.objectContaining({
+        governedContractEventId: 'governed-option-decline-event',
+        priorTeamOfferCeiling: 12_000_000,
+      })
+    );
 
     cleanup();
     render(
@@ -128,6 +146,32 @@ describe('Full Cap Table governed rights consumer', () => {
     expect(
       screen.queryByTestId('cap-sheet-full-fa-decision-row')
     ).not.toBeInTheDocument();
+  });
+
+  it('preserves Sign & Trade for an ordinary eligible hold', () => {
+    const signAndTrade = vi.fn();
+    render(
+      <CapSheetFull
+        teamCapSheet={team as never}
+        currentYear={2027}
+        playersMap={{ [RIGHTS_FIXTURE_PLAYER_ID]: PLAYER }}
+        governedRightsContext={governedContext}
+        onSignAndTradeFreeAgent={signAndTrade}
+      />
+    );
+
+    expect(
+      screen.getByTestId('cap-sheet-full-fa-decision-row')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('cap-sheet-full-fa-resign-cell')
+    ).toBeInTheDocument();
+    const signAndTradeButton = screen.getByTestId(
+      'cap-sheet-full-fa-sign-and-trade-button'
+    );
+    expect(signAndTradeButton).toBeInTheDocument();
+    fireEvent.click(signAndTradeButton);
+    expect(signAndTrade).toHaveBeenCalledWith(PLAYER);
   });
 
   it('renders the replayed Bird tier and Free Agent Amount instead of snapshot fallbacks', () => {

--- a/tests/architect/capSheetFull.governedRights.integration.test.tsx
+++ b/tests/architect/capSheetFull.governedRights.integration.test.tsx
@@ -92,6 +92,42 @@ describe('Full Cap Table governed rights consumer', () => {
     expect(
       screen.getByTestId('cap-sheet-full-fa-resign-cell')
     ).toBeInTheDocument();
+
+    cleanup();
+    render(
+      <CapSheetFull
+        teamCapSheet={{ ...team, players: [] } as never}
+        currentYear={2027}
+        playersMap={{ [RIGHTS_FIXTURE_PLAYER_ID]: PLAYER }}
+        governedRightsContext={governedContext}
+      />
+    );
+    expect(
+      screen.queryByTestId('cap-sheet-full-fa-decision-row')
+    ).not.toBeInTheDocument();
+
+    cleanup();
+    render(
+      <CapSheetFull
+        teamCapSheet={{
+          ...team,
+          players: [],
+          capHolds: [
+            {
+              ...team.capHolds[0],
+              priorTeamOfferCeiling: '12000000',
+              governedContractEventId: 'governed-option-decline-event',
+            },
+          ],
+        } as never}
+        currentYear={2027}
+        playersMap={{ [RIGHTS_FIXTURE_PLAYER_ID]: PLAYER }}
+        governedRightsContext={governedContext}
+      />
+    );
+    expect(
+      screen.queryByTestId('cap-sheet-full-fa-decision-row')
+    ).not.toBeInTheDocument();
   });
 
   it('renders the replayed Bird tier and Free Agent Amount instead of snapshot fallbacks', () => {

--- a/tests/architect/governedPriorTeamOptionSigning.test.ts
+++ b/tests/architect/governedPriorTeamOptionSigning.test.ts
@@ -654,7 +654,7 @@ describe('governed declined Rookie Scale option signing limit', () => {
     expect(result.violations).toEqual([]);
   });
 
-  it.each(['not-a-season', '2027invalid'])(
+  it.each(['not-a-season', '2027invalid', '9999-00', '1899-00'])(
     'blocks ordinary signing when Salary Cap Year cannot be derived from %s',
     (seasonId) => {
       const result = validateNonTradeMutationStage({

--- a/tests/architect/governedPriorTeamOptionSigning.test.ts
+++ b/tests/architect/governedPriorTeamOptionSigning.test.ts
@@ -1,0 +1,499 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createContractEventLedger,
+  toContractEventLedgerPayload,
+  type ContractEventRecord,
+  type ContractSalaryTerm,
+  type GovernedContractState,
+} from '@/features/architect/utils/contractHistory';
+import {
+  validateGovernedPriorTeamOptionSigning,
+  type MutationContract,
+  type MutationPlayer,
+  type MutationTeam,
+} from '@/features/architect/utils/capLegalityValidation';
+import { validateNonTradeMutationStage } from '@/features/architect/utils/nonTradeMutationValidationStage';
+import { normalizeCurrentStateCapHold } from '@/features/architect/utils/mutationPipeline.read.normalizeData.capData';
+import {
+  makeEvent,
+  makeResultingState,
+} from './contractHistory/contractHistoryFixtures';
+
+const WORLD_ID = 'world-bze-276';
+const TEAM_ID = 'DET';
+const PLAYER_ID = 'player-bze-276';
+const CONTRACT_ID = 'contract-bze-276';
+const SALARY_CAP_YEAR = 2028;
+const SEASON = '2027-28';
+const DECLINED_SALARY = 12_000_000;
+const FREE_AGENT_AMOUNT = 21_850_000;
+const EFFECTIVE_AT = '2027-07-01T00:00:00-04:00';
+const EVENT_ID = `${CONTRACT_ID}:to:${SEASON}:decline:v2`;
+
+const unknownTemporal = () => ({
+  precision: 'unknown' as const,
+  value: null,
+  rawValue: null,
+});
+
+const instant = (value: string) => ({
+  precision: 'instant' as const,
+  value,
+  rawValue: value,
+});
+
+function salaryRow({
+  season,
+  salary,
+  option = null,
+  optionUsed = null,
+}: {
+  season: string;
+  salary: number;
+  option?: 'TO' | null;
+  optionUsed?: boolean | null;
+}): ContractSalaryTerm {
+  return {
+    season,
+    salary,
+    capHit: salary,
+    guaranteed: true,
+    guaranteedAmount: salary,
+    option,
+    optionHolder: option === 'TO' ? 'team' : null,
+    optionUsed,
+    optionDecisionDate: unknownTemporal(),
+    optionDecisionDeadline: option
+      ? instant('2026-11-02T17:00:00-05:00')
+      : unknownTemporal(),
+    optionDecisionTerms: option
+      ? {
+          termsVersion: 1,
+          conditional: false,
+          decisionWindowOpensAt: instant('2026-10-01T09:00:00-04:00'),
+          contractEndsAt: instant(EFFECTIVE_AT),
+          nonCompensationTermsMatchPriorSeason: true,
+          compensationProtectionMatchesPriorSeason: true,
+          rookieScaleOptionOrdinal: season === SEASON ? 'fourth' : 'third',
+          rookieScaleFourthSeasonTermsMatchThird:
+            season === SEASON ? true : null,
+          playerOptionProtectionAlternative: null,
+          preExerciseProtectionApplies: null,
+          teamLastGameAt: unknownTemporal(),
+          rfaDeclarationDeadline: unknownTemporal(),
+          rfaRelevanceEvidence: null,
+          etoOrigin: null,
+          etoAddedDuringOriginalTerm: null,
+          allowedNoticeMethods: ['email'],
+          noticeRecipient: 'team',
+          leagueForwardingRequired: true,
+        }
+      : null,
+    tradeBonus: null,
+    incentives: {
+      likely: 0,
+      unlikely: 0,
+      criteriaEvidence: 'known',
+    },
+    guaranteeSchedule: [],
+    voidedByExtension: false,
+    voidedOn: unknownTemporal(),
+  };
+}
+
+const predecessorSalaries: ContractSalaryTerm[] = [
+  salaryRow({ season: '2024-25', salary: 8_000_000 }),
+  salaryRow({ season: '2025-26', salary: 9_000_000 }),
+  salaryRow({
+    season: '2026-27',
+    salary: 10_000_000,
+    option: 'TO',
+    optionUsed: true,
+  }),
+  salaryRow({
+    season: SEASON,
+    salary: DECLINED_SALARY,
+    option: 'TO',
+  }),
+];
+
+function state({
+  contractVersion,
+  salaries,
+  freeAgent,
+}: {
+  contractVersion: number;
+  salaries: ContractSalaryTerm[];
+  freeAgent: boolean;
+}): GovernedContractState {
+  const totalValue = salaries.reduce((sum, row) => sum + (row.salary || 0), 0);
+  return makeResultingState({
+    contractId: CONTRACT_ID,
+    contractVersion,
+    playerId: PLAYER_ID,
+    teamId: TEAM_ID,
+    establishmentKind: 'source-establishment',
+    terms: {
+      ...makeResultingState().terms,
+      contractType: 'ROOKIE SCALE CONTRACT',
+      isRookieScale: true,
+      signingTeam: TEAM_ID,
+      startSeason: predecessorSalaries[0].season,
+      endSeason: salaries.at(-1)?.season ?? null,
+      contractLength: salaries.length,
+      totalValue,
+      averageAnnualValue: Math.round(totalValue / salaries.length),
+      guaranteedValue: totalValue,
+      guaranteedYears: salaries.length,
+      salaries,
+      freeAgency: freeAgent
+        ? {
+            type: 'UFA',
+            year: SALARY_CAP_YEAR,
+            capHold: FREE_AGENT_AMOUNT,
+            qualifyingOffer: null,
+            earlyTerminationOption: null,
+            hasOption: false,
+            optionYear: null,
+            optionType: null,
+          }
+        : {
+            type: 'UFA',
+            year: SALARY_CAP_YEAR,
+            capHold: null,
+            qualifyingOffer: null,
+            earlyTerminationOption: null,
+            hasOption: true,
+            optionYear: SEASON,
+            optionType: 'TO',
+          },
+    },
+  });
+}
+
+function events(): ContractEventRecord[] {
+  const root = makeEvent({
+    eventId: `${CONTRACT_ID}:source-establishment`,
+    eventKind: 'source-establishment',
+    worldId: WORLD_ID,
+    contractId: CONTRACT_ID,
+    playerId: PLAYER_ID,
+    teamId: TEAM_ID,
+    executedAt: '2026-07-01T00:00:00-04:00',
+    effectiveAt: '2026-07-01T00:00:00-04:00',
+    recordedAt: '2026-07-01T00:01:00-04:00',
+    predecessorContractVersion: null,
+    predecessorEventId: null,
+    resultingContractVersion: 1,
+    resultingState: state({
+      contractVersion: 1,
+      salaries: predecessorSalaries,
+      freeAgent: false,
+    }),
+  });
+  const decline = makeEvent({
+    eventId: EVENT_ID,
+    eventKind: 'option-decline',
+    worldId: WORLD_ID,
+    contractId: CONTRACT_ID,
+    playerId: PLAYER_ID,
+    teamId: TEAM_ID,
+    executedAt: '2026-11-02T17:00:00-05:00',
+    effectiveAt: EFFECTIVE_AT,
+    recordedAt: '2026-11-03T09:00:00-05:00',
+    predecessorContractVersion: 1,
+    predecessorEventId: root.eventId,
+    resultingContractVersion: 2,
+    authoringIdentity: 'user-bze-276',
+    resultingState: state({
+      contractVersion: 2,
+      salaries: predecessorSalaries.slice(0, 3),
+      freeAgent: true,
+    }),
+    canonLeafIds: ['CBA2-C16.7', 'CBA2-L02.1'],
+  });
+  return [root, decline];
+}
+
+function ledger(eventOverrides: ContractEventRecord[] = events()) {
+  return toContractEventLedgerPayload(
+    createContractEventLedger({
+      ledgerId: `${WORLD_ID}:${CONTRACT_ID}:contract`,
+      ledgerVersion: eventOverrides.length,
+      events: eventOverrides,
+    })
+  );
+}
+
+function team(): MutationTeam {
+  return {
+    teamCode: TEAM_ID,
+    capHolds: [
+      {
+        playerId: PLAYER_ID,
+        playerName: 'Governed Rookie',
+        amount: FREE_AGENT_AMOUNT,
+        type: 'Bird UFA Amount',
+        season: SEASON,
+        isSigned: false,
+        active: true,
+        reason: 'Declined TO',
+        priorTeamOfferCeiling: DECLINED_SALARY,
+        governedContractEventId: EVENT_ID,
+      },
+    ],
+    contractEventLedgers: [ledger()],
+  };
+}
+
+const player: MutationPlayer = {
+  player_id: PLAYER_ID,
+  name: 'Governed Rookie',
+};
+
+function offer({
+  salary = 11_000_000,
+  unlikely = 1_000_000,
+  likely = 0,
+  capHit = salary,
+}: {
+  salary?: number;
+  unlikely?: number;
+  likely?: number;
+  capHit?: number;
+} = {}): MutationContract {
+  return {
+    salariesByYear: [
+      {
+        season: SEASON,
+        salary,
+        capHit,
+        guaranteed: true,
+        guaranteedAmount: salary,
+        incentives: { likely, unlikely },
+      },
+    ],
+    years: 1,
+    contractYears: 1,
+    totalValue: salary,
+  };
+}
+
+function validate(
+  overrides: Partial<
+    Parameters<typeof validateGovernedPriorTeamOptionSigning>[0]
+  > = {}
+) {
+  return validateGovernedPriorTeamOptionSigning({
+    team: team(),
+    player,
+    contract: offer(),
+    worldId: WORLD_ID,
+    year: SALARY_CAP_YEAR,
+    asOfDate: '2027-07-02',
+    dateDefaulted: false,
+    ...overrides,
+  });
+}
+
+describe('governed declined Rookie Scale option signing limit', () => {
+  it('preserves the BZE-275 cap-hold linkage through current-state normalization', () => {
+    expect(
+      normalizeCurrentStateCapHold({
+        ...team().capHolds?.[0],
+        unrelatedClientField: 'drop-me',
+      })
+    ).toMatchObject({
+      playerId: PLAYER_ID,
+      priorTeamOfferCeiling: DECLINED_SALARY,
+      governedContractEventId: EVENT_ID,
+    });
+  });
+
+  it('passes the exact Canon boundary and ignores likely bonuses and cap hit', () => {
+    const result = validate({
+      contract: offer({
+        salary: 11_000_000,
+        unlikely: 1_000_000,
+        likely: 8_000_000,
+        capHit: 30_000_000,
+      }),
+    });
+    expect(result).toEqual({ valid: true, violations: [], warnings: [] });
+  });
+
+  it('blocks the exact Canon negative by $0.01 without rounding it away', () => {
+    const result = validate({
+      contract: offer({ salary: 11_000_000, unlikely: 1_000_000.01 }),
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations[0]).toMatchObject({
+      rule: 'governed_rookie_option_offer_exceeds_ceiling',
+      governedOfferAmount: 12_000_000.01,
+      priorTeamOfferCeiling: DECLINED_SALARY,
+      canonLeafId: 'CBA2-C16.7',
+    });
+  });
+
+  it('passes salary-only at the ceiling and blocks the smallest amount above it', () => {
+    expect(
+      validate({ contract: offer({ salary: DECLINED_SALARY, unlikely: 0 }) })
+        .valid
+    ).toBe(true);
+    expect(
+      validate({
+        contract: offer({ salary: DECLINED_SALARY + 0.01, unlikely: 0 }),
+      }).valid
+    ).toBe(false);
+  });
+
+  it('does not impose the Prior Team limit on another team', () => {
+    expect(
+      validate({
+        team: { teamCode: 'ORL', capHolds: [], contractEventLedgers: [] },
+      }).valid
+    ).toBe(true);
+  });
+
+  it.each([
+    ['missing link', () => ({ governedContractEventId: undefined })],
+    ['wrong link', () => ({ governedContractEventId: 'missing-event' })],
+    ['wrong ceiling', () => ({ priorTeamOfferCeiling: 11_999_999 })],
+    ['wrong season', () => ({ season: '2028-29' })],
+    ['wrong free-agent amount', () => ({ amount: FREE_AGENT_AMOUNT + 1 })],
+    ['inactive hold', () => ({ active: false })],
+    ['signed hold', () => ({ isSigned: true })],
+  ])('fails closed for %s', (_label, tamper) => {
+    const changedTeam = team();
+    changedTeam.capHolds = [{ ...changedTeam.capHolds?.[0], ...tamper() }];
+    expect(validate({ team: changedTeam }).valid).toBe(false);
+  });
+
+  it('fails closed for duplicate cap holds and duplicate linked events', () => {
+    const duplicateHolds = team();
+    duplicateHolds.capHolds = [
+      ...(duplicateHolds.capHolds || []),
+      { ...(duplicateHolds.capHolds || [])[0] },
+    ];
+    expect(validate({ team: duplicateHolds }).violations[0]).toMatchObject({
+      failureKind: 'duplicate',
+    });
+
+    const duplicateLedgers = team();
+    duplicateLedgers.contractEventLedgers = [ledger(), ledger()];
+    expect(validate({ team: duplicateLedgers }).violations[0]).toMatchObject({
+      failureKind: 'duplicate',
+    });
+  });
+
+  it('fails closed when the option decline has no authenticated author', () => {
+    const unauthenticatedEvents = events();
+    unauthenticatedEvents[1] = {
+      ...unauthenticatedEvents[1],
+      authoringIdentity: null,
+    };
+    const unauthenticatedTeam = team();
+    unauthenticatedTeam.contractEventLedgers = [
+      ledger(unauthenticatedEvents),
+    ];
+    expect(validate({ team: unauthenticatedTeam }).violations[0]).toMatchObject(
+      { failureKind: 'unauthenticated' }
+    );
+  });
+
+  it('fails closed for world, team, Season, decision, Contract, and malformed-ledger mismatches', () => {
+    expect(validate({ worldId: 'world-other' }).valid).toBe(false);
+
+    const wrongTeam = team();
+    wrongTeam.teamCode = 'ORL';
+    expect(validate({ team: wrongTeam }).valid).toBe(false);
+
+    expect(validate({ year: 2029 }).violations[0]).toMatchObject({
+      failureKind: 'stale',
+    });
+
+    const wrongDecisionEvents = events();
+    wrongDecisionEvents[1] = {
+      ...wrongDecisionEvents[1],
+      eventKind: 'option-exercise',
+    };
+    const wrongDecision = team();
+    wrongDecision.contractEventLedgers = [ledger(wrongDecisionEvents)];
+    expect(validate({ team: wrongDecision }).valid).toBe(false);
+
+    const wrongContract = team();
+    wrongContract.contractEventLedgers = [
+      {
+        ...ledger(),
+        ledgerId: `${WORLD_ID}:contract-other:contract`,
+      },
+    ];
+    expect(validate({ team: wrongContract }).valid).toBe(false);
+
+    const malformed = team();
+    malformed.contractEventLedgers = [
+      { ...ledger(), payloadVersion: 999 } as never,
+    ];
+    expect(validate({ team: malformed }).violations[0]).toMatchObject({
+      failureKind: 'malformed',
+    });
+  });
+
+  it('fails closed when a later Contract event makes the linked decline stale', () => {
+    const chain = events();
+    const laterState = state({
+      contractVersion: 3,
+      salaries: predecessorSalaries.slice(0, 3),
+      freeAgent: true,
+    });
+    chain.push(
+      makeEvent({
+        eventId: `${CONTRACT_ID}:amendment:v3`,
+        eventKind: 'amendment',
+        worldId: WORLD_ID,
+        contractId: CONTRACT_ID,
+        playerId: PLAYER_ID,
+        teamId: TEAM_ID,
+        executedAt: '2027-07-02T00:00:00-04:00',
+        effectiveAt: '2027-07-02T00:00:00-04:00',
+        recordedAt: '2027-07-02T00:01:00-04:00',
+        predecessorContractVersion: 2,
+        predecessorEventId: EVENT_ID,
+        resultingContractVersion: 3,
+        resultingState: laterState,
+      })
+    );
+    const staleTeam = team();
+    staleTeam.contractEventLedgers = [ledger(chain)];
+    expect(validate({ team: staleTeam }).violations[0]).toMatchObject({
+      failureKind: 'stale',
+    });
+  });
+
+  it('runs at the authoritative non-trade validation stage before persistence', () => {
+    const result = validateNonTradeMutationStage({
+      mutationType: 'signFreeAgent',
+      payload: {
+        teamCode: TEAM_ID,
+        playerId: PLAYER_ID,
+        contract: offer({ salary: 11_000_000, unlikely: 1_000_000.01 }),
+        signedUsing: 'CAP_SPACE',
+      },
+      currentState: {
+        team: team(),
+        player,
+        teamCode: TEAM_ID,
+      },
+      computeResult: { success: true },
+      seasonId: SEASON,
+      asOfDate: '2027-07-02',
+      dateDefaulted: false,
+      worldId: WORLD_ID,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations?.[0]).toContain(
+      'governed_rookie_option_offer_exceeds_ceiling'
+    );
+  });
+});

--- a/tests/architect/governedPriorTeamOptionSigning.test.ts
+++ b/tests/architect/governedPriorTeamOptionSigning.test.ts
@@ -26,6 +26,8 @@ const PLAYER_ID = 'player-bze-276';
 const CONTRACT_ID = 'contract-bze-276';
 const SALARY_CAP_YEAR = 2028;
 const SEASON = '2027-28';
+const THIRD_SALARY_CAP_YEAR = 2027;
+const THIRD_SEASON = '2026-27';
 const DECLINED_SALARY = 12_000_000;
 const FREE_AGENT_AMOUNT = 21_850_000;
 const EFFECTIVE_AT = '2027-07-01T00:00:00-04:00';
@@ -54,6 +56,10 @@ function salaryRow({
   option?: 'TO' | null;
   optionUsed?: boolean | null;
 }): ContractSalaryTerm {
+  const seasonStartYear = season.match(/^(\d{4})-\d{2}$/)?.[1];
+  const contractEndsAt = seasonStartYear
+    ? `${seasonStartYear}-07-01T00:00:00-04:00`
+    : EFFECTIVE_AT;
   return {
     season,
     salary,
@@ -72,7 +78,7 @@ function salaryRow({
           termsVersion: 1,
           conditional: false,
           decisionWindowOpensAt: instant('2026-10-01T09:00:00-04:00'),
-          contractEndsAt: instant(EFFECTIVE_AT),
+          contractEndsAt: instant(contractEndsAt),
           nonCompensationTermsMatchPriorSeason: true,
           compensationProtectionMatchesPriorSeason: true,
           rookieScaleOptionOrdinal: season === SEASON ? 'fourth' : 'third',
@@ -122,10 +128,16 @@ function state({
   contractVersion,
   salaries,
   freeAgent,
+  salaryCapYear = SALARY_CAP_YEAR,
+  optionSeason = SEASON,
+  startSeason = predecessorSalaries[0].season,
 }: {
   contractVersion: number;
   salaries: ContractSalaryTerm[];
   freeAgent: boolean;
+  salaryCapYear?: number;
+  optionSeason?: string;
+  startSeason?: string;
 }): GovernedContractState {
   const totalValue = salaries.reduce((sum, row) => sum + (row.salary || 0), 0);
   return makeResultingState({
@@ -139,7 +151,7 @@ function state({
       contractType: 'ROOKIE SCALE CONTRACT',
       isRookieScale: true,
       signingTeam: TEAM_ID,
-      startSeason: predecessorSalaries[0].season,
+      startSeason,
       endSeason: salaries.at(-1)?.season ?? null,
       contractLength: salaries.length,
       totalValue,
@@ -150,7 +162,7 @@ function state({
       freeAgency: freeAgent
         ? {
             type: 'UFA',
-            year: SALARY_CAP_YEAR,
+            year: salaryCapYear,
             capHold: FREE_AGENT_AMOUNT,
             qualifyingOffer: null,
             earlyTerminationOption: null,
@@ -160,19 +172,41 @@ function state({
           }
         : {
             type: 'UFA',
-            year: SALARY_CAP_YEAR,
+            year: salaryCapYear,
             capHold: null,
             qualifyingOffer: null,
             earlyTerminationOption: null,
             hasOption: true,
-            optionYear: SEASON,
+            optionYear: optionSeason,
             optionType: 'TO',
           },
     },
   });
 }
 
-function events(): ContractEventRecord[] {
+function events({
+  salaries = predecessorSalaries,
+  salaryCapYear = SALARY_CAP_YEAR,
+  optionSeason = SEASON,
+  executedAt = '2026-11-02T17:00:00-05:00',
+  effectiveAt = EFFECTIVE_AT,
+  recordedAt = '2026-11-03T09:00:00-05:00',
+  rootExecutedAt = '2026-07-01T00:00:00-04:00',
+  rootEffectiveAt = '2026-07-01T00:00:00-04:00',
+  rootRecordedAt = '2026-07-01T00:01:00-04:00',
+}: {
+  salaries?: ContractSalaryTerm[];
+  salaryCapYear?: number;
+  optionSeason?: string;
+  executedAt?: string;
+  effectiveAt?: string;
+  recordedAt?: string;
+  rootExecutedAt?: string;
+  rootEffectiveAt?: string;
+  rootRecordedAt?: string;
+} = {}): ContractEventRecord[] {
+  const optionIndex = salaries.findIndex((row) => row.season === optionSeason);
+  const eventId = `${CONTRACT_ID}:to:${optionSeason}:decline:v2`;
   const root = makeEvent({
     eventId: `${CONTRACT_ID}:source-establishment`,
     eventKind: 'source-establishment',
@@ -180,36 +214,42 @@ function events(): ContractEventRecord[] {
     contractId: CONTRACT_ID,
     playerId: PLAYER_ID,
     teamId: TEAM_ID,
-    executedAt: '2026-07-01T00:00:00-04:00',
-    effectiveAt: '2026-07-01T00:00:00-04:00',
-    recordedAt: '2026-07-01T00:01:00-04:00',
+    executedAt: rootExecutedAt,
+    effectiveAt: rootEffectiveAt,
+    recordedAt: rootRecordedAt,
     predecessorContractVersion: null,
     predecessorEventId: null,
     resultingContractVersion: 1,
     resultingState: state({
       contractVersion: 1,
-      salaries: predecessorSalaries,
+      salaries,
       freeAgent: false,
+      salaryCapYear,
+      optionSeason,
+      startSeason: salaries[0].season,
     }),
   });
   const decline = makeEvent({
-    eventId: EVENT_ID,
+    eventId,
     eventKind: 'option-decline',
     worldId: WORLD_ID,
     contractId: CONTRACT_ID,
     playerId: PLAYER_ID,
     teamId: TEAM_ID,
-    executedAt: '2026-11-02T17:00:00-05:00',
-    effectiveAt: EFFECTIVE_AT,
-    recordedAt: '2026-11-03T09:00:00-05:00',
+    executedAt,
+    effectiveAt,
+    recordedAt,
     predecessorContractVersion: 1,
     predecessorEventId: root.eventId,
     resultingContractVersion: 2,
     authoringIdentity: 'user-bze-276',
     resultingState: state({
       contractVersion: 2,
-      salaries: predecessorSalaries.slice(0, 3),
+      salaries: salaries.slice(0, optionIndex),
       freeAgent: true,
+      salaryCapYear,
+      optionSeason,
+      startSeason: salaries[0].season,
     }),
     canonLeafIds: ['CBA2-C16.7', 'CBA2-L02.1'],
   });
@@ -257,16 +297,18 @@ function offer({
   unlikely = 1_000_000,
   likely = 0,
   capHit = salary,
+  season = SEASON,
 }: {
   salary?: number;
   unlikely?: number;
   likely?: number;
   capHit?: number;
+  season?: string;
 } = {}): MutationContract {
   return {
     salariesByYear: [
       {
-        season: SEASON,
+        season,
         salary,
         capHit,
         guaranteed: true,
@@ -323,6 +365,13 @@ describe('governed declined Rookie Scale option signing limit', () => {
     expect(result).toEqual({ valid: true, violations: [], warnings: [] });
   });
 
+  it('uses exact cents so a floating-point exact-ceiling split passes', () => {
+    const result = validate({
+      contract: offer({ salary: 11_999_999.99, unlikely: 0.01 }),
+    });
+    expect(result).toEqual({ valid: true, violations: [], warnings: [] });
+  });
+
   it('blocks the exact Canon negative by $0.01 without rounding it away', () => {
     const result = validate({
       contract: offer({ salary: 11_000_000, unlikely: 1_000_000.01 }),
@@ -357,17 +406,93 @@ describe('governed declined Rookie Scale option signing limit', () => {
   });
 
   it.each([
-    ['missing link', () => ({ governedContractEventId: undefined })],
-    ['wrong link', () => ({ governedContractEventId: 'missing-event' })],
-    ['wrong ceiling', () => ({ priorTeamOfferCeiling: 11_999_999 })],
-    ['wrong season', () => ({ season: '2028-29' })],
-    ['wrong free-agent amount', () => ({ amount: FREE_AGENT_AMOUNT + 1 })],
-    ['inactive hold', () => ({ active: false })],
-    ['signed hold', () => ({ isSigned: true })],
-  ])('fails closed for %s', (_label, tamper) => {
-    const changedTeam = team();
-    changedTeam.capHolds = [{ ...changedTeam.capHolds?.[0], ...tamper() }];
-    expect(validate({ team: changedTeam }).valid).toBe(false);
+    ['missing link', () => ({ governedContractEventId: undefined }), 'missing'],
+    [
+      'wrong link',
+      () => ({ governedContractEventId: 'missing-event' }),
+      'missing',
+    ],
+    ['wrong ceiling', () => ({ priorTeamOfferCeiling: 11_999_999 }), 'mismatch'],
+    ['wrong season', () => ({ season: '2028-29' }), 'mismatch'],
+    [
+      'wrong free-agent amount',
+      () => ({ amount: FREE_AGENT_AMOUNT + 1 }),
+      'mismatch',
+    ],
+    ['inactive hold', () => ({ active: false }), 'stale'],
+    ['signed hold', () => ({ isSigned: true }), 'stale'],
+  ])(
+    'fails closed for %s with the expected authority kind',
+    (_label, tamper, failureKind) => {
+      const changedTeam = team();
+      changedTeam.capHolds = [{ ...changedTeam.capHolds?.[0], ...tamper() }];
+      expect(validate({ team: changedTeam }).violations[0]).toMatchObject({
+        failureKind,
+      });
+    }
+  );
+
+  it('fails closed for missing player or team identity before applicability scanning', () => {
+    expect(
+      validate({ player: { name: 'Missing player identity' } })
+        .violations[0]
+    ).toMatchObject({ failureKind: 'missing' });
+
+    expect(
+      validate({ team: { ...team(), teamCode: undefined } }).violations[0]
+    ).toMatchObject({ failureKind: 'missing' });
+  });
+
+  it('accepts governed declines of both third- and fourth-Season Rookie Scale Team Options', () => {
+    expect(validate().valid).toBe(true);
+
+    const thirdOptionSalaries = predecessorSalaries.map((row) =>
+      row.season === THIRD_SEASON
+        ? salaryRow({
+            season: THIRD_SEASON,
+            salary: 10_000_000,
+            option: 'TO',
+          })
+        : row
+    );
+    const thirdEvents = events({
+      salaries: thirdOptionSalaries,
+      salaryCapYear: THIRD_SALARY_CAP_YEAR,
+      optionSeason: THIRD_SEASON,
+      executedAt: '2025-11-02T17:00:00-05:00',
+      effectiveAt: '2026-07-01T00:00:00-04:00',
+      recordedAt: '2025-11-03T09:00:00-05:00',
+      rootExecutedAt: '2024-07-01T00:00:00-04:00',
+      rootEffectiveAt: '2024-07-01T00:00:00-04:00',
+      rootRecordedAt: '2024-07-01T00:01:00-04:00',
+    });
+    const thirdEventId = thirdEvents[1].eventId;
+    const thirdTeam = team();
+    thirdTeam.capHolds = [
+      {
+        ...thirdTeam.capHolds?.[0],
+        season: THIRD_SEASON,
+        priorTeamOfferCeiling: 10_000_000,
+        governedContractEventId: thirdEventId,
+      },
+    ];
+    thirdTeam.contractEventLedgers = [ledger(thirdEvents)];
+
+    expect(
+      validateGovernedPriorTeamOptionSigning({
+        team: thirdTeam,
+        player,
+        contract: offer({
+          salary: 9_000_000,
+          unlikely: 1_000_000,
+          season: THIRD_SEASON,
+        }),
+        worldId: WORLD_ID,
+        year: THIRD_SALARY_CAP_YEAR,
+        asOfDate: '2026-07-02',
+        dateDefaulted: false,
+      })
+    ).toEqual({ valid: true, violations: [], warnings: [] });
   });
 
   it('fails closed for duplicate cap holds and duplicate linked events', () => {
@@ -494,6 +619,56 @@ describe('governed declined Rookie Scale option signing limit', () => {
     expect(result.valid).toBe(false);
     expect(result.violations?.[0]).toContain(
       'governed_rookie_option_offer_exceeds_ceiling'
+    );
+  });
+
+  it('passes an exact-ceiling offer through the shared mutation stage', () => {
+    const result = validateNonTradeMutationStage({
+      mutationType: 'signFreeAgent',
+      payload: {
+        teamCode: TEAM_ID,
+        playerId: PLAYER_ID,
+        contract: offer({ salary: 11_999_999.99, unlikely: 0.01 }),
+        signedUsing: 'CAP_SPACE',
+      },
+      currentState: {
+        team: team(),
+        player,
+        teamCode: TEAM_ID,
+      },
+      computeResult: { success: true },
+      seasonId: SEASON,
+      asOfDate: '2027-07-02',
+      dateDefaulted: false,
+      worldId: WORLD_ID,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('blocks ordinary signing when the Salary Cap Year cannot be derived', () => {
+    const result = validateNonTradeMutationStage({
+      mutationType: 'signFreeAgent',
+      payload: {
+        teamCode: TEAM_ID,
+        playerId: PLAYER_ID,
+        contract: offer(),
+        signedUsing: 'CAP_SPACE',
+      },
+      currentState: {
+        team: team(),
+        player,
+        teamCode: TEAM_ID,
+      },
+      computeResult: { success: true },
+      seasonId: 'not-a-season',
+      asOfDate: '2027-07-02',
+      dateDefaulted: false,
+      worldId: WORLD_ID,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations?.[0]).toContain(
+      'governed_signing_salary_cap_year_missing'
     );
   });
 });

--- a/tests/architect/governedPriorTeamOptionSigning.test.ts
+++ b/tests/architect/governedPriorTeamOptionSigning.test.ts
@@ -385,6 +385,14 @@ describe('governed declined Rookie Scale option signing limit', () => {
     });
   });
 
+  it('rejects a sub-cent offer above the ceiling instead of rounding it into compliance', () => {
+    const result = validate({
+      contract: offer({ salary: DECLINED_SALARY + 0.001, unlikely: 0 }),
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations[0]).toMatchObject({ failureKind: 'malformed' });
+  });
+
   it('passes salary-only at the ceiling and blocks the smallest amount above it', () => {
     expect(
       validate({ contract: offer({ salary: DECLINED_SALARY, unlikely: 0 }) })
@@ -646,29 +654,32 @@ describe('governed declined Rookie Scale option signing limit', () => {
     expect(result.violations).toEqual([]);
   });
 
-  it('blocks ordinary signing when the Salary Cap Year cannot be derived', () => {
-    const result = validateNonTradeMutationStage({
-      mutationType: 'signFreeAgent',
-      payload: {
-        teamCode: TEAM_ID,
-        playerId: PLAYER_ID,
-        contract: offer(),
-        signedUsing: 'CAP_SPACE',
-      },
-      currentState: {
-        team: team(),
-        player,
-        teamCode: TEAM_ID,
-      },
-      computeResult: { success: true },
-      seasonId: 'not-a-season',
-      asOfDate: '2027-07-02',
-      dateDefaulted: false,
-      worldId: WORLD_ID,
-    });
-    expect(result.valid).toBe(false);
-    expect(result.violations?.[0]).toContain(
-      'governed_signing_salary_cap_year_missing'
-    );
-  });
+  it.each(['not-a-season', '2027invalid'])(
+    'blocks ordinary signing when Salary Cap Year cannot be derived from %s',
+    (seasonId) => {
+      const result = validateNonTradeMutationStage({
+        mutationType: 'signFreeAgent',
+        payload: {
+          teamCode: TEAM_ID,
+          playerId: PLAYER_ID,
+          contract: offer(),
+          signedUsing: 'CAP_SPACE',
+        },
+        currentState: {
+          team: team(),
+          player,
+          teamCode: TEAM_ID,
+        },
+        computeResult: { success: true },
+        seasonId,
+        asOfDate: '2027-07-02',
+        dateDefaulted: false,
+        worldId: WORLD_ID,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.violations?.[0]).toContain(
+        'governed_signing_salary_cap_year_missing'
+      );
+    }
+  );
 });

--- a/tests/e2e/architect-option-decision.spec.ts
+++ b/tests/e2e/architect-option-decision.spec.ts
@@ -1579,6 +1579,8 @@ test.describe('BZE-275 governed Full Cap Table option/ETO browser proof', () => 
 
     await firstYearSalary.fill('12000000');
     await firstYearSalary.blur();
+    await expect(blockedAlert).toHaveCount(0);
+    await expect(confirm).toBeEnabled();
     await confirm.click();
     await expect(modal).toHaveCount(0, { timeout: 25_000 });
     await waitForReviewDashboard(page);

--- a/tests/e2e/architect-option-decision.spec.ts
+++ b/tests/e2e/architect-option-decision.spec.ts
@@ -718,6 +718,11 @@ const playerRow = (page: Page, playerName: string) =>
       .filter({ hasText: playerName }),
   });
 
+const ownFaDecisionRow = (page: Page, playerName: string) =>
+  page
+    .getByTestId('cap-sheet-full-fa-decision-row')
+    .filter({ hasText: playerName });
+
 const optionCell = (page: Page, playerName: string) =>
   playerRow(page, playerName)
     .locator('[data-action-exposure-classification]')
@@ -804,6 +809,14 @@ const capture = async (page: Page, testInfo: TestInfo, label: string) => {
     path: testInfo.outputPath(`${label}.png`),
     fullPage: true,
   });
+};
+
+const captureViewport = async (
+  page: Page,
+  testInfo: TestInfo,
+  label: string
+) => {
+  await page.screenshot({ path: testInfo.outputPath(`${label}.png`) });
 };
 
 const worldTeam = async (worldId: string) =>
@@ -1471,5 +1484,240 @@ test.describe('BZE-275 governed Full Cap Table option/ETO browser proof', () => 
       )
     ).toMatchObject({ priorTeamOfferCeiling: 12_000_000 });
     await capture(page, testInfo, 'BZE-275-repair-branched-replay');
+  });
+
+  test('BZE-276 enforces the declined Rookie Scale ceiling at Prior Team signing and preserves the allowed result', async ({
+    page,
+  }, testInfo) => {
+    await expect
+      .poll(() => readReviewUserId(page), { timeout: 25_000 })
+      .not.toBe('');
+    const userId = await readReviewUserId(page);
+    const rookie = buildFixturePlayer({
+      optionType: 'TO',
+      suffix: 'BZE-276-Prior-Team-Signing',
+      isRookieScale: true,
+      optionSalary: 12_000_000,
+      optionUnlikelyBonus: 200_000,
+    });
+    const { worldId } = await seedOptionWorld({
+      userId,
+      optionType: 'TO',
+      includeBlocked: false,
+      fixtureOverrides: [rookie],
+    });
+    await activateWorld(page, userId, worldId);
+
+    await recordDecision({
+      page,
+      fixture: rookie,
+      choice: 'decline',
+      notice: {
+        deliveredAt: '2026-11-02T17:00:00-05:00',
+        leagueReceivedAt: '2026-11-02T17:01:00-05:00',
+        forwardedAt: '2026-11-03T09:00:00-05:00',
+      },
+    });
+
+    const declinedTeam = await worldTeam(worldId);
+    expect(
+      (Array.isArray(declinedTeam?.capHolds) ? declinedTeam.capHolds : []).find(
+        (hold) =>
+          Boolean(hold) &&
+          typeof hold === 'object' &&
+          !Array.isArray(hold) &&
+          (hold as RecordLike).playerId === rookie.playerId
+      )
+    ).toMatchObject({
+      priorTeamOfferCeiling: 12_000_000,
+      governedContractEventId: expect.any(String),
+    });
+
+    await openTab(page, 'Full Cap Table');
+    const faRow = ownFaDecisionRow(page, rookie.displayName);
+    await expect(faRow).toBeVisible({ timeout: 20_000 });
+    const resignCell = faRow
+      .getByTestId('cap-sheet-full-fa-resign-cell')
+      .first();
+    await expect(resignCell).toHaveAttribute(
+      'data-action-exposure-classification',
+      'V1 supported'
+    );
+    await resignCell.click();
+
+    const modal = page.getByTestId('edit-contract-modal');
+    await expect(modal).toBeVisible({ timeout: 20_000 });
+    await expect(
+      modal.getByTestId('contract-modal-action-context')
+    ).toContainText(rookie.displayName);
+    await modal.getByTestId('contract-action-resign').check();
+    const firstYearSalary = modal.locator('input[inputmode="decimal"]').first();
+    await firstYearSalary.fill('12000001');
+    await firstYearSalary.blur();
+
+    const beforeBlockedTeam = JSON.stringify(await worldTeam(worldId));
+    const beforeBlockedEvents = JSON.stringify(await worldEvents(worldId));
+    const confirm = modal.getByTestId('edit-contract-confirm-action-button');
+    await expect(confirm).toBeEnabled();
+    await confirm.click();
+    const blockedAlert = modal.getByRole('alert');
+    await expect(blockedAlert).toBeVisible({ timeout: 20_000 });
+    await expect(blockedAlert).toContainText(
+      /exceeds the Prior Team's \$12,000,000\.00 limit/i
+    );
+    await expect(blockedAlert).toContainText(/No changes were saved/i);
+    expect(JSON.stringify(await worldTeam(worldId))).toBe(beforeBlockedTeam);
+    expect(JSON.stringify(await worldEvents(worldId))).toBe(
+      beforeBlockedEvents
+    );
+    await blockedAlert.scrollIntoViewIfNeeded();
+    await captureViewport(
+      page,
+      testInfo,
+      'BZE-276-over-ceiling-blocked-no-write-1280x720'
+    );
+
+    await firstYearSalary.fill('12000000');
+    await firstYearSalary.blur();
+    await confirm.click();
+    await expect(modal).toHaveCount(0, { timeout: 25_000 });
+    await waitForReviewDashboard(page);
+    await expect(page.getByTestId('cockpit-last-receipt')).toContainText(
+      /Free agent signed/i,
+      { timeout: 20_000 }
+    );
+
+    await openTab(page, 'Full Cap Table');
+    await expect(ownFaDecisionRow(page, rookie.displayName)).toHaveCount(0);
+    const signedRow = playerRow(page, rookie.displayName);
+    await expect(signedRow).toBeVisible({ timeout: 20_000 });
+    await expect(signedRow).toContainText('$12,000,000');
+    await captureViewport(
+      page,
+      testInfo,
+      'BZE-276-exact-ceiling-signed-full-cap-table-1280x720'
+    );
+
+    const persisted = await worldTeam(worldId);
+    expect(teamPlayerIds(persisted)).toContain(rookie.playerId);
+    expect(
+      (Array.isArray(persisted?.capHolds) ? persisted.capHolds : []).some(
+        (hold) =>
+          Boolean(hold) &&
+          typeof hold === 'object' &&
+          !Array.isArray(hold) &&
+          (hold as RecordLike).playerId === rookie.playerId
+      )
+    ).toBe(false);
+    const signedPlayer = (
+      Array.isArray(persisted?.players) ? persisted.players : []
+    ).find(
+      (candidate) =>
+        Boolean(candidate) &&
+        typeof candidate === 'object' &&
+        !Array.isArray(candidate) &&
+        ((candidate as RecordLike).playerId === rookie.playerId ||
+          (candidate as RecordLike).player_id === rookie.playerId)
+    ) as RecordLike | undefined;
+    const signedContract = signedPlayer?.contract as RecordLike | undefined;
+    const signedRows = Array.isArray(signedContract?.salariesByYear)
+      ? signedContract.salariesByYear
+      : [];
+    expect(signedRows[0]).toMatchObject({
+      season: TARGET_SEASON,
+      salary: 12_000_000,
+    });
+    expect(await worldEvents(worldId)).toHaveLength(2);
+
+    // The signed contract starts in 2027-28; align the single-season Roster
+    // room to that Season before asserting its membership.
+    await page
+      .getByRole('combobox', { name: 'Viewing season' })
+      .selectOption({ label: TARGET_SEASON });
+    await openTab(page, 'Roster');
+    await expect(
+      page
+        .getByRole('region', { name: /^Roster$/i })
+        .getByRole('button', { name: rookie.displayName, exact: false })
+        .first()
+    ).toBeVisible();
+    await openTab(page, 'Cap Sheet');
+    await page
+      .getByRole('button', { name: TARGET_SEASON, exact: true })
+      .click();
+    await expect(
+      page
+        .getByRole('region', { name: /^Cap Sheet$/i })
+        .getByText(rookie.displayName, { exact: true })
+        .first()
+    ).toBeVisible();
+    await openTab(page, 'Team History');
+    await expect(page.getByText(/Signed Free Agent/i).first()).toBeVisible();
+    await expect(
+      page.getByText(rookie.displayName, { exact: false }).first()
+    ).toBeVisible();
+    await openTab(page, 'Compare');
+    await expect(page.getByTestId('comparison-event-count')).toContainText(
+      /2\s+committed events/i,
+      { timeout: 20_000 }
+    );
+    await expect(page.getByTestId('comparison-roster-additions')).toContainText(
+      rookie.displayName
+    );
+    await expect(page.getByTestId('cockpit-world-menu-trigger')).toContainText(
+      'BZE 275 TO Review'
+    );
+    await captureViewport(
+      page,
+      testInfo,
+      'BZE-276-signed-history-compare-team-plan-1280x720'
+    );
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForReviewDashboard(page);
+    await expect
+      .poll(() => readActiveWorldId(page), { timeout: 20_000 })
+      .toBe(worldId);
+    await openTab(page, 'Full Cap Table');
+    await expect(ownFaDecisionRow(page, rookie.displayName)).toHaveCount(0);
+    await expect(playerRow(page, rookie.displayName)).toContainText(
+      '$12,000,000'
+    );
+
+    const branchName = 'BZE 276 Signed Branch';
+    const childWorldId = await branchFixtureWorld(
+      page,
+      userId,
+      worldId,
+      branchName
+    );
+    await openTab(page, 'Full Cap Table');
+    await expect(ownFaDecisionRow(page, rookie.displayName)).toHaveCount(0);
+    await expect(playerRow(page, rookie.displayName)).toContainText(
+      '$12,000,000'
+    );
+    const childTeam = await worldTeam(childWorldId);
+    expect(teamPlayerIds(childTeam)).toContain(rookie.playerId);
+    expect(
+      contractLedgerEvents(childTeam).filter(
+        (event) => event.playerId === rookie.playerId
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ worldId: childWorldId }),
+      ])
+    );
+    expect(await worldEvents(childWorldId)).toHaveLength(2);
+    await captureViewport(
+      page,
+      testInfo,
+      'BZE-276-signed-branch-replay-1280x720'
+    );
+
+    testInfo.annotations.push({
+      type: 'audit-note',
+      description:
+        'BZE-276 fresh governed saved-world proof: MIA declines a $12M fourth-Season Rookie Scale Team Option; a $12,000,001 Prior Team offer is blocked with no team/event write; the exact $12M salary-only offer signs, removes the governed hold, updates Full Cap Table/Roster/Cap Sheet/History/Compare/Team Plan, and survives reload plus branching. Production source readiness remains 0 option-ready / 243 option-blocked.',
+    });
   });
 });


### PR DESCRIPTION
## Outcome

Enforces the governed Prior Team signing ceiling created by a declined Rookie Scale Team Option. First-year Salary plus Unlikely Bonuses must not exceed the declined option Salary.

## Independent-review delta

Independent Claude rejected candidate `32f0a86917c690087a9e7ed16e1b6c36ec360485` because promoting the governed hold into Full Cap Table’s actionable signing lane also exposed that lane’s separate Sign & Trade route.

Exact repaired candidate: `9fcfaeb907dc590af6e42cbff42159e81ab1c4a3`.

- Full Cap Table suppresses Sign & Trade for a complete governed option hold and for either partial governed marker, so malformed asserted authority also fails closed at action exposure.
- Ordinary eligible holds retain Sign & Trade.
- Governed ordinary Prior Team signing and enabled renunciation remain available.
- The sign-and-trade engine and its pre-existing calendar fallback are unchanged and remain open.
- Refreshed automation also identified unsupported Salary Cap Year rollovers; the existing strict parser now validates both endpoints and preserves its established range before downstream signing validation.

## Boundary

- Authenticates one active cap hold against one current immutable option-decline event and matching world, player, Prior Team, Contract, Season, decision, amount, and author.
- Fails closed before mutation for missing, duplicate, stale, malformed, unauthenticated, or mismatched authority.
- Requires exact cent-denominated Salary, Unlikely Bonuses, and ceiling authority.
- Rejects missing, malformed, or unsupported Salary Cap Year authority without a runtime-calendar fallback.
- Keeps only a strictly authoritative linked off-roster hold on the actionable Prior Team lane.
- Preserves exact-ceiling success across Full Cap Table, Roster, Cap Sheet, History, Compare, reload, and branching.
- Fresh BZE-275 saved-world path only; no history invention or backfill, bonus editor, signing redesign, QO or ROFR, extensions, Season Advance, sign-and-trade engine work, or other workflow expansion.

## Canon accounting

- Newly established on this ordinary Prior Team signing path: `CBA2-C16.7` only.
- Prepared: none newly claimed.
- Open: sign-and-trade and all other Canon leaves and workflows remain open.
- Source readiness remains honestly `0 option-ready / 243 option-blocked`.

## Exact-candidate validation

- Full Cap Table governed-rights integration: 8 of 8 passed, including governed suppression with callback supplied, ceiling-only/event-only assertions, ordinary Sign & Trade preservation, actionable signing placement, and renunciation.
- Cap Sheet boundary: 76 of 76 passed.
- Governed BZE-276 boundary: 26 of 26 passed, retaining all ceiling behavior and adding unsupported rollover cases.
- Typecheck, production build, project validation, and Architect baseline gate passed.
- Graphify update completed; no tracked graph output remains.
- Hosted diff-selected PR validation passed in 4m59s.
- CodeRabbit approved the exact candidate; all review threads are resolved.
- Vercel passed.
- Browser/emulator proof was deliberately not rerun: this delta is a render-only affordance condition plus parser edge guards, and focused component coverage directly exercises both render branches. The prior governed signing persistence proof remains unchanged but is not claimed as a rerun on this SHA.
- Broad local Architect/UI tiers and the full suite were deliberately skipped under the requested validation-efficiency boundary and repository policy.

## Independent acceptance

Independent Claude **ACCEPTED** exact candidate `9fcfaeb907dc590af6e42cbff42159e81ab1c4a3`: https://github.com/Bet-Zero/scoutzero/pull/499#issuecomment-5264159252

This supersedes the prior **REJECT** of `32f0a869…`. No code changed after acceptance.

## Non-blocking known limitation

The strict signing helper retains its pre-existing `1900` lower bound while governed time permits `1001–9999`. No current route produces `1001–1899`, and the mismatch fails closed. No code change or speculative follow-up is included in this tranche.

Fixes BZE-276

