### PR TITLE
BZE-277: Exclude Two-Way contracts from trade salary matching

### DIFF
--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -588,6 +588,7 @@ utils/
       tradeExportUtils.ts
       tradeTimingWindows.ts
       tradeUtilityMisc.ts
+      twoWayTradeSalary.ts
       validateInput.ts
       validationIssueText.ts
   tradeManager.ts
@@ -606,5 +607,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-08-12T04:57:54.607Z*
+*Generated on: 2026-08-13T08:21:43.880Z*
 *Auto-updated by: npm run docs*

--- a/src/features/architect/tradeMachine/TradeReceiptPanel.tsx
+++ b/src/features/architect/tradeMachine/TradeReceiptPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/features/architect/utils/entitlements/entitlementPickRowProjection';
 import type { PickRuleDoc } from '@/features/architect/utils/entitlements/pickRulesResolver';
 import { getValidationIssueText } from '@/features/architect/utils/tradeMachine/utils/validationIssueText';
+import { TWO_WAY_TRADE_MATCHING_EXPLANATION } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 import type {
   TeamPlayerLike,
   TradeReceiptLike,
@@ -28,6 +29,7 @@ type PlayerFlagsLike = {
   hasTradeKicker?: boolean;
   isPoisonPill?: boolean;
   tradeKickerPct?: number | string | null;
+  isTwoWay?: boolean;
 };
 
 const toText = (value: unknown) => (value == null ? '' : String(value));
@@ -44,12 +46,14 @@ const PlayerListItem = ({ player, direction }: PlayerListItemProps) => {
     hasAdjustment &&
     (direction === 'outgoing'
       ? !flags.isBYC && !flags.hasTradeKicker
-      : !flags.isPoisonPill && !flags.hasTradeKicker);
+      : !flags.isPoisonPill && !flags.hasTradeKicker) &&
+    !flags.isTwoWay;
   const showBreakdown =
-    direction === 'outgoing'
+    flags.isTwoWay ||
+    (direction === 'outgoing'
       ? flags.isBYC && player.baseSalary !== player.matchingValue
       : (flags.isPoisonPill || flags.hasTradeKicker) &&
-        player.baseSalary !== player.matchingValue;
+        player.baseSalary !== player.matchingValue);
   const kickerPct = (Number(flags.tradeKickerPct || 0) * 100).toFixed(0);
   const playerName = toText(player.name) || 'Unknown';
   const adjTooltipText = `Adjusted: Base ${formatCurrency(player.baseSalary)} → Match ${formatCurrency(player.matchingValue)}`;
@@ -65,6 +69,14 @@ const PlayerListItem = ({ player, direction }: PlayerListItemProps) => {
               title={adjTooltipText}
             >
               Adj
+            </span>
+          )}
+          {flags.isTwoWay && (
+            <span
+              className="text-cockpit-info ml-1"
+              title={TWO_WAY_TRADE_MATCHING_EXPLANATION}
+            >
+              2W
             </span>
           )}
           {direction === 'outgoing' && flags.isBYC && (
@@ -100,13 +112,18 @@ const PlayerListItem = ({ player, direction }: PlayerListItemProps) => {
           {formatCurrency(player.matchingValue)}
         </span>
       </div>
-      {showBreakdown && direction === 'outgoing' && (
+      {showBreakdown && flags.isTwoWay && (
+        <div className="text-cockpit-text-muted text-xs mt-0.5 pl-2">
+          {TWO_WAY_TRADE_MATCHING_EXPLANATION}
+        </div>
+      )}
+      {showBreakdown && !flags.isTwoWay && direction === 'outgoing' && (
         <div className="text-cockpit-text-muted text-xs mt-0.5 pl-2">
           Base: {formatCurrency(player.baseSalary)} → Match:{' '}
           {formatCurrency(player.matchingValue)} (BYC: max(prior, 50% new))
         </div>
       )}
-      {showBreakdown && direction === 'incoming' && (
+      {showBreakdown && !flags.isTwoWay && direction === 'incoming' && (
         <div className="text-cockpit-text-muted text-xs mt-0.5 pl-2">
           Base: {formatCurrency(player.baseSalary)} → Match:{' '}
           {formatCurrency(player.matchingValue)}

--- a/src/features/architect/tradeMachine/TradeReceiptPanel.tsx
+++ b/src/features/architect/tradeMachine/TradeReceiptPanel.tsx
@@ -79,7 +79,7 @@ const PlayerListItem = ({ player, direction }: PlayerListItemProps) => {
               2W
             </span>
           )}
-          {direction === 'outgoing' && flags.isBYC && (
+          {!flags.isTwoWay && direction === 'outgoing' && flags.isBYC && (
             <span
               className="text-cockpit-watch ml-1"
               title={`BYC: Base ${formatCurrency(player.baseSalary)} → Match ${formatCurrency(player.matchingValue)} (max of prior, 50% new)`}
@@ -87,7 +87,7 @@ const PlayerListItem = ({ player, direction }: PlayerListItemProps) => {
               BYC
             </span>
           )}
-          {direction === 'incoming' && flags.isPoisonPill && (
+          {!flags.isTwoWay && direction === 'incoming' && flags.isPoisonPill && (
             <span
               className="text-cockpit-info ml-1"
               title={`Poison Pill: Base ${formatCurrency(player.baseSalary)} → Match ${formatCurrency(player.matchingValue)} (averaged salary)`}
@@ -95,7 +95,7 @@ const PlayerListItem = ({ player, direction }: PlayerListItemProps) => {
               PP
             </span>
           )}
-          {flags.hasTradeKicker && (
+          {!flags.isTwoWay && flags.hasTradeKicker && (
             <span
               className="text-cockpit-watch ml-1"
               title={

--- a/src/features/architect/tradeMachine/TradeTeamCard.helpers.ts
+++ b/src/features/architect/tradeMachine/TradeTeamCard.helpers.ts
@@ -61,6 +61,7 @@ export type TeamLike = Omit<HookTradeTeam, 'pickRulesById'> & {
   teamName?: string | null;
   abbreviation?: string | null;
   players?: HookTradePlayer[] | null;
+  twoWayPlayers?: HookTradePlayer[] | null;
   entitlements?: HookTradeEntitlement[] | null;
   pickRulesById?: Record<string, unknown>;
   capHolds?: unknown[] | null;

--- a/src/features/architect/tradeMachine/TradeTeamCard.tsx
+++ b/src/features/architect/tradeMachine/TradeTeamCard.tsx
@@ -13,6 +13,10 @@ import { TeamSelectDropdown } from '@/shared/components/TeamSelectDropdown';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { TradeExceptionManager } from './TradeExceptionManager';
 import { isFaExceptionEligibleType } from '@/features/architect/utils/faExceptionUtils';
+import {
+  isTwoWayTradePlayer,
+  TWO_WAY_TRADE_MATCHING_EXPLANATION,
+} from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 import { validationFlags } from '@/config/validationFlags';
 import { useTradeTeamCardSalaries } from './useTradeTeamCardSalaries';
 // Phase 65: Canonical TPE read accessor
@@ -32,6 +36,9 @@ import type {
   OutgoingPlayersListProps,
   TradeTeamCardProps,
 } from './TradeTeamCard.helpers';
+
+const formatTradeSectionSalary = (salary: number, hasPlayers: boolean) =>
+  hasPlayers && salary === 0 ? '$0' : formatSalary(salary);
 import {
   getPlayerKey,
   getPlayerLabel,
@@ -272,7 +279,7 @@ export const TradeTeamCard = ({
                     {hasValidatorResult ? 'Updating…' : 'Calculating…'}
                   </span>
                 ) : (
-                  formatSalary(outgoingSalary)
+                  formatTradeSectionSalary(outgoingSalary, sends.length > 0)
                 )}
                 {/* Phase 1: Visible indicator when using local estimate (Rule 2) */}
                 {/* P0-3: Hide estimate badge during validation - show loading instead */}
@@ -289,7 +296,7 @@ export const TradeTeamCard = ({
                 {!isValidating && hasOutgoingAdjustment && (
                   <span
                     className="px-1.5 py-0.5 text-[10px] bg-cockpit-info/20 text-cockpit-info rounded-md"
-                    title="Includes BYC, poison pill, or trade kicker adjustments"
+                    title="Includes player-specific trade matching adjustments"
                   >
                     Adjusted
                   </span>
@@ -316,8 +323,9 @@ export const TradeTeamCard = ({
                 // Phase 2.4: Check if this player has matching adjustment (BYC, poison pill, kicker)
                 const baseSalary = getSalaryForYear([p], yearKey);
                 const matchingValue = Number(p.matchOutgoing ?? baseSalary);
+                const isTwoWay = isTwoWayTradePlayer(p);
                 const hasPlayerAdjustment =
-                  Math.abs(matchingValue - baseSalary) > 1;
+                  isTwoWay || Math.abs(matchingValue - baseSalary) > 1;
 
                 // P1: Use shared utility for adjustment type detection
                 const adjustmentLabel = getAdjustmentTooltipLabel(
@@ -342,7 +350,7 @@ export const TradeTeamCard = ({
                         className="px-1 py-0.5 text-[10px] bg-cockpit-info/20 text-cockpit-info rounded-md leading-none"
                         title={tooltipText}
                       >
-                        Adj
+                        {isTwoWay ? '2W' : 'Adj'}
                       </span>
                     )}
                     {onUndoPlayerTrade && (
@@ -395,7 +403,10 @@ export const TradeTeamCard = ({
                     {hasValidatorResult ? 'Updating…' : 'Calculating…'}
                   </span>
                 ) : (
-                  formatSalary(incomingSalary)
+                  formatTradeSectionSalary(
+                    incomingSalary,
+                    incomingPlayers.length > 0
+                  )
                 )}
                 {/* Phase 1: Visible indicator when using local estimate (Rule 2) */}
                 {/* P0-3: Hide estimate badge during validation - show loading instead */}
@@ -412,7 +423,7 @@ export const TradeTeamCard = ({
                 {!isValidating && hasIncomingAdjustment && (
                   <span
                     className="px-1.5 py-0.5 text-[10px] bg-cockpit-info/20 text-cockpit-info rounded-md"
-                    title="Includes BYC, poison pill, or trade kicker adjustments"
+                    title="Includes player-specific trade matching adjustments"
                   >
                     Adjusted
                   </span>
@@ -439,8 +450,9 @@ export const TradeTeamCard = ({
                 // Phase 2.4: Check if this player has matching adjustment (BYC, poison pill, kicker)
                 const baseSalary = getSalaryForYear([p], yearKey);
                 const matchingValue = Number(p.matchIncoming ?? baseSalary);
+                const isTwoWay = isTwoWayTradePlayer(p);
                 const hasPlayerAdjustment =
-                  Math.abs(matchingValue - baseSalary) > 1;
+                  isTwoWay || Math.abs(matchingValue - baseSalary) > 1;
 
                 // P1: Use shared utility for adjustment type detection
                 const adjustmentLabel = getAdjustmentTooltipLabel(
@@ -465,7 +477,7 @@ export const TradeTeamCard = ({
                         className="px-1 py-0.5 text-[10px] bg-cockpit-info/20 text-cockpit-info rounded-md leading-none"
                         title={tooltipText}
                       >
-                        Adj
+                        {isTwoWay ? '2W' : 'Adj'}
                       </span>
                     )}
                     {onUndoPlayerTrade && (
@@ -745,11 +757,14 @@ export const TradeTeamCard = ({
           <div className="text-cockpit-text-primary">
             {incomingPlayers.map((p) => {
               // Auto-detect absorption mode: if no explicit mode set and player fits a TPE, default to TPE
+              const isTwoWay = isTwoWayTradePlayer(p);
               const isTpeEligible = tpeEligiblePlayers.some(
                 (ep) => (ep.player_id || ep.id) === (p.player_id || p.id)
               );
               const effectiveMode =
-                p.absorptionMode || (isTpeEligible ? 'TPE' : 'MATCH');
+                isTwoWay
+                  ? 'MATCH'
+                  : p.absorptionMode || (isTpeEligible ? 'TPE' : 'MATCH');
 
               return (
                 <div
@@ -762,6 +777,12 @@ export const TradeTeamCard = ({
                       <select
                         className="bg-cockpit-raised text-xs rounded-md px-1"
                         value={String(effectiveMode)}
+                        disabled={isTwoWay}
+                        title={
+                          isTwoWay
+                            ? TWO_WAY_TRADE_MATCHING_EXPLANATION
+                            : undefined
+                        }
                         onChange={(e) =>
                           onSetPlayerTrade &&
                           onSetPlayerTrade(
@@ -771,9 +792,13 @@ export const TradeTeamCard = ({
                           )
                         }
                       >
-                        <option value="MATCH">Matching</option>
-                        <option value="TPE">TPE</option>
-                        <option value="FA_EXCEPTION">FA Exception</option>
+                        <option value="MATCH">
+                          {isTwoWay ? 'No salary match (Two-Way)' : 'Matching'}
+                        </option>
+                        {!isTwoWay && <option value="TPE">TPE</option>}
+                        {!isTwoWay && (
+                          <option value="FA_EXCEPTION">FA Exception</option>
+                        )}
                       </select>
                       {/* TPE selector - show when TPE mode selected */}
                       {effectiveMode === 'TPE' && (

--- a/src/features/architect/tradeMachine/useTradeTeamCardSalaries.ts
+++ b/src/features/architect/tradeMachine/useTradeTeamCardSalaries.ts
@@ -137,9 +137,9 @@ export const useTradeTeamCardSalaries = ({
     : localIncomingBaseSalary;
 
   const hasOutgoingAdjustment =
-    hasValidatorResult && Math.abs(outgoingSalary - outgoingBaseSalary) > 1;
+    Math.abs(outgoingSalary - outgoingBaseSalary) > 1;
   const hasIncomingAdjustment =
-    hasValidatorResult && Math.abs(incomingSalary - incomingBaseSalary) > 1;
+    Math.abs(incomingSalary - incomingBaseSalary) > 1;
 
   if (hasValidatorResult) {
     warnOnTotalsDivergence(

--- a/src/features/architect/tradeMachine/useTradeTeamCardSalaries.ts
+++ b/src/features/architect/tradeMachine/useTradeTeamCardSalaries.ts
@@ -14,6 +14,7 @@ import { getCapSettingsForYear } from '@/features/architect/utils/tradeMachine/u
 import { getTeamSnapshot } from '@/features/architect/hooks/useTradeMachineSnapshot';
 import { toSeasonKey } from '@/features/architect/utils/seasonUtils';
 import { getTeamFaExceptionBuckets } from '@/features/architect/utils/faExceptionUtils';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 import {
   toPlayerTeamOption,
   toEntitlementTeamOption,
@@ -55,12 +56,30 @@ export const useTradeTeamCardSalaries = ({
   teamTradeExceptions,
   hasTeam,
 }: UseTradeTeamCardSalariesParams) => {
+  const teamTradePlayers = useMemo(() => {
+    const seenIds = new Set<string>();
+    return [...(team?.players ?? []), ...(team?.twoWayPlayers ?? [])].filter(
+      (player) => {
+        const playerId = player.player_id ?? player.id;
+        if (playerId == null) return true;
+
+        const key = String(playerId);
+        if (seenIds.has(key)) return false;
+        seenIds.add(key);
+        return true;
+      }
+    );
+  }, [team?.players, team?.twoWayPlayers]);
+
   const filteredIncomingPlayers = useMemo(
     () =>
       incomingPlayers.filter(
-        (p) => !team?.players?.some((tp) => tp.player_id === p.player_id)
+        (p) =>
+          !teamTradePlayers.some(
+            (tp) => (tp.player_id ?? tp.id) === (p.player_id ?? p.id)
+          )
       ),
-    [incomingPlayers, team?.players]
+    [incomingPlayers, teamTradePlayers]
   );
 
   const teamTotalSalary = useMemo(() => {
@@ -77,12 +96,28 @@ export const useTradeTeamCardSalaries = ({
   const snapshot = getTeamSnapshot(selectedTeamId, validationResult);
   const hasValidatorResult = snapshot !== null;
 
-  const localOutgoingSalary = useMemo(
+  const localOutgoingBaseSalary = useMemo(
     () => getSalaryForYear(sends, yearKey),
     [sends, yearKey]
   );
-  const localIncomingSalary = useMemo(
+  const localIncomingBaseSalary = useMemo(
     () => getSalaryForYear(incomingPlayers, yearKey),
+    [incomingPlayers, yearKey]
+  );
+  const localOutgoingSalary = useMemo(
+    () =>
+      getSalaryForYear(
+        sends.filter((player) => !isTwoWayTradePlayer(player)),
+        yearKey
+      ),
+    [sends, yearKey]
+  );
+  const localIncomingSalary = useMemo(
+    () =>
+      getSalaryForYear(
+        incomingPlayers.filter((player) => !isTwoWayTradePlayer(player)),
+        yearKey
+      ),
     [incomingPlayers, yearKey]
   );
 
@@ -96,10 +131,10 @@ export const useTradeTeamCardSalaries = ({
 
   const outgoingBaseSalary = hasValidatorResult
     ? snapshot.outgoingBaseSalary
-    : localOutgoingSalary;
+    : localOutgoingBaseSalary;
   const incomingBaseSalary = hasValidatorResult
     ? snapshot.incomingBaseSalary
-    : localIncomingSalary;
+    : localIncomingBaseSalary;
 
   const hasOutgoingAdjustment =
     hasValidatorResult && Math.abs(outgoingSalary - outgoingBaseSalary) > 1;
@@ -132,12 +167,12 @@ export const useTradeTeamCardSalaries = ({
   );
 
   const playersCount = useMemo(
-    () => (team?.players?.length || 0) - sends.length + incomingPlayers.length,
-    [team, sends, incomingPlayers]
+    () => teamTradePlayers.length - sends.length + incomingPlayers.length,
+    [teamTradePlayers, sends, incomingPlayers]
   );
   const outgoingPlayersTeam = useMemo(
-    () => ({ players: team?.players ?? [] }),
-    [team?.players]
+    () => ({ players: teamTradePlayers }),
+    [teamTradePlayers]
   );
   const playerOtherTeams = useMemo(
     () => otherTeams.map(toPlayerTeamOption),
@@ -238,6 +273,8 @@ export const useTradeTeamCardSalaries = ({
         ? yearKey
         : toSeasonKey(yearKey);
     return incomingPlayers.filter((player) => {
+      if (isTwoWayTradePlayer(player)) return false;
+
       const playerSalary =
         getCapHitForSeason(player as UnknownRecord, seasonKey) || 0;
       return (teamTradeExceptions || []).some(

--- a/src/features/architect/utils/tradeHelpers.ts
+++ b/src/features/architect/utils/tradeHelpers.ts
@@ -13,6 +13,10 @@ import { areSamePickById } from '@/features/architect/utils/tradeMachine/utils/p
 import { toEndYear } from './seasonFormat';
 import { getTeamApronStatus as getTeamApronStatusSSoT } from '@/features/architect/utils/capUtils';
 import type { TradeExceptionRecord } from '@/features/architect/utils/tradeMachine/constants/types';
+import {
+  isTwoWayTradePlayer,
+  TWO_WAY_TRADE_MATCHING_LABEL,
+} from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 
 type NumericLike = number | string | null | undefined;
 type UnknownRecord = Record<string, unknown>;
@@ -56,11 +60,16 @@ interface SalariesByYearEntry extends UnknownRecord {
 }
 
 interface TradeHelperContract extends UnknownRecord {
+  contractType?: string | null;
+  isTwoWay?: boolean;
   salariesByYear?: SalariesByYearEntry[];
 }
 
 interface TradeHelperPlayer extends UnknownRecord {
   contract?: TradeHelperContract | null;
+  primaryContract?: TradeHelperContract | null;
+  contractType?: string | null;
+  isTwoWay?: boolean;
   salary?: NumericLike;
   bonusesByYear?: Record<string, { likely?: NumericLike } | undefined>;
   isBYC?: boolean;
@@ -524,6 +533,10 @@ export const generateTradeId = (teams: TradeTeamEntry[]): string =>
 
 export const getPlayerAdjustmentTypes = (player: TradeHelperPlayer): string[] => {
   if (!player) return [];
+
+  if (isTwoWayTradePlayer(player)) {
+    return [TWO_WAY_TRADE_MATCHING_LABEL];
+  }
 
   const adjustmentTypes: string[] = [];
 

--- a/src/features/architect/utils/tradeMachine/constants/types.ts
+++ b/src/features/architect/utils/tradeMachine/constants/types.ts
@@ -135,6 +135,8 @@ export interface TradeExceptionPlayer {
   // Contract
   contract?: Record<string, unknown>;
   contracts?: Record<string, unknown>;
+  primaryContract?: Record<string, unknown>;
+  contractType?: string | null;
   yearsOfService?: number;
   draftPick?: unknown;
   isMinimum?: boolean;
@@ -747,6 +749,7 @@ export interface TradeReceiptPlayerFlags {
   hasTradeKicker: boolean;
   tradeKickerPct: number;
   isSignAndTrade: boolean;
+  isTwoWay: boolean;
 }
 
 export interface TradeReceiptBycDetails {

--- a/src/features/architect/utils/tradeMachine/engine/tradeValidator.helpers.ts
+++ b/src/features/architect/utils/tradeMachine/engine/tradeValidator.helpers.ts
@@ -5,7 +5,7 @@
 
 import { resolvePlayerDestinationTeamId } from './tradeValidator.ruleEnvelopes';
 import { checkRosterCounts } from '../rules/validateRoster';
-import { isTwoWayContract } from '@/features/architect/utils/contractUtils';
+import { isTwoWayTradePlayer } from '../utils/twoWayTradeSalary';
 import type {
   TradeValidatorPlayer,
   TradeValidatorTeamSlot,
@@ -21,15 +21,7 @@ import type {
 export function isTwoWayPlayer(
   player: TradeValidatorPlayer | null | undefined
 ): boolean {
-  if (!player) return false;
-  if (player.isTwoWay === true) return true;
-  // TradeValidatorPlayer carries contractType at runtime but its type doesn't
-  // structurally overlap ContractUtilsPlayer, and isTwoWayContract only reads
-  // the contract-type marker (null-safe). Widening that shared signature ripples
-  // through 10+ callers (weak-type incompatibilities), so bridge here instead.
-  return isTwoWayContract(
-    player as unknown as Parameters<typeof isTwoWayContract>[0]
-  );
+  return isTwoWayTradePlayer(player);
 }
 
 export function shouldRoutePlayerToTeam({

--- a/src/features/architect/utils/tradeMachine/engine/tradeValidator.helpers.ts
+++ b/src/features/architect/utils/tradeMachine/engine/tradeValidator.helpers.ts
@@ -5,7 +5,7 @@
 
 import { resolvePlayerDestinationTeamId } from './tradeValidator.ruleEnvelopes';
 import { checkRosterCounts } from '../rules/validateRoster';
-import { isTwoWayTradePlayer } from '../utils/twoWayTradeSalary';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 import type {
   TradeValidatorPlayer,
   TradeValidatorTeamSlot,

--- a/src/features/architect/utils/tradeMachine/engine/tradeValidator.receipt.ts
+++ b/src/features/architect/utils/tradeMachine/engine/tradeValidator.receipt.ts
@@ -12,6 +12,7 @@ import {
 import { SALARY_MATCHING_VERSION } from '../rules/validateSalaryMatching';
 import { decorateEntitlementForTrade } from '@/features/architect/utils/entitlements/entitlementTerms';
 import { getSalaryForYear } from '@/features/architect/utils/tradeHelpers';
+import { isTwoWayTradePlayer } from '../utils/twoWayTradeSalary';
 import {
   normalizeTeamCodeLike,
   readSalaryMatchingRuleEnvelope,
@@ -159,7 +160,7 @@ export function generateTradeReceipt({
     const outgoingPlayers = (team.outgoingPlayers || team.sends || []).map(
       (player: TradeValidatorPlayer) => {
         const baseSalary = getSalaryForYear(player, context.currentYear) || 0;
-        const matchingValue = player.matchOutgoing || baseSalary;
+        const matchingValue = player.matchOutgoing ?? baseSalary;
         const isBYC = !!player.isBYC || !!player.baseYearCompensation;
         const bycMethod: 'previousSalary' | '50%_of_new' =
           (player.previousSalary || 0) >= Math.floor(baseSalary * 0.5)
@@ -180,6 +181,7 @@ export function generateTradeReceipt({
             tradeKickerPct:
               player.tradeKicker?.percentage || player.tradeKickerPct || 0,
             isSignAndTrade: !!player.signAndTrade,
+            isTwoWay: isTwoWayTradePlayer(player),
           },
           // BYC breakdown: include previous salary and calculation details
           bycDetails: isBYC
@@ -197,7 +199,7 @@ export function generateTradeReceipt({
     const incomingPlayers = (team.incomingPlayers || []).map(
       (player: TradeValidatorPlayer) => {
       const baseSalary = getSalaryForYear(player, context.currentYear) || 0;
-      const matchingValue = player.matchIncoming || baseSalary;
+      const matchingValue = player.matchIncoming ?? baseSalary;
       const isPoisonPill = !!player.isPoisonPill;
       const hasTradeKicker = !!(
         player.tradeKicker?.percentage || player.tradeKickerPct
@@ -216,6 +218,7 @@ export function generateTradeReceipt({
           tradeKickerPct:
             player.tradeKicker?.percentage || player.tradeKickerPct || 0,
           isSignAndTrade: !!player.signAndTrade,
+          isTwoWay: isTwoWayTradePlayer(player),
         },
         // Poison pill breakdown: include extension years and averaging calculation
         poisonPillDetails:

--- a/src/features/architect/utils/tradeMachine/rules/validateEligibility.ts
+++ b/src/features/architect/utils/tradeMachine/rules/validateEligibility.ts
@@ -2,78 +2,21 @@ import { validationFlags } from '@/config/validationFlags';
 import {
   EligibilityValidationResult,
   TeamContext,
-  TradeExceptionPlayer,
   TradeTeam,
-  ValidationIssue,
 } from '../constants/types';
 import { summarizeValidationIssues } from '../utils/validationIssueText';
 import { collectEligibilityReacquisitionIssues } from './validateReacquisition';
-
-interface EligibilityPlayer extends TradeExceptionPlayer {
-  isTwoWay?: boolean;
-  contractType?: string;
-  contract?: {
-    contractType?: string;
-    isTwoWay?: boolean;
-    [key: string]: unknown;
-  };
-}
 
 interface EnforcementCallbacks {
   warn?: (message: string) => void;
   reject?: (message: string) => void;
 }
 
-function createIssue(
-  message: string,
-  code: string,
-  details: string | null = null,
-  meta: Record<string, unknown> | null = null
-): ValidationIssue {
-  return {
-    message,
-    severity: 'error',
-    rule: 'eligibility',
-    code,
-    details,
-    meta,
-  };
-}
-
-function isTwoWayPlayer(player: EligibilityPlayer | null | undefined): boolean {
-  if (!player) return false;
-  if (player.isTwoWay === true) return true;
-  if (player.contractType?.toLowerCase() === 'two-way') return true;
-  if (player.contract?.contractType?.toLowerCase() === 'two-way') return true;
-  if (player.contract?.isTwoWay === true) return true;
-  return false;
-}
-
 export function validateEligibility(
   team: TradeTeam,
   tradeCtx: TeamContext = {}
 ): EligibilityValidationResult {
-  const violations: ValidationIssue[] = [];
-  const outgoingPlayers = Array.isArray(team.sends)
-    ? (team.sends as EligibilityPlayer[])
-    : Array.isArray(team.outgoingPlayers)
-      ? (team.outgoingPlayers as EligibilityPlayer[])
-      : [];
-
-  outgoingPlayers.forEach((player) => {
-    if (isTwoWayPlayer(player)) {
-      violations.push(
-        createIssue(
-          `Two-way contract: ${player.name || 'Player'} cannot be traded. Two-way players must be waived, not traded.`,
-          'ELIGIBILITY__TWO_WAY_PLAYER_BLOCKED',
-          null,
-          { playerName: player.name || 'Player' }
-        )
-      );
-    }
-  });
-
-  violations.push(...collectEligibilityReacquisitionIssues(team, tradeCtx));
+  const violations = collectEligibilityReacquisitionIssues(team, tradeCtx);
 
   return {
     passed: violations.length === 0,

--- a/src/features/architect/utils/tradeMachine/rules/validateFaExceptionUsage.ts
+++ b/src/features/architect/utils/tradeMachine/rules/validateFaExceptionUsage.ts
@@ -104,7 +104,10 @@ export function validateFaExceptionUsage(
     } else {
       // Check for outgoing salary (both salaryOut and outgoingPlayers)
       const hasOutgoingSalary =
-        Number(team.salaryOut || 0) > 0 || (team.outgoingPlayers || []).length > 0;
+        Number(team.salaryOut || 0) > 0 ||
+        (team.outgoingPlayers || []).some(
+          (player) => !isTwoWayTradePlayer(player)
+        );
 
       // Auto-select FA exception for eligible players (if no absorptionMode is set)
       faExceptionEligiblePlayers.forEach((player) => {

--- a/src/features/architect/utils/tradeMachine/rules/validateFaExceptionUsage.ts
+++ b/src/features/architect/utils/tradeMachine/rules/validateFaExceptionUsage.ts
@@ -1,5 +1,6 @@
 import { getApronStatus, getSalaryForYear } from '../../tradeHelpers';
 import { getTeamFaExceptionBuckets } from '../../faExceptionUtils';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 
 type NumericLike = number | string | null | undefined;
 
@@ -13,6 +14,10 @@ type FaExceptionIncomingPlayer = {
   bucketType?: unknown;
   matchIncoming?: NumericLike;
   salary?: NumericLike;
+  contractType?: string | null;
+  isTwoWay?: boolean;
+  contract?: Record<string, unknown> | null;
+  primaryContract?: Record<string, unknown> | null;
 };
 
 type FaExceptionTeamData = {
@@ -55,6 +60,9 @@ export function validateFaExceptionUsage(
   const context = rawContext || {};
   const capSettings = context.capSettings || {};
   const incomingPlayers = rawIncomingPlayers || [];
+  const faExceptionEligiblePlayers = incomingPlayers.filter(
+    (player) => !isTwoWayTradePlayer(player)
+  );
   const resolveIncomingTradeSalary = (player: FaExceptionIncomingPlayer) =>
     Number(
       player?.matchIncoming ??
@@ -71,7 +79,7 @@ export function validateFaExceptionUsage(
   // Check if team is above first apron (cannot use FA exceptions)
   const apronStatus = getApronStatus(Number(teamTotalSalary || 0), capSettings);
   if (apronStatus.includes('1st Apron') || apronStatus.includes('2nd Apron')) {
-    const hasUsage = incomingPlayers.some(
+    const hasUsage = faExceptionEligiblePlayers.some(
       (player) => player.absorptionMode === 'FA_EXCEPTION'
     );
     if (hasUsage) {
@@ -85,7 +93,7 @@ export function validateFaExceptionUsage(
     // Check post-trade salary doesn't exceed first apron
     const projectedSalary = Number(team.projectedSalary || teamTotalSalary);
     if (projectedSalary >= Number(capSettings.firstApron || 0)) {
-      const hasUsage = incomingPlayers.some(
+      const hasUsage = faExceptionEligiblePlayers.some(
         (player) => player.absorptionMode === 'FA_EXCEPTION'
       );
       if (hasUsage) {
@@ -99,7 +107,7 @@ export function validateFaExceptionUsage(
         Number(team.salaryOut || 0) > 0 || (team.outgoingPlayers || []).length > 0;
 
       // Auto-select FA exception for eligible players (if no absorptionMode is set)
-      incomingPlayers.forEach((player) => {
+      faExceptionEligiblePlayers.forEach((player) => {
         if (
           !player.absorptionMode &&
           buckets.length > 0 &&
@@ -118,7 +126,7 @@ export function validateFaExceptionUsage(
       });
 
       // Check each incoming player using FA Exception
-      incomingPlayers.forEach((player) => {
+      faExceptionEligiblePlayers.forEach((player) => {
         if (player.absorptionMode === 'FA_EXCEPTION') {
           // Check for aggregation with outgoing salary
           if (hasOutgoingSalary) {

--- a/src/features/architect/utils/tradeMachine/rules/validateSalaryMatching.ts
+++ b/src/features/architect/utils/tradeMachine/rules/validateSalaryMatching.ts
@@ -22,6 +22,7 @@ import { getHardCapStatus } from '@/features/architect/utils/tradeMachine/utils/
 import { SECOND_APRON_SALARY_MISMATCH } from '@/features/architect/utils/tradeMachine/constants/secondApronMessages';
 import { getTeamTpeList } from '@/features/architect/utils/persistenceContracts';
 import { isSecondApronTeam } from '../utils/capUtils';
+import { isTwoWayTradePlayer } from '../utils/twoWayTradeSalary';
 import type {
   AuthoritativeSalaryMatchingResult,
   TeamContext,
@@ -276,7 +277,9 @@ export function validateSalaryMatching(
     );
 
   const hasTPEPlayers = incomingPlayers.some(
-    (player) => player.absorptionMode === 'TPE' || !!player.tpeId
+    (player) =>
+      !isTwoWayTradePlayer(player) &&
+      (player.absorptionMode === 'TPE' || !!player.tpeId)
   );
 
   const appliedTPEs = Array.isArray(team.appliedTPEs) ? team.appliedTPEs : [];
@@ -304,7 +307,9 @@ export function validateSalaryMatching(
     const tpeViolations: string[] = [];
 
     incomingPlayers.forEach((player) => {
-      const playerSalary = toFiniteNumber(player.salary || player.matchIncoming || 0);
+      if (isTwoWayTradePlayer(player)) return;
+
+      const playerSalary = toFiniteNumber(resolveIncomingTradeSalary(player));
       const isTpeAbsorbed = player.absorptionMode === 'TPE' || !!player.tpeId;
 
       if (!isTpeAbsorbed) return;

--- a/src/features/architect/utils/tradeMachine/rules/validateSalaryMatching.ts
+++ b/src/features/architect/utils/tradeMachine/rules/validateSalaryMatching.ts
@@ -21,8 +21,8 @@ import {
 import { getHardCapStatus } from '@/features/architect/utils/tradeMachine/utils/hardCapStatus';
 import { SECOND_APRON_SALARY_MISMATCH } from '@/features/architect/utils/tradeMachine/constants/secondApronMessages';
 import { getTeamTpeList } from '@/features/architect/utils/persistenceContracts';
-import { isSecondApronTeam } from '../utils/capUtils';
-import { isTwoWayTradePlayer } from '../utils/twoWayTradeSalary';
+import { isSecondApronTeam } from '@/features/architect/utils/tradeMachine/utils/capUtils';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 import type {
   AuthoritativeSalaryMatchingResult,
   TeamContext,
@@ -233,8 +233,16 @@ export function validateSalaryMatching(
   let allowableIncoming = 0;
   let ruleApplied = '';
   let formulaUsed = '';
+  const incomingPlayers = getIncomingPlayers(team);
+  const hasFaExceptionEligibleIncoming =
+    incomingPlayers.length === 0 ||
+    incomingPlayers.some((player) => !isTwoWayTradePlayer(player));
 
-  if (team.absorptionMode === 'FA_EXCEPTION' && team.bucketType) {
+  if (
+    team.absorptionMode === 'FA_EXCEPTION' &&
+    team.bucketType &&
+    hasFaExceptionEligibleIncoming
+  ) {
     const buckets = Array.isArray(team.team?.faExceptionBuckets)
       ? team.team.faExceptionBuckets
       : [];
@@ -267,7 +275,6 @@ export function validateSalaryMatching(
     };
   }
 
-  const incomingPlayers = getIncomingPlayers(team);
   const resolveIncomingTradeSalary = (player: SalaryMatchingPlayer): number =>
     Number(
       player?.matchIncoming ??
@@ -407,7 +414,9 @@ export function validateSalaryMatching(
 
   const faExceptionValidation = team.faExceptionValidation || null;
   const faExceptionPlayers = incomingPlayers.filter(
-    (player) => player.absorptionMode === 'FA_EXCEPTION'
+    (player) =>
+      !isTwoWayTradePlayer(player) &&
+      player.absorptionMode === 'FA_EXCEPTION'
   );
   const faExceptionAbsorbedSalary =
     faExceptionValidation?.passed === true

--- a/src/features/architect/utils/tradeMachine/utils/matchingValues.ts
+++ b/src/features/architect/utils/tradeMachine/utils/matchingValues.ts
@@ -11,6 +11,7 @@ import {
   type DataWarning,
 } from './dataValidation';
 import { getSignAndTradeSalaryForYear } from '@/features/architect/utils/tradeMachine/signAndTrade/signAndTradeEligibility';
+import { isTwoWayTradePlayer } from './twoWayTradeSalary';
 
 type YearKey = number | string;
 
@@ -30,6 +31,8 @@ interface MatchingValueExtension {
 
 interface MatchingValueContractLike {
   isRookieScale?: boolean;
+  isTwoWay?: boolean;
+  contractType?: string | null;
   salariesByYear?: Array<Record<string, unknown>>;
 }
 
@@ -48,6 +51,8 @@ interface MatchingValuePlayer {
   } | null;
   contract?: MatchingValueContractLike | null;
   primaryContract?: MatchingValueContractLike | null;
+  isTwoWay?: boolean;
+  contractType?: string | null;
   signAndTrade?: boolean;
   salary?: number | null;
   newSalary?: number | null;
@@ -132,6 +137,10 @@ export function getMatchingValue(
   yearKey: YearKey,
   isOutgoing = false
 ): number {
+  if (isTwoWayTradePlayer(player)) {
+    return 0;
+  }
+
   const salary = getSalaryForYear(player, yearKey);
 
   // For outgoing BYC players, use max(prior, 50% new salary)
@@ -225,6 +234,12 @@ export function computeMatchingValues({
     (team.sends || []).forEach((player) => {
       const { salary: baseSalary, source: salarySource } =
         getEffectiveTradeSalaryForPlayer(player, yearKey);
+
+      if (isTwoWayTradePlayer(player)) {
+        player.matchOutgoing = 0;
+        player.matchIncoming = 0;
+        return;
+      }
 
       if (
         salarySource === 'player.newSalary' ||

--- a/src/features/architect/utils/tradeMachine/utils/matchingValues.ts
+++ b/src/features/architect/utils/tradeMachine/utils/matchingValues.ts
@@ -11,7 +11,7 @@ import {
   type DataWarning,
 } from './dataValidation';
 import { getSignAndTradeSalaryForYear } from '@/features/architect/utils/tradeMachine/signAndTrade/signAndTradeEligibility';
-import { isTwoWayTradePlayer } from './twoWayTradeSalary';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 
 type YearKey = number | string;
 

--- a/src/features/architect/utils/tradeMachine/utils/salaryMargin.ts
+++ b/src/features/architect/utils/tradeMachine/utils/salaryMargin.ts
@@ -136,13 +136,13 @@ export function getAllowableIncomingMargin(
     .filter((player) => player.absorptionMode === 'TPE')
     .reduce(
       (sum, player) =>
-        sum + toNum(player.matchIncoming || player.tpeAmount || 0),
+        sum + toNum(player.matchIncoming ?? player.tpeAmount ?? 0),
       0
     );
 
   const faUsage = incomingPlayers
     .filter((player) => player.absorptionMode === 'FA_EXCEPTION')
-    .reduce((sum, player) => sum + toNum(player.matchIncoming || 0), 0);
+    .reduce((sum, player) => sum + toNum(player.matchIncoming ?? 0), 0);
 
   const margin = baseNoTPE + usedTPE + faUsage;
 

--- a/src/features/architect/utils/tradeMachine/utils/salaryMargin.ts
+++ b/src/features/architect/utils/tradeMachine/utils/salaryMargin.ts
@@ -10,6 +10,7 @@ import {
   resolvePayroll,
   toNum,
 } from './capUtils';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 
 type NumericLike = number | string | null | undefined;
 
@@ -133,7 +134,10 @@ export function getAllowableIncomingMargin(
 
   // Add only actually USED buckets
   const usedTPE = incomingPlayers
-    .filter((player) => player.absorptionMode === 'TPE')
+    .filter(
+      (player) =>
+        !isTwoWayTradePlayer(player) && player.absorptionMode === 'TPE'
+    )
     .reduce(
       (sum, player) =>
         sum + toNum(player.matchIncoming ?? player.tpeAmount ?? 0),
@@ -141,7 +145,11 @@ export function getAllowableIncomingMargin(
     );
 
   const faUsage = incomingPlayers
-    .filter((player) => player.absorptionMode === 'FA_EXCEPTION')
+    .filter(
+      (player) =>
+        !isTwoWayTradePlayer(player) &&
+        player.absorptionMode === 'FA_EXCEPTION'
+    )
     .reduce((sum, player) => sum + toNum(player.matchIncoming ?? 0), 0);
 
   const margin = baseNoTPE + usedTPE + faUsage;

--- a/src/features/architect/utils/tradeMachine/utils/tpeValidation.ts
+++ b/src/features/architect/utils/tradeMachine/utils/tpeValidation.ts
@@ -8,6 +8,7 @@ import {
   TradeTeam,
   UnresolvedTpeUsage,
 } from '../constants/types';
+import { isTwoWayTradePlayer } from './twoWayTradeSalary';
 
 export const SECOND_APRON_TPE_BLOCK =
   'Second apron team cannot use trade exceptions';
@@ -175,7 +176,9 @@ export function buildCanonicalTeamTpeUsage({
   teamHeldTpes.forEach(addTpe);
 
   const tpeAttemptPlayers = (incomingPlayers || []).filter(
-    (player) => player?.absorptionMode === 'TPE' || Boolean(player?.tpeId)
+    (player) =>
+      !isTwoWayTradePlayer(player) &&
+      (player?.absorptionMode === 'TPE' || Boolean(player?.tpeId))
   );
   const usageMap = new Map<string, CanonicalTeamTpeUsageEntry>();
   const unresolvedPlayers: UnresolvedTpeUsage[] = [];
@@ -206,7 +209,14 @@ export function buildCanonicalTeamTpeUsage({
     usageMap.set(tpeId, existingUsage);
   });
 
+  const hasEligibleIncomingPlayer = (incomingPlayers || []).some(
+    (player) => !isTwoWayTradePlayer(player)
+  );
+  const shouldApplyCompatibilityUsage =
+    (incomingPlayers || []).length === 0 || hasEligibleIncomingPlayer;
+
   compatibilityTpes.forEach((rawTpe) => {
+    if (!shouldApplyCompatibilityUsage) return;
     const normalizedTpe = normalizeTpeForValidation(rawTpe);
     if (!normalizedTpe?.id || usageMap.has(normalizedTpe.id)) return;
 

--- a/src/features/architect/utils/tradeMachine/utils/tradeExceptionLifecycle.ts
+++ b/src/features/architect/utils/tradeMachine/utils/tradeExceptionLifecycle.ts
@@ -3,7 +3,7 @@ import {
   createTpeCreationHistoryEntry,
 } from '@/features/architect/utils/exceptionHistory/historyHelpers';
 import type { TradeExceptionRecord } from '@/features/architect/utils/tradeMachine/constants/types';
-import { isTwoWayTradePlayer } from './twoWayTradeSalary';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 
 type TradeExceptionLifecycleIncomingPlayer = {
   player_id?: string | null;

--- a/src/features/architect/utils/tradeMachine/utils/tradeExceptionLifecycle.ts
+++ b/src/features/architect/utils/tradeMachine/utils/tradeExceptionLifecycle.ts
@@ -3,6 +3,7 @@ import {
   createTpeCreationHistoryEntry,
 } from '@/features/architect/utils/exceptionHistory/historyHelpers';
 import type { TradeExceptionRecord } from '@/features/architect/utils/tradeMachine/constants/types';
+import { isTwoWayTradePlayer } from './twoWayTradeSalary';
 
 type TradeExceptionLifecycleIncomingPlayer = {
   player_id?: string | null;
@@ -14,11 +15,19 @@ type TradeExceptionLifecycleIncomingPlayer = {
   absorptionMode?: string | null;
   tpeId?: string | null;
   matchIncoming?: number | null;
+  isTwoWay?: boolean | null;
+  contractType?: string | null;
+  contract?: Record<string, unknown> | null;
+  primaryContract?: Record<string, unknown> | null;
 };
 
 type TradeExceptionLifecycleOutgoingPlayer = {
   name?: string | null;
   displayName?: string | null;
+  isTwoWay?: boolean | null;
+  contractType?: string | null;
+  contract?: Record<string, unknown> | null;
+  primaryContract?: Record<string, unknown> | null;
 };
 
 export type TradeExceptionLifecycleIssue = {
@@ -108,8 +117,11 @@ function buildTpeConsumptionState({
   const warnings: TradeExceptionLifecycleIssue[] = [];
   const blockingIssues: TradeExceptionLifecycleIssue[] = [];
   const absorptionDetails = new Map<string, TradeAbsorbedPlayer[]>();
+  const tpeEligibleIncomingPlayers = incomingPlayers.filter(
+    (player) => !isTwoWayTradePlayer(player)
+  );
 
-  incomingPlayers.forEach((player) => {
+  tpeEligibleIncomingPlayers.forEach((player) => {
     if (player.absorptionMode === 'TPE') {
       const playerLabel = player.name || player.player_id || 'unknown';
       if (!player.tpeId) {
@@ -140,7 +152,7 @@ function buildTpeConsumptionState({
     };
   }
 
-  incomingPlayers.forEach((player) => {
+  tpeEligibleIncomingPlayers.forEach((player) => {
     if (!player.tpeId) return;
 
     if (player.matchIncoming === undefined || player.matchIncoming === null) {
@@ -284,7 +296,11 @@ function applyCreatedTpe({
   updatedTradeExceptions: TradeExceptionRecord[];
   creationHistoryEntry: TradeExceptionHistoryEntry | null;
 } {
-  if (!createdTPE) {
+  const tpeEligibleOutgoingPlayers = outgoingPlayers.filter(
+    (player) => !isTwoWayTradePlayer(player)
+  );
+
+  if (!createdTPE || tpeEligibleOutgoingPlayers.length === 0) {
     return {
       updatedTradeExceptions,
       creationHistoryEntry: null,
@@ -295,7 +311,7 @@ function applyCreatedTpe({
   const tpeId =
     (typeof createdTPE.id === 'string' && createdTPE.id) ||
     `tpe_${teamCode}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-  const createdFrom = buildCreatedFrom(outgoingPlayers);
+  const createdFrom = buildCreatedFrom(tpeEligibleOutgoingPlayers);
   const newTpeSignature = [
     createdTPE.createdSeason,
     createdTPE.expiresOn,

--- a/src/features/architect/utils/tradeMachine/utils/twoWayTradeSalary.ts
+++ b/src/features/architect/utils/tradeMachine/utils/twoWayTradeSalary.ts
@@ -1,0 +1,43 @@
+type ContractTypeCarrier = {
+  contractType?: unknown;
+  isTwoWay?: unknown;
+};
+
+export type TwoWayTradePlayerLike = ContractTypeCarrier & {
+  contract?: ContractTypeCarrier | null;
+  primaryContract?: ContractTypeCarrier | null;
+};
+
+function isTwoWayContractType(value: unknown): boolean {
+  return (
+    typeof value === 'string' &&
+    value.trim().toLowerCase().replace(/[_\s]+/g, '-') === 'two-way'
+  );
+}
+
+/**
+ * Resolves the explicit Two-Way markers carried by Trade Machine player data.
+ * This is deliberately source-independent: callers must not infer contract type
+ * from salary, roster placement, or another player's record.
+ */
+export function isTwoWayTradePlayer(
+  player: unknown
+): boolean {
+  if (!player || typeof player !== 'object') return false;
+
+  const candidate = player as TwoWayTradePlayerLike;
+
+  return (
+    candidate.isTwoWay === true ||
+    candidate.contract?.isTwoWay === true ||
+    candidate.primaryContract?.isTwoWay === true ||
+    isTwoWayContractType(candidate.contractType) ||
+    isTwoWayContractType(candidate.contract?.contractType) ||
+    isTwoWayContractType(candidate.primaryContract?.contractType)
+  );
+}
+
+export const TWO_WAY_TRADE_MATCHING_LABEL = 'Two-Way salary exclusion';
+
+export const TWO_WAY_TRADE_MATCHING_EXPLANATION =
+  'Two-Way contracts do not count toward trade salary matching and cannot create or use a trade exception.';

--- a/src/features/architect/utils/tradeMachine/utils/twoWayTradeSalary.ts
+++ b/src/features/architect/utils/tradeMachine/utils/twoWayTradeSalary.ts
@@ -11,7 +11,7 @@ export type TwoWayTradePlayerLike = ContractTypeCarrier & {
 function isTwoWayContractType(value: unknown): boolean {
   return (
     typeof value === 'string' &&
-    value.trim().toLowerCase().replace(/[_\s]+/g, '-') === 'two-way'
+    value.trim().toLowerCase().replace(/[-_\s]+/g, '') === 'twoway'
   );
 }
 

--- a/src/tests/architect/batchB_cbaRules.test.ts
+++ b/src/tests/architect/batchB_cbaRules.test.ts
@@ -8,16 +8,12 @@
  *
  * Coverage:
  * - GAP-MISS-003: Incomplete roster charges verification
- * - GAP-MISS-005: Two-way contract trade blocking
+ * - CBA2-A02.14: Two-Way contracts are not blanket-blocked from trades
  */
 import { describe, it, expect } from 'vitest';
 import { validateEligibility } from '@/features/architect/utils/tradeMachine/rules/validateEligibility';
 import { computeTeamCapTotals } from '@/features/architect/utils/capTotals/computeTeamCapTotals';
-import { getValidationIssueText } from '@/features/architect/utils/tradeMachine/utils/validationIssueText';
-import type {
-  TradeExceptionPlayer,
-  ValidationIssue,
-} from '@/features/architect/utils/tradeMachine/constants/types';
+import type { TradeExceptionPlayer } from '@/features/architect/utils/tradeMachine/constants/types';
 
 const currentYear = 2025;
 const season = `${currentYear - 1}-${String(currentYear).slice(-2)}`;
@@ -44,9 +40,6 @@ const makePlayer = (
   contract: { salariesByYear: [{ season, salary, capHit: salary }] },
   ...extras,
 });
-
-const issueTexts = (issues: ValidationIssue[] = []) =>
-  issues.map((issue) => getValidationIssueText(issue));
 
 function requireIncompleteRosterCharge(
   totals: ReturnType<typeof computeTeamCapTotals>
@@ -140,177 +133,48 @@ describe('GAP-MISS-003: Incomplete Roster Charges (VERIFIED ALREADY IMPLEMENTED)
   });
 });
 
-describe('GAP-MISS-005: Two-Way Contract Trade Block', () => {
-  describe('validateEligibility blocks two-way player trades', () => {
-    it('blocks trade when player has isTwoWay=true', () => {
-      const twoWayPlayer = makePlayer('Two-Way Guy', 500_000, {
-        isTwoWay: true,
-      });
-
-      const team = {
-        teamId: 'BOS',
-        sends: [twoWayPlayer],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      expect(result.passed).toBe(false);
-      expect(result.violations.length).toBeGreaterThan(0);
-      expect(result.violations[0]).toMatchObject({
-        rule: 'eligibility',
-        code: 'ELIGIBILITY__TWO_WAY_PLAYER_BLOCKED',
-      });
-      expect(
-        texts.some(
-          (v) => v.includes('Two-way') && v.includes('cannot be traded')
-        )
-      ).toBe(true);
-    });
-
-    it('blocks trade when player has contractType="two-way"', () => {
-      const twoWayPlayer = makePlayer('Two-Way Guy', 500_000, {
-        contractType: 'two-way',
-      });
-
-      const team = {
-        teamId: 'BOS',
-        sends: [twoWayPlayer],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      expect(result.passed).toBe(false);
-      expect(
-        texts.some(
-          (v) => v.includes('Two-way') && v.includes('cannot be traded')
-        )
-      ).toBe(true);
-    });
-
-    it('blocks trade when contract.isTwoWay=true', () => {
-      const twoWayPlayer = {
-        name: 'Two-Way Guy',
+describe('CBA2-A02.14: Two-Way Trade Eligibility', () => {
+  it.each([
+    ['top-level flag', { isTwoWay: true }],
+    ['top-level contract type', { contractType: 'two-way' }],
+    [
+      'nested contract marker',
+      {
         contract: {
           salariesByYear: [{ season, salary: 500_000 }],
           isTwoWay: true,
         },
-      };
+      },
+    ],
+  ])('does not invent a blanket eligibility block from the %s', (_label, extras) => {
+    const twoWayPlayer = makePlayer(
+      'Two-Way Guy',
+      500_000,
+      extras as Partial<BatchBPlayer>
+    );
 
-      const team = {
-        teamId: 'BOS',
-        sends: [twoWayPlayer],
-      };
+    const result = validateEligibility(
+      { teamId: 'BOS', sends: [twoWayPlayer] },
+      {}
+    );
 
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
+    expect(result.passed).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
 
-      expect(result.passed).toBe(false);
-      expect(texts.some((v) => v.includes('Two-way'))).toBe(true);
+  it('leaves standard and mixed packages to the salary-matching and roster owners', () => {
+    const standardPlayer = makePlayer('Standard', 10_000_000);
+    const twoWayPlayer = makePlayer('Two-Way', 500_000, {
+      contractType: 'two-way',
     });
 
-    it('allows trade of standard contract player', () => {
-      const standardPlayer = makePlayer('Standard Guy', 10_000_000, {
-        isTwoWay: false,
-      });
+    const result = validateEligibility(
+      { teamId: 'BOS', sends: [standardPlayer, twoWayPlayer] },
+      {}
+    );
 
-      const team = {
-        teamId: 'BOS',
-        sends: [standardPlayer],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      // Should pass (no two-way violation)
-      expect(texts.filter((v) => v.includes('Two-way')).length).toBe(0);
-    });
-
-    it('allows trade when player has no two-way indicators', () => {
-      const regularPlayer = makePlayer('Regular Player', 5_000_000);
-
-      const team = {
-        teamId: 'BOS',
-        sends: [regularPlayer],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      // Should pass (no two-way violation)
-      expect(texts.filter((v) => v.includes('Two-way')).length).toBe(0);
-    });
-
-    it('violation message mentions waiving as alternative', () => {
-      const twoWayPlayer = makePlayer('Two-Way Guy', 500_000, {
-        isTwoWay: true,
-      });
-
-      const team = {
-        teamId: 'BOS',
-        sends: [twoWayPlayer],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      expect(texts.some((v) => v.includes('waived'))).toBe(true);
-    });
-
-    it('handles outgoingPlayers field name (alternative to sends)', () => {
-      const twoWayPlayer = makePlayer('Two-Way Guy', 500_000, {
-        isTwoWay: true,
-      });
-
-      const team = {
-        teamId: 'BOS',
-        outgoingPlayers: [twoWayPlayer],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      expect(result.passed).toBe(false);
-      expect(texts.some((v) => v.includes('Two-way'))).toBe(true);
-    });
-
-    it('blocks multiple two-way players in same trade', () => {
-      const twoWay1 = makePlayer('Two-Way 1', 500_000, { isTwoWay: true });
-      const twoWay2 = makePlayer('Two-Way 2', 500_000, { isTwoWay: true });
-
-      const team = {
-        teamId: 'BOS',
-        sends: [twoWay1, twoWay2],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      // Should have violations for both
-      const twoWayViolations = texts.filter((v) => v.includes('Two-way'));
-      expect(twoWayViolations.length).toBe(2);
-    });
-
-    it('handles mixed standard and two-way players', () => {
-      const standardPlayer = makePlayer('Standard', 10_000_000);
-      const twoWayPlayer = makePlayer('Two-Way', 500_000, { isTwoWay: true });
-
-      const team = {
-        teamId: 'BOS',
-        sends: [standardPlayer, twoWayPlayer],
-      };
-
-      const result = validateEligibility(team, {});
-      const texts = issueTexts(result.violations);
-
-      // Should fail due to two-way player
-      expect(result.passed).toBe(false);
-
-      // Should have exactly one two-way violation
-      const twoWayViolations = texts.filter((v) => v.includes('Two-way'));
-      expect(twoWayViolations.length).toBe(1);
-    });
+    expect(result.passed).toBe(true);
+    expect(result.violations).toEqual([]);
   });
 });
 

--- a/src/tests/architect/tradeEditorTeamCard.boundary.e105.test.tsx
+++ b/src/tests/architect/tradeEditorTeamCard.boundary.e105.test.tsx
@@ -1312,6 +1312,7 @@ describe('TradeTeamCard boundary E105', () => {
 
   it('surfaces the separate Two-Way roster and removes TPE/exception absorption choices', async () => {
     const TradeTeamCard = await loadTradeTeamCard();
+    harness.getTeamSnapshotMock.mockReturnValue(null as never);
     harness.getTeamTpeListMock.mockReturnValue([
       {
         id: 'tpe-1',
@@ -1354,6 +1355,7 @@ describe('TradeTeamCard boundary E105', () => {
       screen.getByRole('option', { name: 'No salary match (Two-Way)' })
     ).toBeInTheDocument();
     expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.getByText('Adjusted')).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'TPE' })).not.toBeInTheDocument();
     expect(
       screen.queryByRole('option', { name: 'FA Exception' })

--- a/src/tests/architect/tradeEditorTeamCard.boundary.e105.test.tsx
+++ b/src/tests/architect/tradeEditorTeamCard.boundary.e105.test.tsx
@@ -39,8 +39,12 @@ type TestPlayer = {
   capHit?: number;
   absorptionMode?: string;
   bucketType?: string;
+  isTwoWay?: boolean;
+  contractType?: string;
   contract?: {
     salariesByYear?: Array<{ salary?: number | string | null }>;
+    contractType?: string;
+    isTwoWay?: boolean;
   };
   bio?: {
     displayName?: string;
@@ -65,6 +69,7 @@ type TestTeam = {
   teamName: string;
   nickname: string;
   players: TestPlayer[];
+  twoWayPlayers?: TestPlayer[];
   entitlements: TestEntitlement[];
   pickRulesById: Record<string, { id: string }>;
   capHolds: Array<{ id: string }>;
@@ -94,6 +99,7 @@ type CapImpactTilesMockProps = {
 
 type OutgoingPlayersListMockProps = {
   sourceTeamId?: string | null;
+  team?: { players?: TestPlayer[] };
 };
 
 type TeamScopedMockProps = {
@@ -423,6 +429,20 @@ const FA_EXCEPTION_PLAYER = {
   name: 'Incoming FA',
   absorptionMode: 'FA_EXCEPTION',
   bucketType: 'ROOM',
+};
+
+const TWO_WAY_PLAYER = {
+  ...INCOMING_PLAYER,
+  id: 'two-way-1',
+  player_id: 'two-way-1',
+  name: 'Tobias Lund',
+  salary: 636_435,
+  capHit: 636_435,
+  contractType: 'two-way',
+  contract: {
+    contractType: 'Two-Way',
+    salariesByYear: [{ salary: 636_435 }],
+  },
 };
 
 const ENTITLEMENT = {
@@ -1288,5 +1308,55 @@ describe('TradeTeamCard boundary E105', () => {
       'setFaBucket',
       'ROOM'
     );
+  });
+
+  it('surfaces the separate Two-Way roster and removes TPE/exception absorption choices', async () => {
+    const TradeTeamCard = await loadTradeTeamCard();
+    harness.getTeamTpeListMock.mockReturnValue([
+      {
+        id: 'tpe-1',
+        amount: 9_000_000,
+        isUsed: false,
+        expirationDate: '2099-01-01',
+        name: 'Test TPE',
+      },
+    ]);
+
+    render(
+      <TradeTeamCard
+        team={{ ...BASE_TEAMS[0].team, twoWayPlayers: [TWO_WAY_PLAYER] }}
+        sends={[]}
+        yearKey={2026}
+        incomingPlayers={[TWO_WAY_PLAYER]}
+        incomingEntitlements={[]}
+        onSetPlayerTrade={vi.fn()}
+        onUndoPlayerTrade={vi.fn()}
+        onRequestSignAndTrade={vi.fn()}
+        onSelectTeam={vi.fn()}
+        onRemove={vi.fn()}
+        onEditContract={vi.fn()}
+        validationResult={{ legal: true }}
+        entitlementsOut={[]}
+      />
+    );
+
+    expect(harness.outgoingPlayersListMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        team: {
+          players: expect.arrayContaining([
+            expect.objectContaining({ id: TWO_WAY_PLAYER.id }),
+          ]),
+        },
+      }),
+      expect.anything()
+    );
+    expect(
+      screen.getByRole('option', { name: 'No salary match (Two-Way)' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.queryByRole('option', { name: 'TPE' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'FA Exception' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/tests/trade/TradeReceiptPanel.twoWay.test.tsx
+++ b/src/tests/trade/TradeReceiptPanel.twoWay.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TradeReceiptPanel } from '@/features/architect/tradeMachine/TradeReceiptPanel';
+import { TWO_WAY_TRADE_MATCHING_EXPLANATION } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
+import type { TradeReceiptLike } from '@/features/architect/tradeMachine/validationPresentationTypes';
+
+const receipt: TradeReceiptLike = {
+  isLegal: true,
+  validatorVersion: '2.0',
+  yearKey: 2026,
+  seasonKey: '2025-26',
+  teams: [
+    {
+      teamName: 'Boston Celtics',
+      teamCode: 'BOS',
+      preTradeTeamSalary: 160_000_000,
+      preTradeTeamSalarySource: 'teamTotalSalary',
+      salaryMatchingEvaluation: {
+        ruleApplied: 'FA_EXCEPTION',
+        formulaUsed: 'Two-Way salary excluded',
+        allowableIncoming: 8_000_000,
+        actualIncoming: 8_000_000,
+        margin: 0,
+      },
+      totals: {
+        outgoingBaseTotal: 636_435,
+        outgoingMatchingTotal: 0,
+        incomingBaseTotal: 636_435,
+        incomingMatchingTotal: 0,
+      },
+      outgoingPlayers: [
+        {
+          name: 'Outgoing Two-Way',
+          baseSalary: 636_435,
+          matchingValue: 0,
+          flags: {
+            isTwoWay: true,
+            isBYC: true,
+            hasTradeKicker: true,
+            tradeKickerPct: 0.15,
+          },
+        },
+      ],
+      incomingPlayers: [
+        {
+          name: 'Incoming Two-Way',
+          baseSalary: 636_435,
+          matchingValue: 0,
+          flags: {
+            isTwoWay: true,
+            isPoisonPill: true,
+            hasTradeKicker: true,
+            tradeKickerPct: 0.15,
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('TradeReceiptPanel Two-Way presentation', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllEnvs();
+  });
+
+  it('shows the Two-Way explanation and suppresses incompatible adjustment badges', () => {
+    vi.stubEnv('VITE_SHOW_TRADE_RECEIPT', 'true');
+
+    render(<TradeReceiptPanel receipt={receipt} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Show Details' }));
+
+    expect(screen.getByText('Outgoing Two-Way')).toBeTruthy();
+    expect(screen.getByText('Incoming Two-Way')).toBeTruthy();
+    expect(screen.getAllByText('2W')).toHaveLength(2);
+    expect(
+      screen.getAllByText(TWO_WAY_TRADE_MATCHING_EXPLANATION)
+    ).toHaveLength(2);
+    expect(screen.queryByText('BYC')).toBeNull();
+    expect(screen.queryByText('PP')).toBeNull();
+    expect(screen.queryByText('TK')).toBeNull();
+    expect(screen.queryByText('Adj')).toBeNull();
+  });
+});

--- a/src/tests/trade/tradeExceptionLifecycle.test.ts
+++ b/src/tests/trade/tradeExceptionLifecycle.test.ts
@@ -94,4 +94,90 @@ describe('tradeExceptionLifecycle', () => {
       ])
     );
   });
+
+  it('CBA2-SC-050(h72): ignores Two-Way TPE assignments and attributes creation only to matching-salary players', () => {
+    const result = applyTradeExceptionLifecycle({
+      currentTradeExceptions: [
+        {
+          id: 'existing-tpe',
+          amount: 5_000_000,
+          remainingAmount: 5_000_000,
+          usedAmount: 0,
+          createdSeason: 2025,
+          expiresOn: '2026-07-01T00:00:00.000Z',
+        },
+      ],
+      hasTradeExceptionsValidation: true,
+      createdTPE: {
+        id: 'created-tpe',
+        amount: 2_000_000,
+        createdSeason: 2026,
+        expiresOn: '2027-07-01T00:00:00.000Z',
+      },
+      incomingPlayers: [
+        {
+          player_id: 'incoming-two-way',
+          name: 'Incoming Two-Way',
+          contractType: 'two-way',
+          absorptionMode: 'TPE',
+          tpeId: 'existing-tpe',
+          matchIncoming: 636_435,
+        },
+      ],
+      outgoingPlayers: [
+        { name: 'Outgoing Standard', contractType: 'STANDARD' },
+        { name: 'Outgoing Two-Way', contractType: 'two-way' },
+      ],
+      teamCode: 'BOS',
+      seasonId: '2025-26',
+      seasonYear: 2026,
+      timestampISO: FIXED_TIMESTAMP_ISO,
+      mutationType: 'executeTrade',
+      mutationId: 'mutation_two_way_exclusion',
+    });
+
+    expect(result.blockingIssues).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.updatedTradeExceptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'existing-tpe',
+          remainingAmount: 5_000_000,
+          usedAmount: 0,
+        }),
+        expect.objectContaining({
+          id: 'created-tpe',
+          createdFrom: 'Outgoing Standard',
+        }),
+      ])
+    );
+    expect(result.historyEntries).toEqual([
+      expect.objectContaining({
+        type: 'TPE_CREATED',
+        tpeId: 'created-tpe',
+        createdFrom: 'Outgoing Standard',
+      }),
+    ]);
+
+    const twoWayOnlyCreation = applyTradeExceptionLifecycle({
+      currentTradeExceptions: [],
+      hasTradeExceptionsValidation: true,
+      createdTPE: {
+        id: 'forged-two-way-tpe',
+        amount: 636_435,
+        createdSeason: 2026,
+        expiresOn: '2027-07-01T00:00:00.000Z',
+      },
+      outgoingPlayers: [
+        { name: 'Outgoing Two-Way', contractType: 'two-way' },
+      ],
+      teamCode: 'LAL',
+      seasonId: '2025-26',
+      seasonYear: 2026,
+      timestampISO: FIXED_TIMESTAMP_ISO,
+    });
+
+    expect(twoWayOnlyCreation.updatedTradeExceptions).toEqual([]);
+    expect(twoWayOnlyCreation.historyEntries).toEqual([]);
+  });
 });

--- a/tests/salaryMargin.test.ts
+++ b/tests/salaryMargin.test.ts
@@ -106,6 +106,16 @@ describe('Salary Margin Utilities', () => {
           { absorptionMode: 'TPE', matchIncoming: 3_000_000, tpeAmount: 9_000_000 },
           { absorptionMode: 'TPE', tpeAmount: 2_000_000 },
           { absorptionMode: 'FA_EXCEPTION', matchIncoming: 1_500_000 },
+          {
+            absorptionMode: 'TPE',
+            matchIncoming: 636_435,
+            contractType: 'TwoWay',
+          },
+          {
+            absorptionMode: 'FA_EXCEPTION',
+            matchIncoming: 636_435,
+            contract: { contractType: 'TwoWay' },
+          },
           { absorptionMode: 'MATCH', matchIncoming: 99_000_000 },
         ],
         context: {
@@ -120,6 +130,7 @@ describe('Salary Margin Utilities', () => {
       // (2026-27 ETPE). On top of that only the USED buckets are added:
       //   used TPE:       $3,000,000 (matchIncoming) + $2,000,000 (tpeAmount)
       //   FA exception:   $1,500,000
+      //   Two-Way rows:   ignored even with stale bucket assignments
       //   MATCH player:   not added (absorbed by the base band)
       // 9,096,000 + 5,000,000 + 1,500,000 = 15,596,000
       expect(getAllowableIncomingMargin(team)).toBe(15_596_000);

--- a/tests/trade/faExceptions_as_trade_buckets.test.ts
+++ b/tests/trade/faExceptions_as_trade_buckets.test.ts
@@ -16,6 +16,12 @@ type FaExceptionPlayer = {
   fromTeamId?: number;
   toTeamId?: number;
   salary?: number;
+  contractType?: string;
+  isTwoWay?: boolean;
+  contract?: {
+    contractType?: string;
+    isTwoWay?: boolean;
+  };
 };
 
 type FaExceptionTeamFixture = {
@@ -137,6 +143,27 @@ describe('FA exceptions as trade buckets', () => {
     };
     const v = validateFaExceptionUsage(team);
     expect(v[0]).toMatch(/Second Apron/);
+  });
+
+  it('ignores stale FA exception assignment for a Two-Way player', () => {
+    const team: FaExceptionTeamFixture = {
+      ...baseTeam,
+      teamTotalSalary: 185_000_000,
+      projectedSalary: 185_000_000,
+      team: { faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }] },
+      incomingPlayers: [
+        makePlayer(636_435, {
+          absorptionMode: 'FA_EXCEPTION',
+          bucketType: 'NTMLE',
+          contract: { contractType: 'TwoWay' },
+        }),
+      ],
+    };
+
+    expect(validateFaExceptionUsage(team)).toEqual([]);
+    expect(team.team.faExceptionBuckets[0].remaining).toBe(10_000_000);
+    expect(team.team.hardCapFirstApron).toBeUndefined();
+    expect(team.notes).toBeUndefined();
   });
 
   it('rejects aggregation with outgoing salary', () => {

--- a/tests/trade/validatorTrustFixes.test.ts
+++ b/tests/trade/validatorTrustFixes.test.ts
@@ -450,26 +450,34 @@ describe('validator trust fixes', () => {
     ).not.toBe('FA_EXCEPTION');
   });
 
-  it('routes legal FA-exception absorption through validateTrade', () => {
+  it('allows FA-exception absorption with only an explicit nested Two-Way outgoing contract', () => {
     const faExceptionIncoming = makePlayer('fa_exception_sender', 8_000_000, {
       teamCode: 'LAL',
       absorptionMode: 'FA_EXCEPTION',
       bucketType: 'NTMLE',
     });
+    const twoWayOutgoing = makePlayer('bos_matching_counter', 636_435, {
+      teamCode: 'BOS',
+      contract: makeContract(636_435, { contractType: 'TwoWay' }),
+    });
     const lakers = makeTeam(
       'LAL',
-      [faExceptionIncoming, ...makeRoster('LAL', 14)],
+      [faExceptionIncoming, ...makeRoster('LAL', 13)],
       { totalSalary: 165_000_000 }
     );
-    const celtics = makeTeam('BOS', makeRoster('BOS', 14), {
-      totalSalary: 160_000_000,
-      faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }],
-    });
+    const celtics = makeTeam(
+      'BOS',
+      [twoWayOutgoing, ...makeRoster('BOS', 13)],
+      {
+        totalSalary: 160_000_000,
+        faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }],
+      }
+    );
 
     const result = validateTrade({
       teams: asValidateTradeTeams([
         { team: lakers, sends: [faExceptionIncoming], entitlementsOut: [] },
-        { team: celtics, sends: [], entitlementsOut: [] },
+        { team: celtics, sends: [twoWayOutgoing], entitlementsOut: [] },
       ]),
       capProjections,
       currentYear: CURRENT_YEAR,
@@ -484,17 +492,25 @@ describe('validator trust fixes', () => {
     expect(getRuleSkipReason(celticsResult?.rules?.salaryMatching)).toBe(
       'FA_EXCEPTION'
     );
+    expect(celticsResult?.salaryOut).toBe(0);
+    expect(celticsResult?.faExceptionBuckets).toEqual([
+      expect.objectContaining({ type: 'NTMLE', remaining: 2_000_000 }),
+    ]);
     expect(celticsResult?.hardCapped).toBe(true);
+    expect(celticsResult?.notes).toContain(
+      'Team hard-capped at first apron due to FA exception usage'
+    );
   });
 
-  it('blocks FA-exception aggregation through validateTrade using the live payload shape', () => {
+  it('blocks the equivalent FA-exception acquisition with a Standard outgoing contract', () => {
     const faExceptionIncoming = makePlayer('fa_exception_sender', 8_000_000, {
       teamCode: 'LAL',
       absorptionMode: 'FA_EXCEPTION',
       bucketType: 'NTMLE',
     });
-    const counterPlayer = makePlayer('bos_counter', 2_000_000, {
+    const standardOutgoing = makePlayer('bos_matching_counter', 636_435, {
       teamCode: 'BOS',
+      contract: makeContract(636_435, { contractType: 'STANDARD' }),
     });
     const lakers = makeTeam(
       'LAL',
@@ -503,7 +519,7 @@ describe('validator trust fixes', () => {
     );
     const celtics = makeTeam(
       'BOS',
-      [counterPlayer, ...makeRoster('BOS', 14)],
+      [standardOutgoing, ...makeRoster('BOS', 13)],
       {
         totalSalary: 160_000_000,
         faExceptionBuckets: [{ type: 'NTMLE', remaining: 10_000_000 }],
@@ -513,7 +529,7 @@ describe('validator trust fixes', () => {
     const result = validateTrade({
       teams: asValidateTradeTeams([
         { team: lakers, sends: [faExceptionIncoming], entitlementsOut: [] },
-        { team: celtics, sends: [counterPlayer], entitlementsOut: [] },
+        { team: celtics, sends: [standardOutgoing], entitlementsOut: [] },
       ]),
       capProjections,
       currentYear: CURRENT_YEAR,
@@ -530,6 +546,10 @@ describe('validator trust fixes', () => {
         expect.stringMatching(/Cannot combine FA Exception with outgoing salary/i),
       ])
     );
+    expect(celticsResult?.faExceptionBuckets).toEqual([
+      expect.objectContaining({ type: 'NTMLE', remaining: 10_000_000 }),
+    ]);
+    expect(celticsResult?.hardCapped).toBe(false);
   });
 
   it('threads asOfDate through executeTrade validation so S&T timing ownership changes by date', () => {

--- a/tests/trade/validatorTrustFixes.test.ts
+++ b/tests/trade/validatorTrustFixes.test.ts
@@ -246,8 +246,11 @@ describe('validator trust fixes', () => {
     };
     const twoWayPlayer = makePlayer('lal_two_way', 636_435, {
       teamCode: 'LAL',
-      contractType: 'two-way',
       isTwoWay: false,
+      contract: makeContract(636_435, {
+        contractType: 'TwoWay',
+        isTwoWay: false,
+      }),
       absorptionMode: 'TPE',
       tpeId: heldTpe.id,
     });
@@ -389,6 +392,62 @@ describe('validator trust fixes', () => {
       outgoingBaseTotal: 2_636_435,
       outgoingMatchingTotal: 2_000_000,
     });
+  });
+
+  it('CBA2-A02.14: ignores stale FA-exception assignment for a Two-Way contract', () => {
+    const faExceptionBucket = {
+      type: 'NTMLE',
+      remaining: 10_000_000,
+    };
+    const twoWayPlayer = makePlayer('lal_two_way_fa_exception', 636_435, {
+      teamCode: 'LAL',
+      contract: makeContract(636_435, { contractType: 'TwoWay' }),
+      absorptionMode: 'FA_EXCEPTION',
+      bucketType: faExceptionBucket.type,
+    });
+
+    const result = validateTrade({
+      teams: asValidateTradeTeams([
+        {
+          team: makeTeam(
+            'LAL',
+            [twoWayPlayer, ...makeRoster('LAL', 14)],
+            { totalSalary: 170_000_000 }
+          ),
+          sends: [twoWayPlayer],
+          entitlementsOut: [],
+        },
+        {
+          team: makeTeam('BOS', makeRoster('BOS', 14), {
+            totalSalary: 100_000_000,
+            faExceptionBuckets: [faExceptionBucket],
+          }),
+          sends: [],
+          entitlementsOut: [],
+        },
+      ]),
+      capProjections,
+      currentYear: CURRENT_YEAR,
+    });
+    const celticsResult = result.teamResults.find(
+      (team) => team.teamId === 'BOS'
+    );
+
+    expect(result.legal).toBe(true);
+    expect(celticsResult?.salaryIn).toBe(0);
+    expect(celticsResult?.hardCapped).toBe(false);
+    expect(celticsResult?.faExceptionBuckets).toEqual([
+      expect.objectContaining({
+        type: faExceptionBucket.type,
+        remaining: 10_000_000,
+      }),
+    ]);
+    expect(celticsResult?.notes).not.toContain(
+      'Team hard-capped at first apron due to FA exception usage'
+    );
+    expect(
+      getRuleSkipReason(celticsResult?.rules?.salaryMatching)
+    ).not.toBe('FA_EXCEPTION');
   });
 
   it('routes legal FA-exception absorption through validateTrade', () => {

--- a/tests/trade/validatorTrustFixes.test.ts
+++ b/tests/trade/validatorTrustFixes.test.ts
@@ -234,20 +234,32 @@ const makeSatContract = (firstYearSalary: number): TestContract => ({
 });
 
 describe('validator trust fixes', () => {
-  it('blocks outgoing two-way players through validateTrade', () => {
-    const twoWayPlayer = makePlayer('lal_two_way', 600_000, {
+  it('CBA2-SC-002(b): excludes a Two-Way contract from matching and TPE state while the Standard counterfactual remains ordinary', () => {
+    const heldTpe = {
+      id: 'bos_tpe',
+      amount: 3_000_000,
+      totalAmount: 3_000_000,
+      remaining: 3_000_000,
+      remainingAmount: 3_000_000,
+      createdSeason: 2025,
+      expiresOn: '2026-10-01T00:00:00.000Z',
+    };
+    const twoWayPlayer = makePlayer('lal_two_way', 636_435, {
       teamCode: 'LAL',
       contractType: 'two-way',
-      isTwoWay: true,
+      isTwoWay: false,
+      absorptionMode: 'TPE',
+      tpeId: heldTpe.id,
     });
     const lakers = makeTeam('LAL', [twoWayPlayer, ...makeRoster('LAL', 14)], {
       totalSalary: 170_000_000,
     });
     const celtics = makeTeam('BOS', makeRoster('BOS', 14), {
       totalSalary: 160_000_000,
+      tradeExceptions: [heldTpe],
     });
 
-    const result = validateTrade({
+    const twoWayResult = validateTrade({
       teams: asValidateTradeTeams([
         { team: lakers, sends: [twoWayPlayer], entitlementsOut: [] },
         { team: celtics, sends: [], entitlementsOut: [] },
@@ -256,22 +268,127 @@ describe('validator trust fixes', () => {
       currentYear: CURRENT_YEAR,
     });
 
-    const lakersResult = result.teamResults.find((team) => team.teamId === 'LAL');
+    const lakersTwoWayResult = twoWayResult.teamResults.find(
+      (team) => team.teamId === 'LAL'
+    );
+    const celticsTwoWayResult = twoWayResult.teamResults.find(
+      (team) => team.teamId === 'BOS'
+    );
+    const lakersReceipt = twoWayResult.tradeReceipt?.teams.find(
+      (team) => team.teamCode === 'LAL'
+    );
+    const celticsReceipt = twoWayResult.tradeReceipt?.teams.find(
+      (team) => team.teamCode === 'BOS'
+    );
 
-    expect(result.legal).toBe(false);
-    expect(lakersResult?.rules?.eligibilityEnforcement).toMatchObject({
-      passed: false,
+    expect(twoWayResult.legal).toBe(true);
+    expect(lakersTwoWayResult?.salaryOut).toBe(0);
+    expect(celticsTwoWayResult?.salaryIn).toBe(0);
+    expect(lakersTwoWayResult?.createdTPE).toBeNull();
+    expect(celticsTwoWayResult?.createdTPE).toBeNull();
+    expect(lakersTwoWayResult?.rules?.eligibilityEnforcement?.passed).toBe(true);
+    expect(heldTpe.remainingAmount).toBe(3_000_000);
+    expect(lakersReceipt?.outgoingPlayers[0]).toMatchObject({
+      baseSalary: 636_435,
+      matchingValue: 0,
+      flags: { isTwoWay: true },
     });
-    expect(issueTexts(lakersResult?.rules?.eligibilityEnforcement?.violations)).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/Two-way contract:.*cannot be traded/i),
-      ])
+    expect(celticsReceipt?.incomingPlayers[0]).toMatchObject({
+      baseSalary: 636_435,
+      matchingValue: 0,
+      flags: { isTwoWay: true },
+    });
+
+    const standardPlayer = makePlayer('lal_standard', 2_000_000, {
+      teamCode: 'LAL',
+      contractType: 'STANDARD',
+      isTwoWay: false,
+    });
+    const standardResult = validateTrade({
+      teams: asValidateTradeTeams([
+        {
+          team: makeTeam(
+            'LAL',
+            [standardPlayer, ...makeRoster('LAL', 14)],
+            { totalSalary: 170_000_000 }
+          ),
+          sends: [standardPlayer],
+          entitlementsOut: [],
+        },
+        {
+          team: makeTeam('BOS', makeRoster('BOS', 14), {
+            totalSalary: 100_000_000,
+          }),
+          sends: [],
+          entitlementsOut: [],
+        },
+      ]),
+      capProjections,
+      currentYear: CURRENT_YEAR,
+    });
+    const lakersStandardResult = standardResult.teamResults.find(
+      (team) => team.teamId === 'LAL'
     );
-    expect(issueTexts(lakersResult?.violations)).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/Two-way contract:.*cannot be traded/i),
-      ])
+    const standardReceipt = standardResult.tradeReceipt?.teams.find(
+      (team) => team.teamCode === 'LAL'
     );
+
+    expect(standardResult.legal).toBe(true);
+    expect(lakersStandardResult?.salaryOut).toBe(2_000_000);
+    expect(lakersStandardResult?.createdTPE?.amount).toBe(2_000_000);
+    expect(standardReceipt?.outgoingPlayers[0]).toMatchObject({
+      baseSalary: 2_000_000,
+      matchingValue: 2_000_000,
+      flags: { isTwoWay: false },
+    });
+  });
+
+  it('CBA2-A02.14: decomposes a mixed package so only Standard salary can create a TPE', () => {
+    const standardPlayer = makePlayer('lal_standard', 2_000_000, {
+      teamCode: 'LAL',
+      contractType: 'STANDARD',
+    });
+    const twoWayPlayer = makePlayer('lal_two_way', 636_435, {
+      teamCode: 'LAL',
+      contractType: 'two-way',
+    });
+
+    const result = validateTrade({
+      teams: asValidateTradeTeams([
+        {
+          team: makeTeam(
+            'LAL',
+            [standardPlayer, twoWayPlayer, ...makeRoster('LAL', 13)],
+            { totalSalary: 170_000_000 }
+          ),
+          sends: [standardPlayer, twoWayPlayer],
+          entitlementsOut: [],
+        },
+        {
+          team: makeTeam('BOS', makeRoster('BOS', 13), {
+            totalSalary: 100_000_000,
+          }),
+          sends: [],
+          entitlementsOut: [],
+        },
+      ]),
+      capProjections,
+      currentYear: CURRENT_YEAR,
+    });
+    const lakersResult = result.teamResults.find(
+      (team) => team.teamId === 'LAL'
+    );
+    const lakersReceipt = result.tradeReceipt?.teams.find(
+      (team) => team.teamCode === 'LAL'
+    );
+
+    expect(result.legal).toBe(true);
+    expect(lakersResult?.salaryOut).toBe(2_000_000);
+    expect(lakersResult?.createdTPE?.amount).toBe(2_000_000);
+    expect(lakersReceipt?.totals).toMatchObject({
+      outgoingBaseTotal: 2_636_435,
+      outgoingMatchingTotal: 2_000_000,
+    });
   });
 
   it('routes legal FA-exception absorption through validateTrade', () => {

--- a/tests/tradeHelpers.test.ts
+++ b/tests/tradeHelpers.test.ts
@@ -160,6 +160,13 @@ describe('other helper surface behavior', () => {
     expect(getAdjustmentTooltipLabel({})).toBe(
       'Adjusted trade matching value (BYC/kicker/poison pill may apply)'
     );
+    expect(
+      getAdjustmentTooltipLabel({
+        contractType: 'two-way',
+        isBYC: true,
+        tradeKicker: true,
+      })
+    ).toBe('Two-Way salary exclusion');
   });
 });
 

--- a/tests/tradeHelpers.test.ts
+++ b/tests/tradeHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   getPlayerAdjustmentTypes,
   getAdjustmentTooltipLabel,
 } from '@/features/architect/utils/tradeHelpers';
+import { isTwoWayTradePlayer } from '@/features/architect/utils/tradeMachine/utils/twoWayTradeSalary';
 
 // 🔧  simple mock cap settings for 2025 season
 const settings = {
@@ -55,6 +56,21 @@ describe('getSalaryForYear', () => {
   it('falls back to salary property when contract data missing', () => {
     const p = { salary: 8_500_000 };
     expect(getSalaryForYear(p, year)).toBe(8_500_000);
+  });
+});
+
+describe('Two-Way trade classification', () => {
+  it.each(['TwoWay', 'two-way', 'two_way', 'two way'])(
+    'recognizes the explicit %s contract spelling',
+    (contractType) => {
+      expect(
+        isTwoWayTradePlayer({ contract: { contractType } })
+      ).toBe(true);
+    }
+  );
+
+  it('does not infer Two-Way status from salary alone', () => {
+    expect(isTwoWayTradePlayer({ salary: 636_435 })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes BZE-277
Refs BZE-267
Refs BZE-272

## Summary

- allow Two-Way contracts to move through the approved Trade Machine workflow instead of applying the stale blanket waiver-only block
- exclude explicit Two-Way contracts from outgoing and incoming salary matching, TPE creation/consumption, and FA-exception absorption or hard-cap state
- recognize the explicit contract spellings already carried by repository data, including nested `TwoWay`, without inferring contract type from salary or roster placement
- surface the separate Two-Way roster in the Trade Machine and explain the zero matching value in team cards and transaction receipts
- preserve the BZE-272 completed-trade ledger and manifest as the only completed-state history path

## Canon and audit scope

- Establishes CBA2-A02.14 only: Two-Way salary is excluded from trade matching and cannot create or use a trade exception
- Discriminating scenarios: CBA2-SC-002(b), including the Standard-contract counterfactual, plus the CBA2-SC-050(h72) TPE-history interaction
- Prepared: 0
- Open: all other CBA2-A02 leaves and unrelated Phase 2 findings
- No frozen Canon, Phase 2 register, historical checksum, governed-season release, or source corpus changed

## Final candidate and independent acceptance

- Accepted base: `de252626243362af68f531daa1c44e3271b25027`
- Accepted candidate: `c3a909fd605a48cd629564dcbdec5aa6c2ea3556`
- The final repair delta is limited to the FA-exception outgoing-salary predicate and its authoritative validator and receipt-rendering regression coverage
- Codex exact-head review found no major issues on `c3a909fd60`
- Independent Claude review: ACCEPT on exact candidate `c3a909fd605a48cd629564dcbdec5aa6c2ea3556`; the original blocker is closed, fail-closed Standard behavior remains intact, and the three-file repair delta introduces no regression
- CodeRabbit attempted the final range review but was rate-limited; no exact-head CodeRabbit verdict is claimed

## Validation

- focused node validation — 8/8 passed
- focused TradeReceiptPanel UI validation — 1/1 passed
- `npm run test:trade -- --reporter=dot` — 72 files / 644 tests passed
- `npm run typecheck` — passed
- `npm run validate:project` — passed
- `graphify update .` — passed
- hosted PR Validation (Diff-based) — passed on exact candidate `c3a909fd605a48cd629564dcbdec5aa6c2ea3556`, including hosted typecheck, Architect cast-ledger gate, diff-selected tests, project validation, and production build
- Vercel — passed and Ready on the exact candidate
- exact-head 1280×720 Architect emulator/browser proof — passed as author evidence: a legal MIA/DEN Two-Way swap rendered four `$0` matching rows with the canonical explanation and no BYC/PP/TK badges; no world was created and no trade was applied

## Deliberately skipped / bounded limitations

- no full W1–W15 acceptance battery, full repository suite, or broad Architect/UI suite
- no calendar work or option/extension/service/rights/signing source acquisition
- the exact-head browser proof used sandbox/base data, did not create durable seeded writes, and cleaned all temporary artifacts afterward
- cosmetic `$0` / `—` display differences, the optional test-shape nit, the missing retained screenshot, and the cap-sheet/local classifier divergence remain outside this tranche and have no follow-up issue by owner direction
- the suggested pre-existing TradeTeamCard component split was not taken because it is a broad refactor outside this tranche
- this does not complete Trade Machine salary matching, Phase 3A, or source readiness
