### PR TITLE
Govern the RFA Offer Sheet workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Phase 3A workflow tooling
         run: npm run test:phase3a-workflow
 
+      - name: Governed Offer Sheet creation emulator gate
+        run: npm run ci:offer-sheet-creation-emulator-gate
+
       - name: Run diff-based tests
         run: npm run test:diff -- --verbose
 
@@ -87,6 +90,9 @@ jobs:
 
       - name: Phase 3A workflow tooling
         run: npm run test:phase3a-workflow
+
+      - name: Governed Offer Sheet creation emulator gate
+        run: npm run ci:offer-sheet-creation-emulator-gate
 
       - name: Run full test suite
         run: npm run test:full

--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -453,6 +453,7 @@ utils/
   nonTradeMutationValidationStage.ts
   offerSheets/
     governedOfferSheetLifecycle.ts
+    governedOfferSheetRestrictions.ts
     governedOfferSheetTerms.ts
     governedOfferSheetTime.ts
     index.ts
@@ -621,5 +622,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-08-19T03:28:54.389Z*
+*Generated on: 2026-08-19T04:48:00.666Z*
 *Auto-updated by: npm run docs*

--- a/docs/components/ArchitectHierarchy.md
+++ b/docs/components/ArchitectHierarchy.md
@@ -13,6 +13,7 @@ GMDashboard/
     DraftPositionsInput.tsx
     FullCapFreeAgentModal.tsx
     OfferSheetList.tsx
+    OfferSheetResolutionControls.tsx
     ScenarioMoveRail.tsx
     SeasonAdvanceModal.helpers.ts
     SeasonAdvanceModal.tsx
@@ -450,6 +451,11 @@ utils/
   mutationPipeline.types.ts
   mutationPipeline.validate.ts
   nonTradeMutationValidationStage.ts
+  offerSheets/
+    governedOfferSheetLifecycle.ts
+    governedOfferSheetTerms.ts
+    governedOfferSheetTime.ts
+    index.ts
   offseason/
     index.ts
     resolveOffseasonTransition.helpers.ts
@@ -615,5 +621,5 @@ utils/
 ```
 
 ---
-*Generated on: 2026-08-18T11:33:25.850Z*
+*Generated on: 2026-08-19T03:28:54.389Z*
 *Auto-updated by: npm run docs*

--- a/firestore.rules
+++ b/firestore.rules
@@ -158,6 +158,43 @@ service cloud.firestore {
         allow write: if isOpenForClientWorldWrites(worldId);
       }
 
+      // A governed Offer Sheet is authored by the world owner, but its initial
+      // lifecycle identity becomes immutable once the atomic creation commits.
+      // Resolution compares the writable Team mirrors against this anchor.
+      match /offerSheetAuthorizations/{offerSheetId} {
+        allow read: if isWorldOwner(worldId);
+        allow create: if isOpenForClientWorldWrites(worldId)
+          && request.resource.data.keys().hasOnly([
+            'authorizationVersion',
+            'worldId',
+            'offerSheetId',
+            'dedupKey',
+            'playerId',
+            'homeTeamId',
+            'offeringTeamId',
+            'salaryCapYear',
+            'pendingLifecycleDigest',
+            'immutableEvidenceDigest'
+          ])
+          && request.resource.data.authorizationVersion == 1
+          && request.resource.data.worldId == worldId
+          && request.resource.data.offerSheetId == offerSheetId
+          && request.resource.data.dedupKey is string
+          && request.resource.data.dedupKey.size() > 0
+          && request.resource.data.playerId is string
+          && request.resource.data.playerId.size() > 0
+          && request.resource.data.homeTeamId is string
+          && request.resource.data.homeTeamId.size() > 0
+          && request.resource.data.offeringTeamId is string
+          && request.resource.data.offeringTeamId.size() > 0
+          && request.resource.data.salaryCapYear is int
+          && request.resource.data.pendingLifecycleDigest is string
+          && request.resource.data.pendingLifecycleDigest.matches('^fnv1a64:[0-9a-f]{16}$')
+          && request.resource.data.immutableEvidenceDigest is string
+          && request.resource.data.immutableEvidenceDigest.matches('^fnv1a64:[0-9a-f]{16}$');
+        allow update, delete: if false;
+      }
+
       match /entitlements/{entitlementId} {
         allow read: if isWorldOwner(worldId);
         allow write: if isOpenForClientWorldWrites(worldId);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:scouting": "node scripts/run-scouting-tests.mjs",
     "test:diff": "node scripts/run-tests-by-diff.mjs",
     "test:phase3a-workflow": "tsx --test --test-reporter=dot tests/tooling/phase3aWorkflow.node-test.ts",
+    "ci:offer-sheet-creation-emulator-gate": "cross-env GCLOUD_PROJECT=demo-bze-283 FIREBASE_CLI_DISABLE_UPDATE_CHECK=true npx --yes firebase-tools@13.35.1 emulators:exec --only firestore,auth --project demo-bze-283 \"vitest run --config vitest.emulator.config.js src/tests/architect/mutationPipeline.offerSheetCreation.emulator.test.ts --reporter=dot\"",
     "test:e2e": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui",
     "test:e2e:headed": "npx playwright test --headed",

--- a/src/constants/collections.ts
+++ b/src/constants/collections.ts
@@ -67,6 +67,8 @@ export const ARCHITECT_WORLD_EVENTS_SUBCOLLECTION = 'events';
 export const ARCHITECT_WORLD_FREE_AGENT_POOLS_SUBCOLLECTION = 'freeAgentPools';
 export const ARCHITECT_WORLD_CONTRACT_BASELINES_SUBCOLLECTION =
   'contractBaselines';
+export const ARCHITECT_WORLD_OFFER_SHEET_AUTHORIZATIONS_SUBCOLLECTION =
+  'offerSheetAuthorizations';
 
 /**
  * Free agents collection

--- a/src/features/architect/GMDashboard/components/OfferSheetList.tsx
+++ b/src/features/architect/GMDashboard/components/OfferSheetList.tsx
@@ -11,6 +11,7 @@
  *  - Master Doc: docs/architect/TRADE_MACHINE_MASTER.md
  */
 import React from 'react';
+import { OfferSheetResolutionControls } from './OfferSheetResolutionControls';
 
 import type {
   OfferSheetLifecycleAction,
@@ -179,6 +180,15 @@ export const OfferSheetList = ({
                 </td>
                 <td className="py-1.5 text-right space-x-2">
                   {lifecycleSurfaceState.kind === 'actions' &&
+                    surfaceRole === 'incoming' &&
+                    os.status === 'PENDING_MATCH' ? (
+                      <OfferSheetResolutionControls
+                        offerSheet={os}
+                        onLifecycleAction={onLifecycleAction}
+                        actionsDisabled={actionsDisabled}
+                        actionsDisabledReason={actionsDisabledReason}
+                      />
+                    ) : lifecycleSurfaceState.kind === 'actions' &&
                     lifecycleSurfaceState.actions.map((action) => (
                       <button
                         key={action}

--- a/src/features/architect/GMDashboard/components/OfferSheetResolutionControls.tsx
+++ b/src/features/architect/GMDashboard/components/OfferSheetResolutionControls.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 
-import { isZonedDateTime } from '@/features/architect/utils/governedSeason';
+import { isEasternInstant } from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
 import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
 import type {
   OfferSheetLifecycleActionEvent,
@@ -26,15 +26,27 @@ export const OfferSheetResolutionControls = ({
   );
   const arenasApplies =
     lifecycle.success && lifecycle.data.reservations.arenasApplies;
+  const governedLifecycleReady =
+    lifecycle.success && lifecycle.data.status === 'pending-match';
   const [resolutionAt, setResolutionAt] = useState('');
   const [electAverage, setElectAverage] = useState(false);
   const [statementId, setStatementId] = useState('');
   const [relayedAt, setRelayedAt] = useState('');
-  const exactResolutionReady = isZonedDateTime(resolutionAt);
+  const exactResolutionReady = isEasternInstant(resolutionAt);
   const electionReady =
     !electAverage ||
-    (statementId.trim().length > 0 && isZonedDateTime(relayedAt));
-  const baseDisabled = actionsDisabled || !exactResolutionReady;
+    (statementId.trim().length > 0 && isEasternInstant(relayedAt));
+  const governedDisabledReason =
+    'This offer sheet is missing the saved notice record required to resolve it.';
+  const disabledReason = actionsDisabled
+    ? actionsDisabledReason
+    : !governedLifecycleReady
+      ? governedDisabledReason
+      : !exactResolutionReady
+        ? 'Enter the exact Eastern resolution time.'
+        : undefined;
+  const baseDisabled =
+    actionsDisabled || !governedLifecycleReady || !exactResolutionReady;
 
   const emit = (action: 'match' | 'decline') => {
     onLifecycleAction?.({
@@ -57,6 +69,11 @@ export const OfferSheetResolutionControls = ({
 
   return (
     <div className="ml-auto w-64 space-y-1.5 text-left">
+      {!governedLifecycleReady ? (
+        <p className="text-[10px] leading-snug text-amber-300">
+          {governedDisabledReason}
+        </p>
+      ) : null}
       <label className="block text-[10px] uppercase tracking-wide text-white/45">
         Exact resolution time
         <input
@@ -91,7 +108,7 @@ export const OfferSheetResolutionControls = ({
                 aria-label="Players Association relay time"
                 value={relayedAt}
                 onChange={(event) => setRelayedAt(event.target.value)}
-                placeholder="NBA relay time with offset"
+                placeholder="Eastern relay time with offset"
                 className="w-full rounded border border-white/15 bg-black/40 px-2 py-1.5 text-[10px] text-white outline-none"
               />
             </div>
@@ -103,7 +120,7 @@ export const OfferSheetResolutionControls = ({
           type="button"
           onClick={() => emit('match')}
           disabled={baseDisabled || !electionReady}
-          title={actionsDisabled ? actionsDisabledReason : undefined}
+          title={baseDisabled ? disabledReason : undefined}
           className="rounded bg-blue-600 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           Match
@@ -112,7 +129,7 @@ export const OfferSheetResolutionControls = ({
           type="button"
           onClick={() => emit('decline')}
           disabled={baseDisabled}
-          title={actionsDisabled ? actionsDisabledReason : undefined}
+          title={baseDisabled ? disabledReason : undefined}
           className="rounded bg-red-600 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           Decline

--- a/src/features/architect/GMDashboard/components/OfferSheetResolutionControls.tsx
+++ b/src/features/architect/GMDashboard/components/OfferSheetResolutionControls.tsx
@@ -47,6 +47,11 @@ export const OfferSheetResolutionControls = ({
         : undefined;
   const baseDisabled =
     actionsDisabled || !governedLifecycleReady || !exactResolutionReady;
+  const matchDisabledReason =
+    disabledReason ??
+    (!electionReady
+      ? 'Enter the averaging statement reference and exact Eastern relay time.'
+      : undefined);
 
   const emit = (action: 'match' | 'decline') => {
     onLifecycleAction?.({
@@ -120,7 +125,7 @@ export const OfferSheetResolutionControls = ({
           type="button"
           onClick={() => emit('match')}
           disabled={baseDisabled || !electionReady}
-          title={baseDisabled ? disabledReason : undefined}
+          title={matchDisabledReason}
           className="rounded bg-blue-600 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           Match

--- a/src/features/architect/GMDashboard/components/OfferSheetResolutionControls.tsx
+++ b/src/features/architect/GMDashboard/components/OfferSheetResolutionControls.tsx
@@ -1,0 +1,123 @@
+import React, { useMemo, useState } from 'react';
+
+import { isZonedDateTime } from '@/features/architect/utils/governedSeason';
+import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
+import type {
+  OfferSheetLifecycleActionEvent,
+  OfferSheetLike,
+} from '../offerSheetTypes';
+
+type OfferSheetResolutionControlsProps = {
+  offerSheet: OfferSheetLike;
+  onLifecycleAction?: (event: OfferSheetLifecycleActionEvent) => unknown;
+  actionsDisabled: boolean;
+  actionsDisabledReason: string;
+};
+
+export const OfferSheetResolutionControls = ({
+  offerSheet,
+  onLifecycleAction,
+  actionsDisabled,
+  actionsDisabledReason,
+}: OfferSheetResolutionControlsProps) => {
+  const lifecycle = useMemo(
+    () => GovernedOfferSheetLifecycleZ.safeParse(offerSheet.governedLifecycle),
+    [offerSheet.governedLifecycle]
+  );
+  const arenasApplies =
+    lifecycle.success && lifecycle.data.reservations.arenasApplies;
+  const [resolutionAt, setResolutionAt] = useState('');
+  const [electAverage, setElectAverage] = useState(false);
+  const [statementId, setStatementId] = useState('');
+  const [relayedAt, setRelayedAt] = useState('');
+  const exactResolutionReady = isZonedDateTime(resolutionAt);
+  const electionReady =
+    !electAverage ||
+    (statementId.trim().length > 0 && isZonedDateTime(relayedAt));
+  const baseDisabled = actionsDisabled || !exactResolutionReady;
+
+  const emit = (action: 'match' | 'decline') => {
+    onLifecycleAction?.({
+      action,
+      offerSheet,
+      surfaceRole: 'incoming',
+      resolution: {
+        resolutionAt,
+        averagingElection:
+          action === 'match' && electAverage
+            ? {
+                statementId: statementId.trim(),
+                deliveredToNbaAt: resolutionAt,
+                relayedToPlayersAssociationAt: relayedAt,
+              }
+            : null,
+      },
+    });
+  };
+
+  return (
+    <div className="ml-auto w-64 space-y-1.5 text-left">
+      <label className="block text-[10px] uppercase tracking-wide text-white/45">
+        Exact resolution time
+        <input
+          data-testid={`offer-sheet-resolution-at-${offerSheet.id}`}
+          value={resolutionAt}
+          onChange={(event) => setResolutionAt(event.target.value)}
+          placeholder="2026-07-09T17:00:00-04:00"
+          className="mt-1 w-full rounded border border-white/15 bg-black/40 px-2 py-1.5 text-[11px] normal-case tracking-normal text-white outline-none focus:border-cyan-400/50"
+        />
+      </label>
+      {arenasApplies ? (
+        <div className="rounded border border-white/10 bg-white/[0.03] p-2">
+          <label className="flex items-center gap-1.5 text-[10px] text-white/65">
+            <input
+              type="checkbox"
+              checked={electAverage}
+              onChange={(event) => setElectAverage(event.target.checked)}
+              className="accent-cyan-500"
+            />
+            Elect average annual Salary
+          </label>
+          {electAverage ? (
+            <div className="mt-2 space-y-1.5">
+              <input
+                aria-label="Averaging statement reference"
+                value={statementId}
+                onChange={(event) => setStatementId(event.target.value)}
+                placeholder="Written statement reference"
+                className="w-full rounded border border-white/15 bg-black/40 px-2 py-1.5 text-[10px] text-white outline-none"
+              />
+              <input
+                aria-label="Players Association relay time"
+                value={relayedAt}
+                onChange={(event) => setRelayedAt(event.target.value)}
+                placeholder="NBA relay time with offset"
+                className="w-full rounded border border-white/15 bg-black/40 px-2 py-1.5 text-[10px] text-white outline-none"
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => emit('match')}
+          disabled={baseDisabled || !electionReady}
+          title={actionsDisabled ? actionsDisabledReason : undefined}
+          className="rounded bg-blue-600 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Match
+        </button>
+        <button
+          type="button"
+          onClick={() => emit('decline')}
+          disabled={baseDisabled}
+          title={actionsDisabled ? actionsDisabledReason : undefined}
+          className="rounded bg-red-600 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.helpers.signing.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.helpers.signing.ts
@@ -219,6 +219,7 @@ export type PreparedOfferSheetCreationDefinition =
         offeringTeamCode: string;
         playerId: string;
         contract: LocalContract;
+        offerSheetProposal?: SigningDetails['offerSheetProposal'];
       };
       mutationPayload: OfferSheetMutationPayload;
     }

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.offerSheetActions.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.offerSheetActions.ts
@@ -29,6 +29,7 @@ import type {
   OfferSheetLifecycleExecutionResult,
   OfferSheetLifecycleMutationType,
   OfferSheetResolutionAction,
+  OfferSheetResolutionInput,
   OfferSheetResolutionMutationType,
   OfferSheetStoreExecutionResult,
   SigningDetails,
@@ -171,7 +172,8 @@ export function useOfferSheetActions({
   const runOfferSheetResolutionAction = useCallback(
     (
       action: OfferSheetResolutionAction,
-      offerSheet: OfferSheet | null | undefined
+      offerSheet: OfferSheet | null | undefined,
+      resolution?: OfferSheetResolutionInput
     ): void => {
       const mutationType: OfferSheetResolutionMutationType =
         action === 'match' ? 'matchOfferSheet' : 'declineOfferSheet';
@@ -234,6 +236,9 @@ export function useOfferSheetActions({
             playerName: offerSheet?.playerName,
             dedupKey: offerSheet?.dedupKey,
             seasonKey: offerSheet?.seasonKey,
+            asOfDate: resolution?.resolutionAt,
+            offerSheetAveragingElection:
+              action === 'match' ? resolution?.averagingElection : null,
           },
           expectation
         );
@@ -314,15 +319,21 @@ export function useOfferSheetActions({
   );
 
   const handleMatchOfferSheet = useCallback(
-    (offerSheet: OfferSheet | null | undefined): void => {
-      runOfferSheetResolutionAction('match', offerSheet);
+    (
+      offerSheet: OfferSheet | null | undefined,
+      resolution?: OfferSheetResolutionInput
+    ): void => {
+      runOfferSheetResolutionAction('match', offerSheet, resolution);
     },
     [runOfferSheetResolutionAction]
   );
 
   const handleDeclineOfferSheet = useCallback(
-    (offerSheet: OfferSheet | null | undefined): void => {
-      runOfferSheetResolutionAction('decline', offerSheet);
+    (
+      offerSheet: OfferSheet | null | undefined,
+      resolution?: OfferSheetResolutionInput
+    ): void => {
+      runOfferSheetResolutionAction('decline', offerSheet, resolution);
     },
     [runOfferSheetResolutionAction]
   );

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.offerSheetActions.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.offerSheetActions.ts
@@ -43,7 +43,10 @@ import type { ArchitectReceiptActionContext } from '../postActionHandoff/types';
 export type UseOfferSheetActionsParams = {
   currentYear: number;
   teamCode: string;
-  reportMutationError: (message: string, details?: Record<string, unknown>) => void;
+  reportMutationError: (
+    message: string,
+    details?: Record<string, unknown>
+  ) => void;
   requireActiveWorldForFreeAgencyWorldOnlyCommit: (
     kind: FreeAgencyWorldOnlyActionKind,
     details?: Record<string, unknown>
@@ -93,7 +96,6 @@ export function useOfferSheetActions({
   prepareOfferSheetCreationDefinition,
   applyCapAuditedTeamMutation,
 }: UseOfferSheetActionsParams) {
-
   const handleStoreOfferSheet = useCallback(
     async (
       playerObj: ArchitectPlayer,
@@ -236,7 +238,7 @@ export function useOfferSheetActions({
             playerName: offerSheet?.playerName,
             dedupKey: offerSheet?.dedupKey,
             seasonKey: offerSheet?.seasonKey,
-            asOfDate: resolution?.resolutionAt,
+            offerSheetResolutionAt: resolution?.resolutionAt,
             offerSheetAveragingElection:
               action === 'match' ? resolution?.averagingElection : null,
           },
@@ -466,7 +468,6 @@ export function useOfferSheetActions({
     },
     [applyCapAuditedTeamMutation, currentYear, teamCode]
   );
-
 
   return {
     handleStoreOfferSheet,

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.signingExecution.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.signingExecution.ts
@@ -931,11 +931,13 @@ export function useSigningExecution({
           offeringTeamCode: teamCode,
           playerId,
           contract: architectContract,
+          offerSheetProposal: contract.offerSheetProposal,
         },
         mutationPayload: {
           teamCode: teamCode ?? '',
           playerId,
           contract: architectContract,
+          offerSheetProposal: contract.offerSheetProposal,
           signedUsing,
         },
       };

--- a/src/features/architect/GMDashboard/hooks/useArchitectActions.types.ts
+++ b/src/features/architect/GMDashboard/hooks/useArchitectActions.types.ts
@@ -20,6 +20,7 @@ import type {
   GovernedExtensionAvailability,
   GovernedExtensionProposal,
 } from '@/features/architect/utils/extensions';
+import type { GovernedOfferSheetAveragingElection } from '@/schemas/governedOfferSheet';
 
 import type {
   ArchitectGeneralMutationDashboardReloadTeamSnapshot,
@@ -267,6 +268,8 @@ export type SigningDetails = Omit<Partial<LocalContract>, 'birdRights'> & {
   overrideUsed?: boolean;
   overrideReasons?: string[];
   overrideTimestamp?: string;
+  /** BZE-283: signed Principal Terms and exact notice evidence. */
+  offerSheetProposal?: import('@/schemas/governedOfferSheet').GovernedOfferSheetProposal;
 };
 
 /** Waive options */
@@ -426,6 +429,11 @@ export interface OfferSheet {
   playerId?: string;
   playerName?: string;
   seasonKey?: string;
+}
+
+export interface OfferSheetResolutionInput {
+  resolutionAt: string;
+  averagingElection: GovernedOfferSheetAveragingElection | null;
 }
 
 export type OfferSheetResolutionAction = 'match' | 'decline';
@@ -749,8 +757,14 @@ export interface FreeAgencyWorldOnlyModalActionOwner {
 export interface FreeAgencyOfferSheetLifecycleActionOwner {
   // BZE-191: one-click resolution — Match keeps the player, Decline moves the
   // player + cap to the offering team, both in a single atomic mutation.
-  matchOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
-  declineOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
+  matchOfferSheet: (
+    offerSheet: OfferSheet | null | undefined,
+    resolution?: OfferSheetResolutionInput
+  ) => void;
+  declineOfferSheet: (
+    offerSheet: OfferSheet | null | undefined,
+    resolution?: OfferSheetResolutionInput
+  ) => void;
   finalizeOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
 }
 
@@ -878,8 +892,14 @@ export interface UseArchitectActionsReturn {
     playerObj: ArchitectPlayer,
     contract: SigningDetails
   ) => Promise<MutationActionResult>;
-  handleMatchOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
-  handleDeclineOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
+  handleMatchOfferSheet: (
+    offerSheet: OfferSheet | null | undefined,
+    resolution?: OfferSheetResolutionInput
+  ) => void;
+  handleDeclineOfferSheet: (
+    offerSheet: OfferSheet | null | undefined,
+    resolution?: OfferSheetResolutionInput
+  ) => void;
   handleFinalizeOfferSheet: (offerSheet: OfferSheet | null | undefined) => void;
 
   // Trade actions

--- a/src/features/architect/GMDashboard/offerSheetTypes.ts
+++ b/src/features/architect/GMDashboard/offerSheetTypes.ts
@@ -10,10 +10,8 @@
  *  - Return Package: return_packages/trade_machine/TM_VALIDATOR_TS_FREE_AGENCY_OFFER_SHEET_SURFACE_E91_RETURN_PACKAGE.md
  *  - Master Doc: docs/architect/TRADE_MACHINE_MASTER.md
  */
-import type {
-  FreeAgencyActionOwner,
-  OfferSheetResolutionInput,
-} from './hooks/useArchitectActions';
+import type { FreeAgencyActionOwner } from './hooks/useArchitectActions';
+import type { OfferSheetResolutionInput } from './hooks/useArchitectActions';
 import type {
   FreeAgentSurfaceEntry,
   FreeAgentPoolProps,

--- a/src/features/architect/GMDashboard/offerSheetTypes.ts
+++ b/src/features/architect/GMDashboard/offerSheetTypes.ts
@@ -10,7 +10,10 @@
  *  - Return Package: return_packages/trade_machine/TM_VALIDATOR_TS_FREE_AGENCY_OFFER_SHEET_SURFACE_E91_RETURN_PACKAGE.md
  *  - Master Doc: docs/architect/TRADE_MACHINE_MASTER.md
  */
-import type { FreeAgencyActionOwner } from './hooks/useArchitectActions';
+import type {
+  FreeAgencyActionOwner,
+  OfferSheetResolutionInput,
+} from './hooks/useArchitectActions';
 import type {
   FreeAgentSurfaceEntry,
   FreeAgentPoolProps,
@@ -39,12 +42,14 @@ export interface OfferSheetLike extends LooseRecord {
   totalValue?: number | string | null;
   status: OfferSheetStatus;
   createdAt?: string | number | Date | null;
+  governedLifecycle?: unknown;
 }
 
 export interface OfferSheetLifecycleActionEvent {
   action: OfferSheetLifecycleAction;
   offerSheet: OfferSheetLike;
   surfaceRole: OfferSheetSurfaceRole;
+  resolution?: OfferSheetResolutionInput;
 }
 
 export interface OfferSheetListProps {

--- a/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
+++ b/src/features/architect/GMDashboard/sections/FreeAgencySection.tsx
@@ -92,16 +92,19 @@ const FreeAgencySection = ({
     action,
     offerSheet,
     surfaceRole,
+    resolution,
   }: OfferSheetLifecycleActionEvent) => {
     switch (`${surfaceRole}:${action}`) {
       case 'incoming:match':
         offerSheetLifecycleActionOwner?.matchOfferSheet(
-          offerSheet as OfferSheetFinalizeArg
+          offerSheet as OfferSheetFinalizeArg,
+          resolution
         );
         return;
       case 'incoming:decline':
         offerSheetLifecycleActionOwner?.declineOfferSheet(
-          offerSheet as OfferSheetFinalizeArg
+          offerSheet as OfferSheetFinalizeArg,
+          resolution
         );
         return;
       case 'incoming:finalizeMatched':

--- a/src/features/architect/utils/architectFirestorePaths.ts
+++ b/src/features/architect/utils/architectFirestorePaths.ts
@@ -37,6 +37,7 @@ import {
   ARCHITECT_WORLD_ENTITLEMENTS_SUBCOLLECTION,
   ARCHITECT_WORLD_FREE_AGENT_POOLS_SUBCOLLECTION,
   ARCHITECT_WORLD_CONTRACT_BASELINES_SUBCOLLECTION,
+  ARCHITECT_WORLD_OFFER_SHEET_AUTHORIZATIONS_SUBCOLLECTION,
 } from '@/constants/collections';
 
 // Re-export base collection helpers for convenience
@@ -141,6 +142,19 @@ export const worldContractBaselineRef = (
     worldId,
     ARCHITECT_WORLD_CONTRACT_BASELINES_SUBCOLLECTION,
     shardId
+  );
+
+/** Immutable authorization anchor for one governed Offer Sheet lifecycle. */
+export const worldOfferSheetAuthorizationRef = (
+  worldId: string,
+  offerSheetId: string
+): DocumentReference =>
+  doc(
+    db,
+    ARCHITECT_WORLDS_COLLECTION,
+    worldId,
+    ARCHITECT_WORLD_OFFER_SHEET_AUTHORIZATIONS_SUBCOLLECTION,
+    offerSheetId
   );
 
 /**

--- a/src/features/architect/utils/capLegalityValidation/extension.ts
+++ b/src/features/architect/utils/capLegalityValidation/extension.ts
@@ -4,7 +4,6 @@
  * OWNERSHIP: Feature: architect/core
  */
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
-import { getCapSettings } from '@/features/architect/utils/capHelpers';
 import { getCapRulesForYear } from '@/features/architect/utils/capRulesProfile';
 import type { CapRulesProfile } from '@/features/architect/utils/capRulesProfile';
 import {
@@ -495,7 +494,6 @@ export function validateExtension({
   const violations: CapLegalityViolation[] = [];
   const warnings: CapLegalityViolation[] = [];
 
-  const capSettings = getCapSettings(year);
   const contract = player.contract;
   const offerSheetRestriction = inspectGovernedOfferSheetMatchRestriction(
     contract?.offerSheetMatchRestriction,

--- a/src/features/architect/utils/capLegalityValidation/extension.ts
+++ b/src/features/architect/utils/capLegalityValidation/extension.ts
@@ -12,6 +12,7 @@ import {
   HARD_CAP_TYPES,
 } from '@/features/architect/utils/tradeMachine/utils/hardCapStatus';
 import { computePlayerRulesProfile } from '@/features/architect/utils/playerRulesProfile/computeProfile';
+import { inspectGovernedOfferSheetMatchRestriction } from '@/features/architect/utils/offerSheets';
 import type {
   CapLegalityViolation,
   MutationSalaryRow,
@@ -163,7 +164,6 @@ function getValidationHardCapStatus(
 // ==============================================================================
 // EXTENSION HELPER FUNCTIONS (Phase 3)
 // ==============================================================================
-
 
 /**
  * Get the last year's salary from a player's current contract.
@@ -459,7 +459,6 @@ export function validateExtensionTermsAndRaises({
  * @returns {{blocked: boolean, reason: string|null, violation: Object|null}}
  */
 
-
 /**
  * Validate a waive action
  *
@@ -491,12 +490,35 @@ export function validateExtension({
   player,
   extension,
   year,
+  asOfDate,
 }: ValidateExtensionParams): MutationValidationResult {
   const violations: CapLegalityViolation[] = [];
   const warnings: CapLegalityViolation[] = [];
 
   const capSettings = getCapSettings(year);
   const contract = player.contract;
+  const offerSheetRestriction = inspectGovernedOfferSheetMatchRestriction(
+    contract?.offerSheetMatchRestriction,
+    asOfDate
+  );
+
+  if (offerSheetRestriction.status === 'active') {
+    violations.push({
+      rule: 'offer_sheet_match_amendment_restricted',
+      message: `A contract matched from an Offer Sheet cannot be amended before ${offerSheetRestriction.restriction.restrictedUntil}.`,
+      severity: 'error',
+    });
+  } else if (
+    offerSheetRestriction.status === 'incompatible' ||
+    offerSheetRestriction.status === 'needs-input'
+  ) {
+    violations.push({
+      rule: 'offer_sheet_match_restriction_unresolved',
+      message:
+        'The matched Offer Sheet restriction cannot be certified for this extension.',
+      severity: 'error',
+    });
+  }
 
   // 0. PHASE 3: Check for two-way contracts (cannot be extended)
   const isTwoWay = getNormalizedContractType(contract) === 'two-way';

--- a/src/features/architect/utils/capLegalityValidation/schema.ts
+++ b/src/features/architect/utils/capLegalityValidation/schema.ts
@@ -165,6 +165,7 @@ export type ValidateExtensionParams = {
   player: MutationPlayer;
   extension: MutationContract | null | undefined;
   year: number;
+  asOfDate?: string;
 };
 
 export type ValidateRenounceRightsParams = {

--- a/src/features/architect/utils/capLegalityValidation/signing.offerSheetResolution.ts
+++ b/src/features/architect/utils/capLegalityValidation/signing.offerSheetResolution.ts
@@ -9,21 +9,21 @@
 import type { ArchitectMutationOfferSheet } from '@/features/architect/utils/mutationPipeline';
 import type { CapLegalityViolation } from './schema';
 import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
-import {
-  isZonedDateTime,
-  parseZonedDateTime,
-} from '@/features/architect/utils/governedSeason';
+import { parseZonedDateTime } from '@/features/architect/utils/governedSeason';
+import { isEasternInstant } from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
 
 export function validateOfferSheetResolution({
   offerSheet,
   actingTeamCode,
   action,
   asOfDate,
+  resolutionAt,
 }: {
   offerSheet: ArchitectMutationOfferSheet | null | undefined;
   actingTeamCode: string;
   action: string;
   asOfDate?: string;
+  resolutionAt?: string;
 }) {
   const violations: CapLegalityViolation[] = [];
   const warnings: CapLegalityViolation[] = [];
@@ -96,14 +96,14 @@ export function validateOfferSheetResolution({
           message: 'The Offer Sheet notice lifecycle is unreadable.',
           severity: 'error',
         });
-      } else if (!isZonedDateTime(asOfDate)) {
+      } else if (!isEasternInstant(resolutionAt)) {
         violations.push({
           rule: 'offer_sheet_resolution_instant_required',
-          message: 'Matching requires an exact resolution instant with UTC offset.',
+          message: 'Matching requires an exact Eastern resolution instant.',
           severity: 'error',
         });
       } else if (
-        (parseZonedDateTime(asOfDate) as number) >
+        (parseZonedDateTime(resolutionAt) as number) >
         (parseZonedDateTime(root.exerciseNoticeDeadline) as number)
       ) {
         violations.push({

--- a/src/features/architect/utils/capLegalityValidation/signing.offerSheetResolution.ts
+++ b/src/features/architect/utils/capLegalityValidation/signing.offerSheetResolution.ts
@@ -8,6 +8,11 @@
 
 import type { ArchitectMutationOfferSheet } from '@/features/architect/utils/mutationPipeline';
 import type { CapLegalityViolation } from './schema';
+import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
+import {
+  isZonedDateTime,
+  parseZonedDateTime,
+} from '@/features/architect/utils/governedSeason';
 
 export function validateOfferSheetResolution({
   offerSheet,
@@ -77,8 +82,37 @@ export function validateOfferSheetResolution({
       });
     }
 
-    // Phase 21: Check 48-hour window (blocking violation — late match is not allowed)
-    if (action === 'match' && asOfDate && offerSheet?.createdAt) {
+    // BZE-283: the certified notice event owns the exact deadline. Legacy
+    // ungoverned records keep their prior compatibility check, but they cannot
+    // reach the governed mutation compute path.
+    if (action === 'match' && offerSheet?.governedLifecycle !== undefined) {
+      const lifecycle = GovernedOfferSheetLifecycleZ.safeParse(
+        offerSheet.governedLifecycle
+      );
+      const root = lifecycle.success ? lifecycle.data.events[0] : null;
+      if (!lifecycle.success || root?.eventKind !== 'offer-sheet-signed') {
+        violations.push({
+          rule: 'offer_sheet_governed_lifecycle_incompatible',
+          message: 'The Offer Sheet notice lifecycle is unreadable.',
+          severity: 'error',
+        });
+      } else if (!isZonedDateTime(asOfDate)) {
+        violations.push({
+          rule: 'offer_sheet_resolution_instant_required',
+          message: 'Matching requires an exact resolution instant with UTC offset.',
+          severity: 'error',
+        });
+      } else if (
+        (parseZonedDateTime(asOfDate) as number) >
+        (parseZonedDateTime(root.exerciseNoticeDeadline) as number)
+      ) {
+        violations.push({
+          rule: 'offer_sheet_window_expired',
+          message: `Exercise Notice deadline expired at ${root.exerciseNoticeDeadline}.`,
+          severity: 'error',
+        });
+      }
+    } else if (action === 'match' && asOfDate && offerSheet?.createdAt) {
       const created = new Date(offerSheet.createdAt);
       const deadline = new Date(created.getTime() + 48 * 60 * 60 * 1000);
       const cutoff = deadline.toISOString().slice(0, 10);

--- a/src/features/architect/utils/capTotals/computeTeamCapTotals.ts
+++ b/src/features/architect/utils/capTotals/computeTeamCapTotals.ts
@@ -42,6 +42,7 @@ import {
 import { resolveHardCapSnapshotOverlay } from '@/features/architect/utils/capTotals/hardCapSnapshotOverlay';
 import { toEndYear, toSeasonKey } from '@/features/architect/utils/seasonFormat';
 import type { TeamTotals } from '@/features/architect/types';
+import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -72,6 +73,7 @@ export interface ComputedTeamCapTotals extends UnknownRecord {
   deadMoneyTotal: number;
   capHoldsTotal: number;
   incompleteChargesTotal: number;
+  outstandingOfferSheetTotal?: number;
   totalCapAllocations: number;
   salaryCap: number;
   luxuryTax: number;
@@ -170,6 +172,7 @@ export type TeamCapTotalsSnapshot =
 export interface TeamCapSheetLike extends TeamDeadMoneySourcesLike {
   players?: unknown[] | null;
   capHolds?: unknown[] | null;
+  offerSheets?: unknown[] | null;
   totals?: TeamCapTotalsSnapshot | UnknownRecord | null;
   hardCapLevel?: unknown;
   hardCapDetail?: unknown;
@@ -183,6 +186,7 @@ interface CanonicalCapTotalsInputs {
   deadMoneyTotal: number;
   capHoldsTotal: number;
   incompleteChargesTotal: number;
+  outstandingOfferSheetTotal: number;
 }
 
 const num = (v: unknown): number => {
@@ -231,8 +235,25 @@ function computeCanonicalTotalCapAllocations({
   deadMoneyTotal,
   capHoldsTotal,
   incompleteChargesTotal,
+  outstandingOfferSheetTotal,
 }: CanonicalCapTotalsInputs): number {
-  return playersTotal + deadMoneyTotal + capHoldsTotal + incompleteChargesTotal;
+  return playersTotal + deadMoneyTotal + capHoldsTotal + incompleteChargesTotal + outstandingOfferSheetTotal;
+}
+
+function computeOutstandingOfferSheetTotal(
+  offerSheets: unknown[] | null | undefined,
+  season: string
+): number {
+  if (!Array.isArray(offerSheets)) return 0;
+  return offerSheets.reduce<number>((sum, value) => {
+    const record = asRecord(value);
+    if (record?.status !== 'PENDING_MATCH') return sum;
+    const lifecycle = GovernedOfferSheetLifecycleZ.safeParse(
+      record.governedLifecycle
+    );
+    if (!lifecycle.success || lifecycle.data.status !== 'pending-match') return sum;
+    return sum + (lifecycle.data.reservations.offeringTeam.find((row) => row.season === season)?.amount ?? 0);
+  }, 0);
 }
 
 /**
@@ -276,12 +297,17 @@ export function computeTeamCapTotals(
   const missingSlots = Math.max(0, minRoster - standardRosterCount);
   const chargePerSlot = rules.salaries.rookieMin;
   const incompleteChargesTotal = missingSlots * chargePerSlot;
+  const outstandingOfferSheetTotal = computeOutstandingOfferSheetTotal(
+    teamCapSheet?.offerSheets,
+    toSeasonKey(yearKey)
+  );
 
   const totalCapAllocations = computeCanonicalTotalCapAllocations({
     playersTotal,
     deadMoneyTotal,
     capHoldsTotal,
     incompleteChargesTotal,
+    outstandingOfferSheetTotal,
   });
 
   const deltas = {
@@ -297,6 +323,7 @@ export function computeTeamCapTotals(
     deadMoneyTotal,
     capHoldsTotal,
     incompleteChargesTotal,
+    outstandingOfferSheetTotal,
     totalCapAllocations,
     salaryCap,
     luxuryTax,

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
@@ -171,10 +171,12 @@ export function computeStoreOfferSheetResult({
     return {
       success: false,
       error: governed.reasons.join(' '),
-      warnings: [{
-        status: governed.status,
-        reasons: governed.reasons,
-      }],
+      warnings: [
+        {
+          status: governed.status,
+          reasons: governed.reasons,
+        },
+      ],
     };
   }
   const createdAt = governed.receivedAt;
@@ -320,7 +322,8 @@ export function computeMatchOfferSheetResult({
     currentState,
     seasonId,
     timestamp,
-    resolutionAt: asOfDate,
+    resolutionAt: payload.offerSheetResolutionAt,
+    worldAsOfDate: asOfDate,
     acceptedStatuses: ['PENDING_MATCH'],
     metadataType: 'matchOfferSheet',
   });
@@ -347,7 +350,8 @@ export function computeDeclineOfferSheetResult({
     currentState,
     seasonId,
     timestamp,
-    resolutionAt: asOfDate,
+    resolutionAt: payload.offerSheetResolutionAt,
+    worldAsOfDate: asOfDate,
     acceptedStatuses: ['PENDING_MATCH'],
     metadataType: 'declineOfferSheet',
   });

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
@@ -9,9 +9,11 @@
 import {
   findPlayerInTeamPlayers,
   getTeamSourceRecord,
+  synchronizeTeamTotalsSnapshotOrTeam,
 } from './mutationPipeline.helpers';
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
 import { normalizeSalaryRow } from '@/features/architect/utils/contractNormalization';
+import { createGovernedOfferSheetLifecycle } from '@/features/architect/utils/offerSheets';
 import {
   computeMatchedOfferSheetOutcome,
   computeDeclinedOfferSheetOutcome,
@@ -25,25 +27,6 @@ import type {
   MutationPayloadInputByType,
   NormalizedMutationSalaryRow,
 } from './mutationPipeline';
-
-const ISO_DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-
-function buildOfferSheetCreatedAt({
-  asOfDate,
-  timestamp,
-}: {
-  asOfDate?: string | number | null;
-  timestamp: number;
-}): string {
-  const dateOnly =
-    typeof asOfDate === 'string' && ISO_DATE_ONLY_PATTERN.test(asOfDate.trim())
-      ? asOfDate.trim()
-      : null;
-
-  return dateOnly
-    ? `${dateOnly}T00:00:00.000Z`
-    : new Date(timestamp).toISOString();
-}
 
 function hasActiveUnsignedCapHoldRights(
   team: MutationOfferSheetTeamAndPlayerCurrentState['homeTeam'],
@@ -116,6 +99,12 @@ export function computeStoreOfferSheetResult({
         'storeOfferSheet requires contract terms before offer-sheet creation.',
     };
   }
+  if (!currentYear) {
+    return {
+      success: false,
+      error: 'storeOfferSheet requires a valid Salary Cap Year.',
+    };
+  }
 
   // Validate store-only invariants programmatically just in case
   if (contract.rfaOfferSheetOnly !== true || contract.rfaOfferSheet !== true) {
@@ -167,7 +156,28 @@ export function computeStoreOfferSheetResult({
   // Generate unique ID (includes timestamp for uniqueness, but NOT used for dedup)
   const offerSheetId =
     payload.offerSheetId || `os_${teamCode}_${playerId}_${timestamp}`;
-  const createdAt = buildOfferSheetCreatedAt({ asOfDate, timestamp });
+  const governed = createGovernedOfferSheetLifecycle({
+    state: currentState,
+    contract,
+    proposalInput: payload.offerSheetProposal,
+    worldId,
+    salaryCapYear: currentYear,
+    worldAsOfDate: asOfDate,
+    timestamp,
+    offerSheetId,
+    dedupKey,
+  });
+  if (!governed.success) {
+    return {
+      success: false,
+      error: governed.reasons.join(' '),
+      warnings: [{
+        status: governed.status,
+        reasons: governed.reasons,
+      }],
+    };
+  }
+  const createdAt = governed.receivedAt;
 
   // Build canonical OfferSheet object
   const offerSheet: ArchitectMutationOfferSheet = {
@@ -187,6 +197,7 @@ export function computeStoreOfferSheetResult({
     status: 'PENDING_MATCH',
     createdAt,
     totalValue: contract.totalValue,
+    governedLifecycle: governed.lifecycle,
   };
 
   const updatedOfferingTeam = { ...offeringTeam };
@@ -220,6 +231,10 @@ export function computeStoreOfferSheetResult({
       offerSheet,
     ];
   }
+  updatedOfferingTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
+    updatedOfferingTeam,
+    currentYear
+  ).totals;
 
   // Update source metadata
   updatedOfferingTeam.source = {
@@ -278,6 +293,7 @@ export function computeStoreOfferSheetResult({
       playerId: offerSheet.playerId,
       offerSheetId: offerSheet.id,
       dedupKey, // Phase 18.1: Include for traceability
+      governedOfferSheetLifecycle: governed.lifecycle,
       timestamp,
     },
   };
@@ -294,15 +310,17 @@ export function computeMatchOfferSheetResult({
   currentState,
   seasonId,
   timestamp,
+  asOfDate,
 }: ComputeMutationParamsWithCurrentState<
   MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['matchOfferSheet']
->): ComputeResultLike {
+> & { asOfDate?: string | number | null }): ComputeResultLike {
   return computeMatchedOfferSheetOutcome({
     payload,
     currentState,
     seasonId,
     timestamp,
+    resolutionAt: asOfDate,
     acceptedStatuses: ['PENDING_MATCH'],
     metadataType: 'matchOfferSheet',
   });
@@ -319,15 +337,17 @@ export function computeDeclineOfferSheetResult({
   currentState,
   seasonId,
   timestamp,
+  asOfDate,
 }: ComputeMutationParamsWithCurrentState<
   MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['declineOfferSheet']
->): ComputeResultLike {
+> & { asOfDate?: string | number | null }): ComputeResultLike {
   return computeDeclinedOfferSheetOutcome({
     payload,
     currentState,
     seasonId,
     timestamp,
+    resolutionAt: asOfDate,
     acceptedStatuses: ['PENDING_MATCH'],
     metadataType: 'declineOfferSheet',
   });

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.initial.ts
@@ -296,6 +296,8 @@ export function computeStoreOfferSheetResult({
       offerSheetId: offerSheet.id,
       dedupKey, // Phase 18.1: Include for traceability
       governedOfferSheetLifecycle: governed.lifecycle,
+      expectedOfferSheetCreationSnapshots:
+        currentState.offerSheetCreationSnapshots,
       timestamp,
     },
   };

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
@@ -26,7 +26,10 @@ import {
   synchronizeTeamTotalsSnapshotOrTeam,
 } from './mutationPipeline.helpers';
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
-import { resolveGovernedOfferSheetLifecycle } from '@/features/architect/utils/offerSheets';
+import {
+  governedOfferSheetBonusTotal,
+  resolveGovernedOfferSheetLifecycle,
+} from '@/features/architect/utils/offerSheets';
 import type { GovernedOfferSheetLifecycle } from '@/schemas/governedOfferSheet';
 import {
   matchesOfferSheetIdentity,
@@ -42,12 +45,16 @@ import type {
 export type OfferSheetOutcomeParams = {
   payload: {
     dedupKey?: string | null;
-    offerSheetAveragingElection?: import('@/schemas/governedOfferSheet').GovernedOfferSheetAveragingElection | null;
+    offerSheetAveragingElection?:
+      | import('@/schemas/governedOfferSheet').GovernedOfferSheetAveragingElection
+      | null;
+    offerSheetResolutionAt?: string | number | null;
   };
   currentState: MutationOfferSheetResolutionCurrentState;
   seasonId: string;
   timestamp: number;
   resolutionAt?: string | number | null;
+  worldAsOfDate?: string | number | null;
   /** Prior offer-sheet statuses this outcome is allowed to run from. */
   acceptedStatuses: readonly string[];
   /** Mutation type recorded in result metadata (drives history/receipt routing). */
@@ -63,19 +70,37 @@ function offerSheetForAccounting(
   lifecycle: GovernedOfferSheetLifecycle,
   side: 'home' | 'offering'
 ) {
+  const signedEvent = lifecycle.events.find(
+    (event) => event.eventKind === 'offer-sheet-signed'
+  );
+  if (!signedEvent) return offerSheet;
   const useAverage =
     side === 'offering' ||
     lifecycle.reservations.homeTeamAccounting === 'average-annual-salary';
-  if (!useAverage || !offerSheet) return offerSheet;
+  const averageBySeason = new Map(
+    lifecycle.reservations.offeringTeam.map((row) => [row.season, row.amount])
+  );
   return {
     ...offerSheet,
-    salariesByYear: lifecycle.reservations.offeringTeam.map((row) => ({
-      season: row.season,
-      salary: row.amount,
-      capHit: row.amount,
-      guaranteed: true,
-      guaranteedAmount: row.amount,
-    })),
+    salariesByYear: signedEvent.proposal.salariesByYear.map((row) => {
+      const likely = governedOfferSheetBonusTotal(row, 'likely');
+      const unlikely = governedOfferSheetBonusTotal(row, 'unlikely');
+      return {
+        season: row.season,
+        salary: row.regularSalary,
+        capHit: useAverage
+          ? (averageBySeason.get(row.season) ?? row.regularSalary)
+          : row.regularSalary,
+        guaranteed:
+          row.guaranteedForLackOfSkill &&
+          row.guaranteedForInjuryOrIllness &&
+          !row.individuallyNegotiatedProtectionConditions,
+        option: row.option,
+        ...(likely > 0 || unlikely > 0
+          ? { incentives: { likely, unlikely } }
+          : {}),
+      };
+    }),
   };
 }
 
@@ -89,6 +114,7 @@ export function computeMatchedOfferSheetOutcome({
   seasonId,
   timestamp,
   resolutionAt,
+  worldAsOfDate,
   acceptedStatuses,
   metadataType,
 }: OfferSheetOutcomeParams): ComputeResultLike {
@@ -124,6 +150,7 @@ export function computeMatchedOfferSheetOutcome({
     state: currentState,
     action: 'match',
     resolutionAt,
+    worldAsOfDate,
     averagingElectionInput: payload.offerSheetAveragingElection,
     timestamp,
   });
@@ -157,6 +184,7 @@ export function computeMatchedOfferSheetOutcome({
     signedUsing: 'Match',
     timestamp,
     signingDate: governed.lifecycle.events.at(-1)?.executedAt,
+    governedLifecycle: governed.lifecycle,
   });
   if (!normalizedContract) {
     return {
@@ -270,6 +298,7 @@ export function computeDeclinedOfferSheetOutcome({
   seasonId,
   timestamp,
   resolutionAt,
+  worldAsOfDate,
   acceptedStatuses,
   metadataType,
 }: OfferSheetOutcomeParams): ComputeResultLike {
@@ -303,6 +332,7 @@ export function computeDeclinedOfferSheetOutcome({
     state: currentState,
     action: 'decline',
     resolutionAt,
+    worldAsOfDate,
     averagingElectionInput: payload.offerSheetAveragingElection,
     timestamp,
   });
@@ -327,7 +357,11 @@ export function computeDeclinedOfferSheetOutcome({
   }
 
   const normalizedContract = buildNormalizedOfferSheetFinalContract({
-    offerSheet: offerSheetForAccounting(offerSheet, governed.lifecycle, 'offering'),
+    offerSheet: offerSheetForAccounting(
+      offerSheet,
+      governed.lifecycle,
+      'offering'
+    ),
     signingTeam: offeringTeam.teamCode || '',
     signedUsing: 'Offer Sheet',
     timestamp,

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
@@ -26,21 +26,28 @@ import {
   synchronizeTeamTotalsSnapshotOrTeam,
 } from './mutationPipeline.helpers';
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
+import { resolveGovernedOfferSheetLifecycle } from '@/features/architect/utils/offerSheets';
+import type { GovernedOfferSheetLifecycle } from '@/schemas/governedOfferSheet';
 import {
   matchesOfferSheetIdentity,
   buildNormalizedOfferSheetFinalContract,
   removeOfferSheetEntries,
 } from './mutationPipeline.read';
 import type {
+  ArchitectMutationOfferSheet,
   ComputeResultLike,
   MutationOfferSheetResolutionCurrentState,
 } from './mutationPipeline';
 
 export type OfferSheetOutcomeParams = {
-  payload: { dedupKey?: string | null };
+  payload: {
+    dedupKey?: string | null;
+    offerSheetAveragingElection?: import('@/schemas/governedOfferSheet').GovernedOfferSheetAveragingElection | null;
+  };
   currentState: MutationOfferSheetResolutionCurrentState;
   seasonId: string;
   timestamp: number;
+  resolutionAt?: string | number | null;
   /** Prior offer-sheet statuses this outcome is allowed to run from. */
   acceptedStatuses: readonly string[];
   /** Mutation type recorded in result metadata (drives history/receipt routing). */
@@ -49,6 +56,27 @@ export type OfferSheetOutcomeParams = {
 
 function formatAcceptedStatuses(acceptedStatuses: readonly string[]): string {
   return acceptedStatuses.join(' or ');
+}
+
+function offerSheetForAccounting(
+  offerSheet: ArchitectMutationOfferSheet,
+  lifecycle: GovernedOfferSheetLifecycle,
+  side: 'home' | 'offering'
+) {
+  const useAverage =
+    side === 'offering' ||
+    lifecycle.reservations.homeTeamAccounting === 'average-annual-salary';
+  if (!useAverage || !offerSheet) return offerSheet;
+  return {
+    ...offerSheet,
+    salariesByYear: lifecycle.reservations.offeringTeam.map((row) => ({
+      season: row.season,
+      salary: row.amount,
+      capHit: row.amount,
+      guaranteed: true,
+      guaranteedAmount: row.amount,
+    })),
+  };
 }
 
 /**
@@ -60,6 +88,7 @@ export function computeMatchedOfferSheetOutcome({
   currentState,
   seasonId,
   timestamp,
+  resolutionAt,
   acceptedStatuses,
   metadataType,
 }: OfferSheetOutcomeParams): ComputeResultLike {
@@ -91,6 +120,17 @@ export function computeMatchedOfferSheetOutcome({
     };
   }
 
+  const governed = resolveGovernedOfferSheetLifecycle({
+    state: currentState,
+    action: 'match',
+    resolutionAt,
+    averagingElectionInput: payload.offerSheetAveragingElection,
+    timestamp,
+  });
+  if (!governed.success) {
+    return { success: false, error: governed.reasons.join(' ') };
+  }
+
   const playerId = String(offerSheet.playerId || '').trim();
   if (!playerId) {
     return {
@@ -112,10 +152,11 @@ export function computeMatchedOfferSheetOutcome({
   }
 
   const normalizedContract = buildNormalizedOfferSheetFinalContract({
-    offerSheet,
+    offerSheet: offerSheetForAccounting(offerSheet, governed.lifecycle, 'home'),
     signingTeam: homeTeam.teamCode || '',
     signedUsing: 'Match',
     timestamp,
+    signingDate: governed.lifecycle.events.at(-1)?.executedAt,
   });
   if (!normalizedContract) {
     return {
@@ -212,6 +253,7 @@ export function computeMatchedOfferSheetOutcome({
       playerName: updatedPlayer.displayName || updatedPlayer.name,
       signedUsing: 'Match',
       contract: normalizedContract,
+      governedOfferSheetLifecycle: governed.lifecycle,
       timestamp,
     },
   };
@@ -227,6 +269,7 @@ export function computeDeclinedOfferSheetOutcome({
   currentState,
   seasonId,
   timestamp,
+  resolutionAt,
   acceptedStatuses,
   metadataType,
 }: OfferSheetOutcomeParams): ComputeResultLike {
@@ -256,6 +299,17 @@ export function computeDeclinedOfferSheetOutcome({
     };
   }
 
+  const governed = resolveGovernedOfferSheetLifecycle({
+    state: currentState,
+    action: 'decline',
+    resolutionAt,
+    averagingElectionInput: payload.offerSheetAveragingElection,
+    timestamp,
+  });
+  if (!governed.success) {
+    return { success: false, error: governed.reasons.join(' ') };
+  }
+
   const playerId = String(offerSheet.playerId || '').trim();
   if (!playerId) {
     return {
@@ -273,10 +327,11 @@ export function computeDeclinedOfferSheetOutcome({
   }
 
   const normalizedContract = buildNormalizedOfferSheetFinalContract({
-    offerSheet,
+    offerSheet: offerSheetForAccounting(offerSheet, governed.lifecycle, 'offering'),
     signingTeam: offeringTeam.teamCode || '',
     signedUsing: 'Offer Sheet',
     timestamp,
+    signingDate: governed.lifecycle.events.at(-1)?.executedAt,
   });
   if (!normalizedContract) {
     return {
@@ -405,6 +460,7 @@ export function computeDeclinedOfferSheetOutcome({
       playerName: updatedPlayer.displayName || updatedPlayer.name,
       signedUsing: 'Offer Sheet',
       contract: normalizedContract,
+      governedOfferSheetLifecycle: governed.lifecycle,
       timestamp,
     },
   };

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
@@ -279,6 +279,7 @@ export function computeMatchedOfferSheetOutcome({
     metadata: {
       type: metadataType,
       offerSheetId,
+      dedupKey: resolvedDedupKey,
       playerId,
       homeTeam: homeTeam.teamCode,
       offeringTeam: offeringTeam.teamCode,
@@ -287,6 +288,7 @@ export function computeMatchedOfferSheetOutcome({
       signedUsing: 'Match',
       contract: normalizedContract,
       governedOfferSheetLifecycle: governed.lifecycle,
+      expectedGovernedOfferSheetLifecycle: governed.expectedLifecycle,
       timestamp,
     },
   };
@@ -493,6 +495,7 @@ export function computeDeclinedOfferSheetOutcome({
     metadata: {
       type: metadataType,
       offerSheetId,
+      dedupKey: resolvedDedupKey,
       playerId,
       offeringTeam: offeringTeam.teamCode,
       homeTeam: homeTeam.teamCode,
@@ -501,6 +504,7 @@ export function computeDeclinedOfferSheetOutcome({
       signedUsing: 'Offer Sheet',
       contract: normalizedContract,
       governedOfferSheetLifecycle: governed.lifecycle,
+      expectedGovernedOfferSheetLifecycle: governed.expectedLifecycle,
       timestamp,
     },
   };

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
@@ -289,6 +289,8 @@ export function computeMatchedOfferSheetOutcome({
       contract: normalizedContract,
       governedOfferSheetLifecycle: governed.lifecycle,
       expectedGovernedOfferSheetLifecycle: governed.expectedLifecycle,
+      expectedOfferSheetResolutionSnapshots:
+        currentState.offerSheetResolutionSnapshots,
       timestamp,
     },
   };
@@ -505,6 +507,8 @@ export function computeDeclinedOfferSheetOutcome({
       contract: normalizedContract,
       governedOfferSheetLifecycle: governed.lifecycle,
       expectedGovernedOfferSheetLifecycle: governed.expectedLifecycle,
+      expectedOfferSheetResolutionSnapshots:
+        currentState.offerSheetResolutionSnapshots,
       timestamp,
     },
   };

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.outcome.ts
@@ -149,6 +149,7 @@ export function computeMatchedOfferSheetOutcome({
   const governed = resolveGovernedOfferSheetLifecycle({
     state: currentState,
     action: 'match',
+    dedupKey: requestedDedupKey,
     resolutionAt,
     worldAsOfDate,
     averagingElectionInput: payload.offerSheetAveragingElection,
@@ -238,6 +239,10 @@ export function computeMatchedOfferSheetOutcome({
     offerSheetId || '',
     resolvedDedupKey
   );
+  updatedOfferingTeam.totals = synchronizeTeamTotalsSnapshotOrTeam(
+    updatedOfferingTeam,
+    toEndYear(seasonId)
+  ).totals;
   updatedOfferingTeam.source = {
     ...getTeamSourceRecord(updatedOfferingTeam.source),
     type: 'world-snapshot',
@@ -331,6 +336,7 @@ export function computeDeclinedOfferSheetOutcome({
   const governed = resolveGovernedOfferSheetLifecycle({
     state: currentState,
     action: 'decline',
+    dedupKey,
     resolutionAt,
     worldAsOfDate,
     averagingElectionInput: payload.offerSheetAveragingElection,

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.ts
@@ -46,7 +46,8 @@ export function computeFinalizeMatchedOfferSheetResult({
     currentState,
     seasonId,
     timestamp,
-    resolutionAt: asOfDate,
+    resolutionAt: payload.offerSheetResolutionAt,
+    worldAsOfDate: asOfDate,
     acceptedStatuses: ['MATCHED'],
     metadataType: 'finalizeMatchedOfferSheet',
   });
@@ -73,7 +74,8 @@ export function computeFinalizeDeclinedOfferSheetResult({
     currentState,
     seasonId,
     timestamp,
-    resolutionAt: asOfDate,
+    resolutionAt: payload.offerSheetResolutionAt,
+    worldAsOfDate: asOfDate,
     acceptedStatuses: ['DECLINED'],
     metadataType: 'finalizeDeclinedOfferSheet',
   });

--- a/src/features/architect/utils/mutationPipeline.compute.offerSheets.ts
+++ b/src/features/architect/utils/mutationPipeline.compute.offerSheets.ts
@@ -36,15 +36,17 @@ export function computeFinalizeMatchedOfferSheetResult({
   currentState,
   seasonId,
   timestamp,
+  asOfDate,
 }: ComputeMutationParamsWithCurrentState<
   MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['finalizeMatchedOfferSheet']
->): ComputeResultLike {
+> & { asOfDate?: string | number | null }): ComputeResultLike {
   return computeMatchedOfferSheetOutcome({
     payload,
     currentState,
     seasonId,
     timestamp,
+    resolutionAt: asOfDate,
     acceptedStatuses: ['MATCHED'],
     metadataType: 'finalizeMatchedOfferSheet',
   });
@@ -61,15 +63,17 @@ export function computeFinalizeDeclinedOfferSheetResult({
   currentState,
   seasonId,
   timestamp,
+  asOfDate,
 }: ComputeMutationParamsWithCurrentState<
   MutationOfferSheetResolutionCurrentState,
   MutationPayloadInputByType['finalizeDeclinedOfferSheet']
->): ComputeResultLike {
+> & { asOfDate?: string | number | null }): ComputeResultLike {
   return computeDeclinedOfferSheetOutcome({
     payload,
     currentState,
     seasonId,
     timestamp,
+    resolutionAt: asOfDate,
     acceptedStatuses: ['DECLINED'],
     metadataType: 'finalizeDeclinedOfferSheet',
   });

--- a/src/features/architect/utils/mutationPipeline.helpers.playerNorm.contract.ts
+++ b/src/features/architect/utils/mutationPipeline.helpers.playerNorm.contract.ts
@@ -155,6 +155,7 @@ export function projectCurrentStatePlayerContractIngress(
   const tradeEligibility = normalizeCurrentStatePlayerContractTradeEligibility(
     contractRecord.tradeEligibility
   );
+  const offerSheetMatchRestriction = contractRecord.offerSheetMatchRestriction;
 
   if (salariesByYear !== undefined) {
     projected.salariesByYear = salariesByYear;
@@ -266,6 +267,12 @@ export function projectCurrentStatePlayerContractIngress(
   }
   if (includeCurrentOnlyContractFields && tradeEligibility !== undefined) {
     projected.tradeEligibility = tradeEligibility;
+  }
+  if (
+    includeCurrentOnlyContractFields &&
+    offerSheetMatchRestriction !== undefined
+  ) {
+    projected.offerSheetMatchRestriction = offerSheetMatchRestriction;
   }
 
   return Object.keys(projected).length > 0 ? projected : undefined;

--- a/src/features/architect/utils/mutationPipeline.helpers.playerNorm.ts
+++ b/src/features/architect/utils/mutationPipeline.helpers.playerNorm.ts
@@ -84,6 +84,7 @@ export function normalizeCurrentStatePlayerRfaContext(
   const retainedUntilFinalize = toOptionalBoolean(
     context.retainedUntilFinalize
   );
+  const governedEvidence = context.governedEvidence;
 
   if (pendingHomeTeamCode !== undefined) {
     normalized.pendingHomeTeamCode = pendingHomeTeamCode;
@@ -93,6 +94,13 @@ export function normalizeCurrentStatePlayerRfaContext(
   }
   if (retainedUntilFinalize !== undefined) {
     normalized.retainedUntilFinalize = retainedUntilFinalize;
+  }
+  if (governedEvidence !== undefined) {
+    try {
+      normalized.governedEvidence = JSON.parse(JSON.stringify(governedEvidence));
+    } catch {
+      normalized.governedEvidence = governedEvidence;
+    }
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;

--- a/src/features/architect/utils/mutationPipeline.helpers.ts
+++ b/src/features/architect/utils/mutationPipeline.helpers.ts
@@ -6,12 +6,8 @@
  * OWNERSHIP: Feature: architect/core
  */
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
-import {
-  synchronizeTeamTotalsSnapshot,
-} from '@/features/architect/utils/capTotals/computeTeamCapTotals';
-import {
-  normalizeCanonicalTeamExceptions,
-} from '@/features/architect/utils/exceptions/exceptionOwnership';
+import { synchronizeTeamTotalsSnapshot } from '@/features/architect/utils/capTotals/computeTeamCapTotals';
+import { normalizeCanonicalTeamExceptions } from '@/features/architect/utils/exceptions/exceptionOwnership';
 
 // Type-only imports from the pipeline (safe: import type is erased at runtime — no circular dep at runtime)
 import type {
@@ -58,9 +54,36 @@ export const CURRENT_STATE_BASE_TEAM_ENTITLEMENT_IDS_FIELD_KEY = `${CURRENT_STAT
 // ==============================================================================
 
 export const AUTHORITATIVE_WORLD_TEAM_CODES = [
-  'ATL', 'BOS', 'BKN', 'CHA', 'CHI', 'CLE', 'DAL', 'DEN', 'DET', 'GSW',
-  'HOU', 'IND', 'LAC', 'LAL', 'MEM', 'MIA', 'MIL', 'MIN', 'NOP', 'NYK',
-  'OKC', 'ORL', 'PHI', 'PHX', 'POR', 'SAC', 'SAS', 'TOR', 'UTA', 'WAS',
+  'ATL',
+  'BOS',
+  'BKN',
+  'CHA',
+  'CHI',
+  'CLE',
+  'DAL',
+  'DEN',
+  'DET',
+  'GSW',
+  'HOU',
+  'IND',
+  'LAC',
+  'LAL',
+  'MEM',
+  'MIA',
+  'MIL',
+  'MIN',
+  'NOP',
+  'NYK',
+  'OKC',
+  'ORL',
+  'PHI',
+  'PHX',
+  'POR',
+  'SAC',
+  'SAS',
+  'TOR',
+  'UTA',
+  'WAS',
 ] as const;
 
 export const CURRENT_STATE_PLAYER_CONTRACT_KEYS = [
@@ -98,6 +121,7 @@ export const CURRENT_STATE_PLAYER_CONTRACT_KEYS = [
   'tradeKicker',
   'tradeRestrictions',
   'tradeEligibility',
+  'offerSheetMatchRestriction',
 ] as const;
 // These current-contract fields remain on the normalized player seam because
 // option/signing flows spread the existing contract before canonicalization and
@@ -124,7 +148,6 @@ export const CURRENT_STATE_PLAYER_FUTURE_CONTRACT_KEYS = [
   'tradeRestrictions',
 ] as const;
 
-
 // ==============================================================================
 // WRITES SUMMARY CONSTANT
 // ==============================================================================
@@ -145,7 +168,6 @@ export const EMPTY_WRITES_SUMMARY = Object.freeze({
   worldMetadataPatched: 0,
   worldStatsUpdated: false,
 }) as WritesSummaryLike;
-
 
 // Wave 22 Step 1: primitive coercions extracted to submodule
 export * from './mutationPipeline.helpers.primitives';
@@ -187,7 +209,6 @@ import {
 
 // Wave 22 Step 2: player persistence helpers extracted to submodule
 export * from './mutationPipeline.helpers.persistence';
-
 
 // ==============================================================================
 // LOCAL TYPES
@@ -233,7 +254,6 @@ type CurrentStateWithOfferSheetTeams<
   offeringTeam: NonNullable<TCurrentState['offeringTeam']>;
   offerSheetId: string;
 };
-
 
 // ==============================================================================
 // SHARED HELPERS (called from both READ and COMPUTE sections)
@@ -309,7 +329,6 @@ export function materializeCurrentStateBaseTeamPreservedFields<
   return materializedTeam;
 }
 
-
 export function toMutationExceptionPreserveOnlyBuckets(
   value: unknown
 ): MutationExceptionPreserveOnlyBuckets | null {
@@ -323,7 +342,6 @@ export function normalizeMutationExceptionsFromIngress(
     exceptions: toMutationExceptionPreserveOnlyBuckets(value) || null,
   });
 }
-
 
 export function getMutationRosterEntryId(entry: unknown) {
   if (!entry) {
@@ -350,8 +368,9 @@ export function getMutationRosterEntryId(entry: unknown) {
   return playerId || null;
 }
 
-
-export function requireBasicTeamState<TCurrentState extends { team?: unknown | null }>(
+export function requireBasicTeamState<
+  TCurrentState extends { team?: unknown | null },
+>(
   currentState: TCurrentState,
   mutationType: string
 ): CurrentStateWithBasicTeam<TCurrentState> {
@@ -402,7 +421,6 @@ export function requireSigningState<
   return currentState as CurrentStateWithSigningPair<TCurrentState>;
 }
 
-
 export function requireDestinationState(
   currentState: MutationSignAndTradeCurrentState,
   mutationType: string
@@ -442,7 +460,6 @@ export function requireOfferSheetTeamState<
   return currentState as CurrentStateWithOfferSheetTeams<TCurrentState>;
 }
 
-
 // Local boundary helper for the live team.source spread sites only.
 export function getTeamSourceRecord(
   source: TeamLike['source'] | null | undefined
@@ -459,7 +476,6 @@ export function getTeamSourceRecord(
   return {};
 }
 
-
 export function getSalaryRowEndYear(
   row: MutationPipelineSalaryRow | null | undefined
 ): number | null {
@@ -470,7 +486,6 @@ export function getSalaryRowEndYear(
 
   return toEndYear(row?.season) ?? null;
 }
-
 
 export function synchronizeTeamTotalsSnapshotOrTeam<
   T extends
@@ -483,7 +498,6 @@ export function synchronizeTeamTotalsSnapshotOrTeam<
 
   return (synchronizeTeamTotalsSnapshot(team, year) || team) as T;
 }
-
 
 export function cloneWritesSummary(
   summary: WritesSummaryLike = EMPTY_WRITES_SUMMARY

--- a/src/features/architect/utils/mutationPipeline.normalize.ts
+++ b/src/features/architect/utils/mutationPipeline.normalize.ts
@@ -111,10 +111,12 @@ const RENOUNCE_MUTATION_PAYLOAD_KEYS = [
 const STORE_OFFER_SHEET_MUTATION_PAYLOAD_KEYS = [
   'contract',
   'offerSheetId',
+  'offerSheetProposal',
   'worldId',
 ] as const satisfies readonly (keyof ArchitectMutationPayload)[];
 const OFFER_SHEET_RESOLUTION_MUTATION_PAYLOAD_KEYS = [
   'dedupKey',
+  'offerSheetAveragingElection',
 ] as const satisfies readonly (keyof ArchitectMutationPayload)[];
 const SIGN_AND_TRADE_MUTATION_PAYLOAD_KEYS = [
   'teamCode',
@@ -606,6 +608,7 @@ export function computeNormalizedWorldMutation(
             currentState: args.currentState,
             seasonId,
             timestamp,
+            asOfDate,
           })
         );
       }
@@ -617,6 +620,7 @@ export function computeNormalizedWorldMutation(
             currentState: args.currentState,
             seasonId,
             timestamp,
+            asOfDate,
           })
         );
       }
@@ -628,6 +632,7 @@ export function computeNormalizedWorldMutation(
             currentState: args.currentState,
             seasonId,
             timestamp,
+            asOfDate,
           })
         );
       }
@@ -639,6 +644,7 @@ export function computeNormalizedWorldMutation(
             currentState: args.currentState,
             seasonId,
             timestamp,
+            asOfDate,
           })
         );
       }

--- a/src/features/architect/utils/mutationPipeline.normalize.ts
+++ b/src/features/architect/utils/mutationPipeline.normalize.ts
@@ -4,9 +4,7 @@
  * (lines 221–652 and 1563–1751).
  */
 
-import {
-  buildTradeApplyPreparation,
-} from '@/features/architect/utils/tradeContext/tradeContext';
+import { buildTradeApplyPreparation } from '@/features/architect/utils/tradeContext/tradeContext';
 import {
   normalizeTradeMutationCurrentState,
   normalizeTeamOnlyMutationCurrentState,
@@ -117,6 +115,7 @@ const STORE_OFFER_SHEET_MUTATION_PAYLOAD_KEYS = [
 const OFFER_SHEET_RESOLUTION_MUTATION_PAYLOAD_KEYS = [
   'dedupKey',
   'offerSheetAveragingElection',
+  'offerSheetResolutionAt',
 ] as const satisfies readonly (keyof ArchitectMutationPayload)[];
 const SIGN_AND_TRADE_MUTATION_PAYLOAD_KEYS = [
   'teamCode',

--- a/src/features/architect/utils/mutationPipeline.persist.ts
+++ b/src/features/architect/utils/mutationPipeline.persist.ts
@@ -23,6 +23,8 @@ import {
   worldTeamRef,
   worldPlayerRef,
   worldMetadataRef,
+  worldOfferSheetAuthorizationRef,
+  basePlayerRef,
 } from '@/features/architect/utils/architectFirestorePaths';
 import {
   ARCHITECT_WORLDS_COLLECTION,
@@ -56,7 +58,12 @@ import { createRightsEventLedger } from '@/features/architect/utils/rightsHistor
 import { createContractEventLedger } from '@/features/architect/utils/contractHistory';
 import { contractOverlaySetDigest } from '@/features/architect/utils/optionDecisions/contractOverlaySetDigest';
 import { mutationSnapshotDigest } from './mutationPipeline.snapshotDigest';
-import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
+import {
+  GovernedOfferSheetAuthorizationZ,
+  GovernedOfferSheetEvidenceZ,
+  GovernedOfferSheetLifecycleZ,
+} from '@/schemas/governedOfferSheet';
+import { buildGovernedOfferSheetAuthorization } from '@/features/architect/utils/offerSheets';
 
 type ExpectedRightsLedgerReference = Readonly<{
   ledgerId: string;
@@ -68,6 +75,25 @@ type ExpectedLocalDocumentSnapshotReference = Readonly<{
   digest: string | null;
 }>;
 
+type ExpectedDocumentSnapshotReference =
+  ExpectedLocalDocumentSnapshotReference &
+    Readonly<{
+      sourceWorldId: string | null;
+      sourceDigest: string | null;
+      sourceLineage: readonly Readonly<{
+        worldId: string;
+        exists: boolean;
+        digest: string | null;
+      }>[];
+    }>;
+
+type ExpectedOfferSheetCreationSnapshots = Readonly<{
+  homeTeamCode: string;
+  offeringTeamCode: string;
+  homeTeam: ExpectedDocumentSnapshotReference;
+  offeringTeam: ExpectedDocumentSnapshotReference;
+}>;
+
 type ExpectedOfferSheetResolutionSnapshots = Readonly<{
   playerId: string;
   homeTeamCode: string;
@@ -76,6 +102,8 @@ type ExpectedOfferSheetResolutionSnapshots = Readonly<{
   offeringTeam: ExpectedLocalDocumentSnapshotReference;
   homePlayer: ExpectedLocalDocumentSnapshotReference;
   offeringPlayer: ExpectedLocalDocumentSnapshotReference;
+  authorization: ExpectedLocalDocumentSnapshotReference;
+  immutableEvidenceDigest: string;
 }>;
 
 type ExpectedGovernedOfferSheetLifecycleReference = Readonly<{
@@ -120,6 +148,103 @@ function isOfferSheetResolutionMutation(mutationType: string): boolean {
     mutationType === 'finalizeMatchedOfferSheet' ||
     mutationType === 'finalizeDeclinedOfferSheet'
   );
+}
+
+function requireDocumentSnapshotReference(
+  raw: unknown,
+  label: string
+): ExpectedDocumentSnapshotReference {
+  const receipt =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : null;
+  const local = requireLocalDocumentSnapshotReference(raw, label);
+  const sourceWorldId = receipt?.sourceWorldId;
+  const sourceDigest = receipt?.sourceDigest;
+  const sourceLineage = receipt?.sourceLineage;
+  if (
+    (sourceWorldId !== null &&
+      (typeof sourceWorldId !== 'string' || !sourceWorldId.trim())) ||
+    (sourceDigest !== null &&
+      (typeof sourceDigest !== 'string' || !sourceDigest.trim())) ||
+    !Array.isArray(sourceLineage)
+  ) {
+    throw new Error(
+      `Offer Sheet creation is missing the expected ${label} source receipt.`
+    );
+  }
+  return Object.freeze({
+    ...local,
+    sourceWorldId:
+      typeof sourceWorldId === 'string' ? sourceWorldId.trim() : null,
+    sourceDigest:
+      typeof sourceDigest === 'string' ? sourceDigest.trim() : null,
+    sourceLineage: Object.freeze(
+      sourceLineage.map((entry) => {
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+          throw new Error(
+            `Offer Sheet creation is missing the expected ${label} source receipt.`
+          );
+        }
+        const record = entry as Record<string, unknown>;
+        const worldId = String(record.worldId || '').trim();
+        const exists = record.exists;
+        const digest = record.digest;
+        if (
+          !worldId ||
+          typeof exists !== 'boolean' ||
+          (exists && (typeof digest !== 'string' || !digest.trim())) ||
+          (!exists && digest !== null)
+        ) {
+          throw new Error(
+            `Offer Sheet creation is missing the expected ${label} source receipt.`
+          );
+        }
+        return Object.freeze({
+          worldId,
+          exists,
+          digest: exists ? String(digest).trim() : null,
+        });
+      })
+    ),
+  });
+}
+
+function requireExpectedOfferSheetCreationSnapshots({
+  metadata,
+  lifecycle,
+}: {
+  metadata: Record<string, unknown>;
+  lifecycle: ReturnType<typeof GovernedOfferSheetLifecycleZ.parse>;
+}): ExpectedOfferSheetCreationSnapshots {
+  const raw = metadata.expectedOfferSheetCreationSnapshots;
+  const snapshots =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : null;
+  const homeTeamCode = String(snapshots?.homeTeamCode || '').trim();
+  const offeringTeamCode = String(snapshots?.offeringTeamCode || '').trim();
+  if (
+    !snapshots ||
+    homeTeamCode !== lifecycle.homeTeamId ||
+    offeringTeamCode !== lifecycle.offeringTeamId
+  ) {
+    throw new Error(
+      'Offer Sheet creation is missing the expected Team snapshot receipts.'
+    );
+  }
+  return Object.freeze({
+    homeTeamCode,
+    offeringTeamCode,
+    homeTeam: requireDocumentSnapshotReference(
+      snapshots.homeTeam,
+      `${homeTeamCode} Team`
+    ),
+    offeringTeam: requireDocumentSnapshotReference(
+      snapshots.offeringTeam,
+      `${offeringTeamCode} Team`
+    ),
+  });
 }
 
 function requireLocalDocumentSnapshotReference(
@@ -187,6 +312,18 @@ function requireExpectedOfferSheetResolutionSnapshots({
       'Offer Sheet resolution requires existing snapshot receipts for both Teams.'
     );
   }
+  const authorization = requireLocalDocumentSnapshotReference(
+    snapshots.authorization,
+    `${lifecycle.ledgerId} authorization`
+  );
+  const immutableEvidenceDigest = String(
+    snapshots.immutableEvidenceDigest || ''
+  ).trim();
+  if (!authorization.exists || !immutableEvidenceDigest) {
+    throw new Error(
+      'Offer Sheet resolution is missing its immutable authorization receipt.'
+    );
+  }
   return Object.freeze({
     playerId,
     homeTeamCode,
@@ -201,6 +338,8 @@ function requireExpectedOfferSheetResolutionSnapshots({
       snapshots.offeringPlayer,
       `${offeringTeamCode}/${playerId} player`
     ),
+    authorization,
+    immutableEvidenceDigest,
   });
 }
 
@@ -250,6 +389,14 @@ function requireExpectedOfferSheetLifecycleReference({
     metadata,
     lifecycle: resolved.data,
   });
+  if (
+    mutationSnapshotDigest(resolved.data.evidenceSnapshot) !==
+    snapshots.immutableEvidenceDigest
+  ) {
+    throw new Error(
+      'Offer Sheet resolution lifecycle does not match immutable base evidence.'
+    );
+  }
   return Object.freeze({
     ledgerId,
     ledgerVersion,
@@ -335,7 +482,7 @@ function recheckOfferSheetLifecycleBeforeCommit({
   }
 }
 
-async function recheckExtensionSourceLineage({
+async function recheckExactSourceLineage({
   transaction,
   rawLineage,
   expectedSourceWorldIdValue,
@@ -345,6 +492,7 @@ async function recheckExtensionSourceLineage({
   receiptLabel,
   changedLabel,
   changedIdentifier,
+  operationLabel,
 }: {
   transaction: Transaction;
   rawLineage: unknown;
@@ -355,6 +503,7 @@ async function recheckExtensionSourceLineage({
   receiptLabel: string;
   changedLabel: string;
   changedIdentifier: string;
+  operationLabel: string;
 }): Promise<DocumentData> {
   const expectedSourceWorldId =
     expectedSourceWorldIdValue === null
@@ -372,7 +521,7 @@ async function recheckExtensionSourceLineage({
         expectedSourceDigest.length === 0)) ||
     !Array.isArray(rawLineage)
   ) {
-    throw new Error(`Extension is missing the exact ${receiptLabel}.`);
+    throw new Error(`${operationLabel} is missing the exact ${receiptLabel}.`);
   }
 
   const seenWorldIds = new Set<string>();
@@ -385,7 +534,7 @@ async function recheckExtensionSourceLineage({
       typeof rawEntry !== 'object' ||
       Array.isArray(rawEntry)
     ) {
-      throw new Error(`Extension is missing the exact ${receiptLabel}.`);
+      throw new Error(`${operationLabel} is missing the exact ${receiptLabel}.`);
     }
     const entry = rawEntry as Record<string, unknown>;
     const entryWorldId =
@@ -402,7 +551,7 @@ async function recheckExtensionSourceLineage({
         : entryDigest !== null) ||
       winningSourceWorldId !== null
     ) {
-      throw new Error(`Extension is missing the exact ${receiptLabel}.`);
+      throw new Error(`${operationLabel} is missing the exact ${receiptLabel}.`);
     }
     seenWorldIds.add(entryWorldId);
 
@@ -434,7 +583,7 @@ async function recheckExtensionSourceLineage({
       (winningSourceWorldId !== expectedSourceWorldId ||
         winningSourceDigest !== expectedSourceDigest))
   ) {
-    throw new Error(`Extension is missing the exact ${receiptLabel}.`);
+    throw new Error(`${operationLabel} is missing the exact ${receiptLabel}.`);
   }
 
   return winningSourceData;
@@ -695,13 +844,63 @@ export async function persistWorldMutation({
     const metadataRef = worldMetadataRef(worldId);
     writes.push({ kind: 'update', ref: metadataRef, data: worldPatch });
 
+    const metadata = computeResult.metadata as Record<string, unknown>;
+    const isOfferSheetCreation = mutationType === 'storeOfferSheet';
+    const creationLifecycleParse = isOfferSheetCreation
+      ? GovernedOfferSheetLifecycleZ.safeParse(
+          metadata.governedOfferSheetLifecycle
+        )
+      : null;
+    if (
+      isOfferSheetCreation &&
+      (!creationLifecycleParse?.success ||
+        creationLifecycleParse.data.status !== 'pending-match')
+    ) {
+      throw new Error(
+        'Offer Sheet creation is missing its governed pending lifecycle.'
+      );
+    }
+    const creationLifecycle = creationLifecycleParse?.success
+      ? creationLifecycleParse.data
+      : null;
+    const expectedOfferSheetCreationSnapshots = creationLifecycle
+      ? requireExpectedOfferSheetCreationSnapshots({
+          metadata,
+          lifecycle: creationLifecycle,
+        })
+      : null;
+    const creationAuthorization = creationLifecycle
+      ? buildGovernedOfferSheetAuthorization({
+          lifecycle: creationLifecycle,
+          offerSheetId: String(metadata.offerSheetId || ''),
+          dedupKey: String(metadata.dedupKey || ''),
+        })
+      : null;
     const isOfferSheetResolution = isOfferSheetResolutionMutation(mutationType);
     const expectedOfferSheetLifecycle = isOfferSheetResolution
       ? requireExpectedOfferSheetLifecycleReference({
-          metadata: computeResult.metadata as Record<string, unknown>,
+          metadata,
           mutationType,
         })
       : null;
+    if (expectedOfferSheetCreationSnapshots) {
+      const creationTeamCodes = new Set(
+        teamUpdates.map(({ teamCode }) => String(teamCode || '').trim())
+      );
+      if (
+        creationTeamCodes.size !== 2 ||
+        !creationTeamCodes.has(
+          expectedOfferSheetCreationSnapshots.homeTeamCode
+        ) ||
+        !creationTeamCodes.has(
+          expectedOfferSheetCreationSnapshots.offeringTeamCode
+        )
+      ) {
+        throw new Error(
+          'Offer Sheet creation must atomically replace both governed Team mirrors.'
+        );
+      }
+    }
     if (expectedOfferSheetLifecycle) {
       const resolutionTeamCodes = new Set(
         teamUpdates.map(({ teamCode }) => String(teamCode || '').trim())
@@ -725,6 +924,7 @@ export async function persistWorldMutation({
       mutationType === 'renounceRights' ||
       mutationType === 'optionDecision' ||
       mutationType === 'extendPlayer' ||
+      isOfferSheetCreation ||
       isOfferSheetResolution
     ) {
       await runTransaction(db, async (transaction) => {
@@ -734,7 +934,11 @@ export async function persistWorldMutation({
           const teamRef = worldTeamRef(worldId, normalizedTeamCode);
           const currentTeamSnapshot = await transaction.get(teamRef);
           const currentTeamExists = currentTeamSnapshot.exists();
-          if (!currentTeamExists && mutationType !== 'extendPlayer') {
+          if (
+            !currentTeamExists &&
+            mutationType !== 'extendPlayer' &&
+            !isOfferSheetCreation
+          ) {
             throw new Error(
               `Team ${normalizedTeamCode} changed before the governed history append could commit. Reload and try again.`
             );
@@ -743,7 +947,46 @@ export async function persistWorldMutation({
             ? currentTeamSnapshot.data()
             : {};
           let contractSourceTeamData = currentTeamData;
-          if (mutationType === 'renounceRights') {
+          if (expectedOfferSheetCreationSnapshots) {
+            const expectedTeamSnapshot =
+              normalizedTeamCode ===
+              expectedOfferSheetCreationSnapshots.homeTeamCode
+                ? expectedOfferSheetCreationSnapshots.homeTeam
+                : expectedOfferSheetCreationSnapshots.offeringTeam;
+            assertSnapshotReferenceStillCurrent({
+              exists: currentTeamExists,
+              data: currentTeamData,
+              expected: expectedTeamSnapshot,
+              label: `Team snapshot for ${normalizedTeamCode}`,
+            });
+            if (expectedTeamSnapshot.exists) {
+              if (
+                expectedTeamSnapshot.sourceWorldId !== worldId ||
+                expectedTeamSnapshot.sourceDigest !==
+                  expectedTeamSnapshot.digest ||
+                expectedTeamSnapshot.sourceLineage.length !== 0
+              ) {
+                throw new Error(
+                  `Offer Sheet creation is missing the exact Team source receipt for ${normalizedTeamCode}.`
+                );
+              }
+            } else {
+              await recheckExactSourceLineage({
+                transaction,
+                rawLineage: expectedTeamSnapshot.sourceLineage,
+                expectedSourceWorldIdValue:
+                  expectedTeamSnapshot.sourceWorldId,
+                expectedSourceDigest: expectedTeamSnapshot.sourceDigest,
+                currentWorldId: worldId,
+                sourceRef: (sourceWorldId) =>
+                  worldTeamRef(sourceWorldId, normalizedTeamCode),
+                receiptLabel: `Team source receipt for ${normalizedTeamCode}`,
+                changedLabel: 'Team',
+                changedIdentifier: normalizedTeamCode,
+                operationLabel: 'Offer Sheet creation',
+              });
+            }
+          } else if (mutationType === 'renounceRights') {
             const expected = expectedRightsLedgersByTeam[normalizedTeamCode];
             if (!expected) {
               throw new Error(
@@ -779,7 +1022,6 @@ export async function persistWorldMutation({
               expected: expectedOfferSheetLifecycle,
             });
           } else {
-            const metadata = computeResult.metadata as Record<string, unknown>;
             if (mutationType === 'extendPlayer') {
               const expectedTeamExists = metadata.expectedTeamSnapshotExists;
               const expectedTeamDigest = metadata.expectedTeamSnapshotDigest;
@@ -815,7 +1057,7 @@ export async function persistWorldMutation({
                   );
                 }
               } else {
-                contractSourceTeamData = await recheckExtensionSourceLineage({
+                contractSourceTeamData = await recheckExactSourceLineage({
                   transaction,
                   rawLineage: metadata.expectedTeamSourceLineage,
                   expectedSourceWorldIdValue:
@@ -828,6 +1070,7 @@ export async function persistWorldMutation({
                   receiptLabel: `team-source lineage receipt for ${normalizedTeamCode}`,
                   changedLabel: 'team',
                   changedIdentifier: normalizedTeamCode,
+                  operationLabel: 'Extension',
                 });
               }
 
@@ -877,7 +1120,7 @@ export async function persistWorldMutation({
                   );
                 }
               } else {
-                await recheckExtensionSourceLineage({
+                await recheckExactSourceLineage({
                   transaction,
                   rawLineage: metadata.expectedPlayerSourceLineage,
                   expectedSourceWorldIdValue:
@@ -894,6 +1137,7 @@ export async function persistWorldMutation({
                   receiptLabel: `player-source lineage receipt for ${expectedPlayerId}`,
                   changedLabel: 'player',
                   changedIdentifier: expectedPlayerId,
+                  operationLabel: 'Extension',
                 });
               }
             }
@@ -986,8 +1230,95 @@ export async function persistWorldMutation({
             }
           }
         }
+        if (creationAuthorization) {
+          const authorizationRef = worldOfferSheetAuthorizationRef(
+            worldId,
+            creationAuthorization.offerSheetId
+          );
+          const authorizationSnapshot = await transaction.get(
+            authorizationRef
+          );
+          if (authorizationSnapshot.exists()) {
+            const currentAuthorization =
+              GovernedOfferSheetAuthorizationZ.safeParse(
+                authorizationSnapshot.data()
+              );
+            if (
+              !currentAuthorization.success ||
+              mutationSnapshotDigest(currentAuthorization.data) !==
+                mutationSnapshotDigest(creationAuthorization)
+            ) {
+              throw new Error(
+                'Offer Sheet authorization changed before commit. Reload and try again.'
+              );
+            }
+          } else {
+            transaction.set(authorizationRef, creationAuthorization);
+          }
+        }
         if (expectedOfferSheetLifecycle) {
           const { snapshots } = expectedOfferSheetLifecycle;
+          const authorizationRef = worldOfferSheetAuthorizationRef(
+            worldId,
+            expectedOfferSheetLifecycle.offerSheetId
+          );
+          const authorizationSnapshot = await transaction.get(
+            authorizationRef
+          );
+          assertSnapshotReferenceStillCurrent({
+            exists: authorizationSnapshot.exists(),
+            data: authorizationSnapshot.exists()
+              ? authorizationSnapshot.data()
+              : {},
+            expected: snapshots.authorization,
+            label: 'Offer Sheet authorization',
+          });
+          const expectedAuthorization = GovernedOfferSheetAuthorizationZ.parse({
+            authorizationVersion: 1,
+            worldId,
+            offerSheetId: expectedOfferSheetLifecycle.offerSheetId,
+            dedupKey: expectedOfferSheetLifecycle.dedupKey,
+            playerId: snapshots.playerId,
+            homeTeamId: snapshots.homeTeamCode,
+            offeringTeamId: snapshots.offeringTeamCode,
+            salaryCapYear: GovernedOfferSheetLifecycleZ.parse(
+              metadata.governedOfferSheetLifecycle
+            ).salaryCapYear,
+            pendingLifecycleDigest: expectedOfferSheetLifecycle.digest,
+            immutableEvidenceDigest: snapshots.immutableEvidenceDigest,
+          });
+          const currentAuthorization = authorizationSnapshot.exists()
+            ? GovernedOfferSheetAuthorizationZ.safeParse(
+                authorizationSnapshot.data()
+              )
+            : null;
+          if (
+            !currentAuthorization?.success ||
+            mutationSnapshotDigest(currentAuthorization.data) !==
+              mutationSnapshotDigest(expectedAuthorization)
+          ) {
+            throw new Error(
+              'Offer Sheet resolution authorization changed before commit. Reload and try again.'
+            );
+          }
+          const immutableBasePlayer = await transaction.get(
+            basePlayerRef(snapshots.playerId)
+          );
+          const rawBasePlayer = immutableBasePlayer.exists()
+            ? immutableBasePlayer.data()
+            : {};
+          const immutableEvidence = GovernedOfferSheetEvidenceZ.safeParse(
+            rawBasePlayer.rfaContext?.governedEvidence
+          );
+          if (
+            !immutableEvidence.success ||
+            mutationSnapshotDigest(immutableEvidence.data) !==
+              snapshots.immutableEvidenceDigest
+          ) {
+            throw new Error(
+              'Offer Sheet resolution authorization no longer matches immutable base evidence.'
+            );
+          }
           for (const [teamCode, expectedPlayerSnapshot] of [
             [snapshots.homeTeamCode, snapshots.homePlayer],
             [snapshots.offeringTeamCode, snapshots.offeringPlayer],

--- a/src/features/architect/utils/mutationPipeline.persist.ts
+++ b/src/features/architect/utils/mutationPipeline.persist.ts
@@ -63,6 +63,21 @@ type ExpectedRightsLedgerReference = Readonly<{
   ledgerVersion: number;
 }>;
 
+type ExpectedLocalDocumentSnapshotReference = Readonly<{
+  exists: boolean;
+  digest: string | null;
+}>;
+
+type ExpectedOfferSheetResolutionSnapshots = Readonly<{
+  playerId: string;
+  homeTeamCode: string;
+  offeringTeamCode: string;
+  homeTeam: ExpectedLocalDocumentSnapshotReference;
+  offeringTeam: ExpectedLocalDocumentSnapshotReference;
+  homePlayer: ExpectedLocalDocumentSnapshotReference;
+  offeringPlayer: ExpectedLocalDocumentSnapshotReference;
+}>;
+
 type ExpectedGovernedOfferSheetLifecycleReference = Readonly<{
   ledgerId: string;
   ledgerVersion: number;
@@ -71,6 +86,7 @@ type ExpectedGovernedOfferSheetLifecycleReference = Readonly<{
   offeringTeamCode: string;
   offerSheetId: string;
   dedupKey: string;
+  snapshots: ExpectedOfferSheetResolutionSnapshots;
 }>;
 
 type PreparedMutationWrite =
@@ -104,6 +120,88 @@ function isOfferSheetResolutionMutation(mutationType: string): boolean {
     mutationType === 'finalizeMatchedOfferSheet' ||
     mutationType === 'finalizeDeclinedOfferSheet'
   );
+}
+
+function requireLocalDocumentSnapshotReference(
+  raw: unknown,
+  label: string
+): ExpectedLocalDocumentSnapshotReference {
+  const receipt =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : null;
+  const exists = receipt?.exists;
+  const digest = receipt?.digest;
+  if (
+    typeof exists !== 'boolean' ||
+    (exists && (typeof digest !== 'string' || !digest.trim())) ||
+    (!exists && digest !== null)
+  ) {
+    throw new Error(
+      `Offer Sheet resolution is missing the expected ${label} snapshot receipt.`
+    );
+  }
+  return Object.freeze({
+    exists,
+    digest: exists ? String(digest).trim() : null,
+  });
+}
+
+function requireExpectedOfferSheetResolutionSnapshots({
+  metadata,
+  lifecycle,
+}: {
+  metadata: Record<string, unknown>;
+  lifecycle: ReturnType<typeof GovernedOfferSheetLifecycleZ.parse>;
+}): ExpectedOfferSheetResolutionSnapshots {
+  const raw = metadata.expectedOfferSheetResolutionSnapshots;
+  const snapshots =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : null;
+  const playerId = String(snapshots?.playerId || '').trim();
+  const homeTeamCode = String(snapshots?.homeTeamCode || '').trim();
+  const offeringTeamCode = String(snapshots?.offeringTeamCode || '').trim();
+  if (
+    !snapshots ||
+    !playerId ||
+    playerId !== String(metadata.playerId || '').trim() ||
+    playerId !== lifecycle.playerId ||
+    homeTeamCode !== lifecycle.homeTeamId ||
+    offeringTeamCode !== lifecycle.offeringTeamId
+  ) {
+    throw new Error(
+      'Offer Sheet resolution is missing the expected document snapshot receipts.'
+    );
+  }
+  const homeTeam = requireLocalDocumentSnapshotReference(
+    snapshots.homeTeam,
+    `${homeTeamCode} Team`
+  );
+  const offeringTeam = requireLocalDocumentSnapshotReference(
+    snapshots.offeringTeam,
+    `${offeringTeamCode} Team`
+  );
+  if (!homeTeam.exists || !offeringTeam.exists) {
+    throw new Error(
+      'Offer Sheet resolution requires existing snapshot receipts for both Teams.'
+    );
+  }
+  return Object.freeze({
+    playerId,
+    homeTeamCode,
+    offeringTeamCode,
+    homeTeam,
+    offeringTeam,
+    homePlayer: requireLocalDocumentSnapshotReference(
+      snapshots.homePlayer,
+      `${homeTeamCode}/${playerId} player`
+    ),
+    offeringPlayer: requireLocalDocumentSnapshotReference(
+      snapshots.offeringPlayer,
+      `${offeringTeamCode}/${playerId} player`
+    ),
+  });
 }
 
 function requireExpectedOfferSheetLifecycleReference({
@@ -148,6 +246,10 @@ function requireExpectedOfferSheetLifecycleReference({
       'Offer Sheet resolution is missing the expected governed lifecycle reference.'
     );
   }
+  const snapshots = requireExpectedOfferSheetResolutionSnapshots({
+    metadata,
+    lifecycle: resolved.data,
+  });
   return Object.freeze({
     ledgerId,
     ledgerVersion,
@@ -156,7 +258,29 @@ function requireExpectedOfferSheetLifecycleReference({
     offeringTeamCode: resolved.data.offeringTeamId,
     offerSheetId,
     dedupKey,
+    snapshots,
   });
+}
+
+function assertSnapshotReferenceStillCurrent({
+  exists,
+  data,
+  expected,
+  label,
+}: {
+  exists: boolean;
+  data: unknown;
+  expected: ExpectedLocalDocumentSnapshotReference;
+  label: string;
+}): void {
+  if (
+    exists !== expected.exists ||
+    (exists && mutationSnapshotDigest(data) !== expected.digest)
+  ) {
+    throw new Error(
+      `${label} changed before commit. Reload and try again.`
+    );
+  }
 }
 
 function recheckOfferSheetLifecycleBeforeCommit({
@@ -638,6 +762,17 @@ export async function persistWorldMutation({
               );
             }
           } else if (expectedOfferSheetLifecycle) {
+            const expectedTeamSnapshot =
+              normalizedTeamCode ===
+              expectedOfferSheetLifecycle.snapshots.homeTeamCode
+                ? expectedOfferSheetLifecycle.snapshots.homeTeam
+                : expectedOfferSheetLifecycle.snapshots.offeringTeam;
+            assertSnapshotReferenceStillCurrent({
+              exists: currentTeamExists,
+              data: currentTeamData,
+              expected: expectedTeamSnapshot,
+              label: `Team snapshot for ${normalizedTeamCode}`,
+            });
             recheckOfferSheetLifecycleBeforeCommit({
               currentTeamData,
               teamCode: normalizedTeamCode,
@@ -849,6 +984,25 @@ export async function persistWorldMutation({
                 );
               }
             }
+          }
+        }
+        if (expectedOfferSheetLifecycle) {
+          const { snapshots } = expectedOfferSheetLifecycle;
+          for (const [teamCode, expectedPlayerSnapshot] of [
+            [snapshots.homeTeamCode, snapshots.homePlayer],
+            [snapshots.offeringTeamCode, snapshots.offeringPlayer],
+          ] as const) {
+            const currentPlayerSnapshot = await transaction.get(
+              worldPlayerRef(worldId, teamCode, snapshots.playerId)
+            );
+            assertSnapshotReferenceStillCurrent({
+              exists: currentPlayerSnapshot.exists(),
+              data: currentPlayerSnapshot.exists()
+                ? currentPlayerSnapshot.data()
+                : {},
+              expected: expectedPlayerSnapshot,
+              label: `Player snapshot for ${snapshots.playerId} on ${teamCode}`,
+            });
           }
         }
         applyWritesToTransaction(transaction, writes);

--- a/src/features/architect/utils/mutationPipeline.persist.ts
+++ b/src/features/architect/utils/mutationPipeline.persist.ts
@@ -56,10 +56,21 @@ import { createRightsEventLedger } from '@/features/architect/utils/rightsHistor
 import { createContractEventLedger } from '@/features/architect/utils/contractHistory';
 import { contractOverlaySetDigest } from '@/features/architect/utils/optionDecisions/contractOverlaySetDigest';
 import { mutationSnapshotDigest } from './mutationPipeline.snapshotDigest';
+import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
 
 type ExpectedRightsLedgerReference = Readonly<{
   ledgerId: string;
   ledgerVersion: number;
+}>;
+
+type ExpectedGovernedOfferSheetLifecycleReference = Readonly<{
+  ledgerId: string;
+  ledgerVersion: number;
+  digest: string;
+  homeTeamCode: string;
+  offeringTeamCode: string;
+  offerSheetId: string;
+  dedupKey: string;
 }>;
 
 type PreparedMutationWrite =
@@ -84,6 +95,120 @@ function requireDocumentData(value: unknown): DocumentData {
     throw new Error('A prepared Firestore mutation write must be an object.');
   }
   return value as DocumentData;
+}
+
+function isOfferSheetResolutionMutation(mutationType: string): boolean {
+  return (
+    mutationType === 'matchOfferSheet' ||
+    mutationType === 'declineOfferSheet' ||
+    mutationType === 'finalizeMatchedOfferSheet' ||
+    mutationType === 'finalizeDeclinedOfferSheet'
+  );
+}
+
+function requireExpectedOfferSheetLifecycleReference({
+  metadata,
+  mutationType,
+}: {
+  metadata: Record<string, unknown>;
+  mutationType: string;
+}): ExpectedGovernedOfferSheetLifecycleReference {
+  const rawExpected = metadata.expectedGovernedOfferSheetLifecycle;
+  const expected =
+    rawExpected && typeof rawExpected === 'object' && !Array.isArray(rawExpected)
+      ? (rawExpected as Record<string, unknown>)
+      : null;
+  const resolved = GovernedOfferSheetLifecycleZ.safeParse(
+    metadata.governedOfferSheetLifecycle
+  );
+  const offerSheetId = String(metadata.offerSheetId || '').trim();
+  const dedupKey = String(metadata.dedupKey || '').trim();
+  const expectedOutcome =
+    mutationType === 'matchOfferSheet' ||
+    mutationType === 'finalizeMatchedOfferSheet'
+      ? 'matched'
+      : 'declined';
+  const ledgerId = String(expected?.ledgerId || '').trim();
+  const ledgerVersion = Number(expected?.ledgerVersion);
+  const digest = String(expected?.digest || '').trim();
+  if (
+    !expected ||
+    !resolved.success ||
+    !offerSheetId ||
+    !dedupKey ||
+    !ledgerId ||
+    !Number.isInteger(ledgerVersion) ||
+    ledgerVersion < 1 ||
+    !digest ||
+    resolved.data.ledgerId !== ledgerId ||
+    resolved.data.ledgerVersion !== ledgerVersion + 1 ||
+    resolved.data.status !== expectedOutcome
+  ) {
+    throw new Error(
+      'Offer Sheet resolution is missing the expected governed lifecycle reference.'
+    );
+  }
+  return Object.freeze({
+    ledgerId,
+    ledgerVersion,
+    digest,
+    homeTeamCode: resolved.data.homeTeamId,
+    offeringTeamCode: resolved.data.offeringTeamId,
+    offerSheetId,
+    dedupKey,
+  });
+}
+
+function recheckOfferSheetLifecycleBeforeCommit({
+  currentTeamData,
+  teamCode,
+  expected,
+}: {
+  currentTeamData: DocumentData;
+  teamCode: string;
+  expected: ExpectedGovernedOfferSheetLifecycleReference;
+}): void {
+  const rawSheets =
+    teamCode === expected.homeTeamCode
+      ? currentTeamData.incomingOfferSheets
+      : teamCode === expected.offeringTeamCode
+        ? currentTeamData.offerSheets
+        : null;
+  if (!Array.isArray(rawSheets)) {
+    throw new Error(
+      `Offer Sheet lifecycle for ${teamCode} changed before commit. Reload and try again.`
+    );
+  }
+  const matches = rawSheets.filter((rawSheet: unknown) => {
+    if (!rawSheet || typeof rawSheet !== 'object' || Array.isArray(rawSheet)) {
+      return false;
+    }
+    const sheet = rawSheet as Record<string, unknown>;
+    return (
+      String(sheet.id || '').trim() === expected.offerSheetId ||
+      String(sheet.dedupKey || '').trim() === expected.dedupKey
+    );
+  });
+  const lifecycle =
+    matches.length === 1 &&
+    matches[0] &&
+    typeof matches[0] === 'object' &&
+    !Array.isArray(matches[0])
+      ? GovernedOfferSheetLifecycleZ.safeParse(
+          (matches[0] as Record<string, unknown>).governedLifecycle
+        )
+      : null;
+  if (
+    !lifecycle?.success ||
+    lifecycle.data.status !== 'pending-match' ||
+    lifecycle.data.ledgerId !== expected.ledgerId ||
+    lifecycle.data.ledgerVersion !== expected.ledgerVersion ||
+    mutationSnapshotDigest(lifecycle.data) !== expected.digest
+  ) {
+    throw new Error(
+      `Offer Sheet lifecycle for ${teamCode} changed before commit. Reload and try again.`
+    );
+  }
 }
 
 async function recheckExtensionSourceLineage({
@@ -446,6 +571,28 @@ export async function persistWorldMutation({
     const metadataRef = worldMetadataRef(worldId);
     writes.push({ kind: 'update', ref: metadataRef, data: worldPatch });
 
+    const isOfferSheetResolution = isOfferSheetResolutionMutation(mutationType);
+    const expectedOfferSheetLifecycle = isOfferSheetResolution
+      ? requireExpectedOfferSheetLifecycleReference({
+          metadata: computeResult.metadata as Record<string, unknown>,
+          mutationType,
+        })
+      : null;
+    if (expectedOfferSheetLifecycle) {
+      const resolutionTeamCodes = new Set(
+        teamUpdates.map(({ teamCode }) => String(teamCode || '').trim())
+      );
+      if (
+        resolutionTeamCodes.size !== 2 ||
+        !resolutionTeamCodes.has(expectedOfferSheetLifecycle.homeTeamCode) ||
+        !resolutionTeamCodes.has(expectedOfferSheetLifecycle.offeringTeamCode)
+      ) {
+        throw new Error(
+          'Offer Sheet resolution must atomically replace both governed Team mirrors.'
+        );
+      }
+    }
+
     // A governed ledger append must compare the exact history it consumed in
     // the same atomic commit that publishes the replacement ledger. Otherwise
     // two tabs can both report success while the later whole-team write
@@ -453,7 +600,8 @@ export async function persistWorldMutation({
     if (
       mutationType === 'renounceRights' ||
       mutationType === 'optionDecision' ||
-      mutationType === 'extendPlayer'
+      mutationType === 'extendPlayer' ||
+      isOfferSheetResolution
     ) {
       await runTransaction(db, async (transaction) => {
         for (const { teamCode, team } of teamUpdates) {
@@ -489,6 +637,12 @@ export async function persistWorldMutation({
                 `Rights history for ${normalizedTeamCode} changed before commit. Reload and try again.`
               );
             }
+          } else if (expectedOfferSheetLifecycle) {
+            recheckOfferSheetLifecycleBeforeCommit({
+              currentTeamData,
+              teamCode: normalizedTeamCode,
+              expected: expectedOfferSheetLifecycle,
+            });
           } else {
             const metadata = computeResult.metadata as Record<string, unknown>;
             if (mutationType === 'extendPlayer') {

--- a/src/features/architect/utils/mutationPipeline.preflights.ts
+++ b/src/features/architect/utils/mutationPipeline.preflights.ts
@@ -38,6 +38,7 @@ import type {
   PublicComputeWorldMutationArgs,
   SignAndTradePreflightResult,
 } from './mutationPipeline.types';
+import type { GovernedOfferSheetProposal } from '@/schemas/governedOfferSheet';
 
 /**
  * Compute mutation result without side effects.
@@ -211,6 +212,7 @@ export async function preflightOfferSheetMutation({
   offeringTeamCode,
   playerId,
   contract,
+  offerSheetProposal,
   timestamp = Date.now(),
 }: {
   worldId: string;
@@ -218,6 +220,7 @@ export async function preflightOfferSheetMutation({
   offeringTeamCode: string;
   playerId: string;
   contract: ArchitectMutationContract;
+  offerSheetProposal?: GovernedOfferSheetProposal;
   timestamp?: number;
 }): Promise<OfferSheetPreflightResult> {
   const source = AUTHORITATIVE_SAT_PREFLIGHT_SOURCE;
@@ -284,6 +287,7 @@ export async function preflightOfferSheetMutation({
     teamCode: offeringTeamCode,
     playerId,
     contract: preflightContract,
+    offerSheetProposal,
     signedUsing: contract.exceptionType ?? null,
   };
 
@@ -299,7 +303,15 @@ export async function preflightOfferSheetMutation({
       currentState,
       'storeOfferSheet'
     );
-    const currentYear = toEndYear(seasonId) ?? new Date().getFullYear();
+    const currentYear = toEndYear(seasonId);
+    if (!currentYear) {
+      return {
+        status: 'incomplete',
+        reasons: ['The Offer Sheet Salary Cap Year could not be derived.'],
+        warnings: [],
+        source,
+      };
+    }
 
     // validateSigning with offer-sheet flags routes into the RFA/offer-sheet validation path:
     // validateOfferSheetTerms (years 1–4, raises ≤8%) + offering-team-vs-home-team checks.
@@ -329,12 +341,15 @@ export async function preflightOfferSheetMutation({
 
     // computeWorldMutation catches pre-compute guardrails: player in home team players[],
     // dedup/worldId checks. Pure compute — does not persist.
+    const worldAsOfDate = await loadWorldAsOfDate(worldId);
+    const { asOfDate } = resolveWorldAsOfDate({ worldAsOfDate });
     const computeResult = computeWorldMutation({
       mutationType: 'storeOfferSheet',
       payload,
       currentState,
       seasonId,
       timestamp,
+      asOfDate,
       worldId,
     });
 

--- a/src/features/architect/utils/mutationPipeline.read.dashboardNormalizers.ts
+++ b/src/features/architect/utils/mutationPipeline.read.dashboardNormalizers.ts
@@ -72,6 +72,7 @@ export function normalizeDashboardReloadOfferSheet(
   const contractYears = toOptionalNumberishOrNull(record.contractYears);
   const totalValue = toOptionalNumberishOrNull(record.totalValue);
   const createdAt = toOptionalDateLike(record.createdAt);
+  const governedLifecycle = record.governedLifecycle;
 
   if (id !== undefined) {
     normalized.id = id;
@@ -102,6 +103,9 @@ export function normalizeDashboardReloadOfferSheet(
   }
   if (createdAt !== undefined) {
     normalized.createdAt = createdAt;
+  }
+  if (governedLifecycle !== undefined) {
+    normalized.governedLifecycle = safeCloneForAudit(governedLifecycle);
   }
 
   return normalized;

--- a/src/features/architect/utils/mutationPipeline.read.normalizeData.ts
+++ b/src/features/architect/utils/mutationPipeline.read.normalizeData.ts
@@ -189,6 +189,7 @@ export function normalizeCurrentStateOfferSheet(
   const createdAt = toOptionalDateLike(record.createdAt);
   const matchedAt = toOptionalTrimmedString(record.matchedAt);
   const declinedAt = toOptionalTrimmedString(record.declinedAt);
+  const governedLifecycle = record.governedLifecycle;
 
   if (id !== undefined) {
     normalized.id = id;
@@ -235,6 +236,15 @@ export function normalizeCurrentStateOfferSheet(
   if (declinedAt !== undefined) {
     normalized.declinedAt = declinedAt;
   }
+  if (governedLifecycle !== undefined) {
+    try {
+      normalized.governedLifecycle = JSON.parse(
+        JSON.stringify(governedLifecycle)
+      );
+    } catch {
+      normalized.governedLifecycle = governedLifecycle;
+    }
+  }
 
   return normalized;
 }
@@ -250,4 +260,3 @@ export function normalizeCurrentStateOfferSheets(
     .map((entry) => normalizeCurrentStateOfferSheet(entry))
     .filter((entry): entry is ArchitectMutationOfferSheet => entry !== null);
 }
-

--- a/src/features/architect/utils/mutationPipeline.read.normalizeTeam.currentState.ts
+++ b/src/features/architect/utils/mutationPipeline.read.normalizeTeam.currentState.ts
@@ -445,6 +445,8 @@ export function normalizeOfferSheetTeamAndPlayerMutationCurrentState(
     'offerSheetMirror'
   );
   const teamCode = toOptionalTrimmedString(currentState?.teamCode);
+  const offerSheetCreationSnapshots =
+    currentState?.offerSheetCreationSnapshots;
 
   if (team) {
     normalized.team = team;
@@ -457,6 +459,9 @@ export function normalizeOfferSheetTeamAndPlayerMutationCurrentState(
   }
   if (teamCode !== undefined) {
     normalized.teamCode = teamCode;
+  }
+  if (offerSheetCreationSnapshots) {
+    normalized.offerSheetCreationSnapshots = offerSheetCreationSnapshots;
   }
 
   return normalized;

--- a/src/features/architect/utils/mutationPipeline.read.normalizeTeam.currentState.ts
+++ b/src/features/architect/utils/mutationPipeline.read.normalizeTeam.currentState.ts
@@ -512,6 +512,10 @@ export function normalizeOfferSheetResolutionMutationCurrentState(
   if (offerSheetId !== undefined) {
     normalized.offerSheetId = offerSheetId;
   }
+  if (currentState?.offerSheetResolutionSnapshots) {
+    normalized.offerSheetResolutionSnapshots =
+      currentState.offerSheetResolutionSnapshots;
+  }
 
   return normalized;
 }

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -201,18 +201,17 @@ export async function resolveStoreOfferSheetAuthority({
     );
   }
 
-  const capHoldRightsPlayer =
-    resolvedOwner.capHoldMatch && !resolvedOwner.snapshotPlayer
-      ? toCurrentStatePlayer(
-          await getPlayer(null, resolvedOwner.teamCode, playerId)
-        )
-      : null;
-  const sourcePlayer = resolvedOwner.snapshotPlayer || capHoldRightsPlayer;
-  // BZE-283 authority is source-owned. A mutable world player override may
-  // alter ordinary player/contract state, but it may never author or replace
-  // the authenticated RFA/QO evidence used to permit an Offer Sheet.
+  // BZE-283 authority is source-owned. Team snapshots and player overrides are
+  // user-writable, so neither may author or replace the authenticated RFA/QO
+  // evidence used to permit an Offer Sheet. Always read that evidence from the
+  // immutable base player, while retaining world state for ownership and the
+  // player's mutable display/contract fields.
+  const immutableBasePlayer = toCurrentStatePlayer(
+    await getPlayer(null, resolvedOwner.teamCode, playerId)
+  );
+  const sourcePlayer = resolvedOwner.snapshotPlayer || immutableBasePlayer;
   const sourceGovernedOfferSheetEvidence =
-    sourcePlayer?.rfaContext?.governedEvidence;
+    immutableBasePlayer?.rfaContext?.governedEvidence;
 
   const canonicalPlayer = overrideEntry
     ? normalizeCurrentStatePlayerSnapshot(

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -233,7 +233,8 @@ export async function resolveStoreOfferSheetAuthority({
     team: offeringTeam,
     player: {
       ...canonicalPlayer,
-      ...(sourceGovernedOfferSheetEvidence !== undefined
+      ...(canonicalPlayer.rfaContext ||
+      sourceGovernedOfferSheetEvidence !== undefined
         ? {
             rfaContext: {
               ...(canonicalPlayer.rfaContext || {}),
@@ -964,7 +965,7 @@ export function buildNormalizedOfferSheetFinalContract({
     rfaOfferSheetStatus: undefined,
     tradeRestrictions: matchRestriction
       ? [
-          `Matched Offer Sheet: player consent required and offering-Team trade barred through ${matchRestriction.restrictedUntil}`,
+          `Matched Offer Sheet: player consent required and offering team trade barred through ${matchRestriction.restrictedUntil}`,
           `Matched Offer Sheet: contract amendment and sign-and-trade barred through ${matchRestriction.restrictedUntil}`,
         ]
       : undefined,

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -204,7 +204,7 @@ export async function resolveStoreOfferSheetAuthority({
   const capHoldRightsPlayer =
     resolvedOwner.capHoldMatch && !resolvedOwner.snapshotPlayer
       ? toCurrentStatePlayer(
-          await getPlayer(worldId, resolvedOwner.teamCode, playerId)
+          await getPlayer(null, resolvedOwner.teamCode, playerId)
         )
       : null;
   const sourcePlayer = resolvedOwner.snapshotPlayer || capHoldRightsPlayer;

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -12,6 +12,7 @@ import { getTeam, getPlayer } from '@/features/architect/utils/teamLoader';
 import { getDoc } from 'firebase/firestore';
 import {
   worldPlayerRef,
+  worldOfferSheetAuthorizationRef,
   worldTeamRef,
 } from '@/features/architect/utils/architectFirestorePaths';
 import {
@@ -29,7 +30,13 @@ import { toCurrentStateTeam } from './mutationPipeline.read.normalizeTeam';
 import { loadWorldGovernedOptionAuthority } from '@/features/architect/utils/optionDecisions';
 import { loadWorldGovernedExtensionAuthority } from '@/features/architect/utils/extensions';
 import { mutationSnapshotDigest } from './mutationPipeline.snapshotDigest';
-import type { GovernedOfferSheetLifecycle } from '@/schemas/governedOfferSheet';
+import {
+  GovernedOfferSheetAuthorizationZ,
+  GovernedOfferSheetEvidenceZ,
+  GovernedOfferSheetLifecycleZ,
+  type GovernedOfferSheetLifecycle,
+} from '@/schemas/governedOfferSheet';
+import { buildGovernedOfferSheetAuthorization } from '@/features/architect/utils/offerSheets';
 
 // Wave 48 Step 1: lineage helpers extracted to submodule
 export * from './mutationPipeline.read.stateLoader.lineage';
@@ -37,7 +44,6 @@ import {
   mergeLineageOverridePlayers,
   toLineageOverrideMergePlayer,
   resolveWorldLineage,
-  getFirstExplicitWorldTeamSnapshotFromLineage,
   getFirstExplicitWorldPlayerOverrideFromLineage,
   getWorldTeamSnapshotLineageReceipt,
   getWorldPlayerSnapshotLineageReceipt,
@@ -56,13 +62,74 @@ import type {
   MutationCurrentState,
   MutationCurrentStateBaseTeamIngress,
   MutationCurrentStateOfferSheetTeamIngress,
+  MutationCurrentStatePlayerIngress,
   MutationCurrentStateTradeTeamIngress,
+  MutationDocumentSnapshotReceipt,
   MutationPayloadLike,
   NormalizedMutationSalaryRow,
   PlayerDeleteLike,
   StoreOfferSheetOwnershipCandidate,
   SupportedComputeMutationType,
 } from './mutationPipeline';
+
+type TeamLineageReceipt = Awaited<
+  ReturnType<typeof getWorldTeamSnapshotLineageReceipt>
+>;
+
+type StoreOfferSheetOwnershipCandidateWithReceipt =
+  StoreOfferSheetOwnershipCandidate & {
+    lineageReceipt: TeamLineageReceipt;
+  };
+
+function requireStableTeamLineageReceipt({
+  before,
+  after,
+  teamCode,
+}: {
+  before: TeamLineageReceipt;
+  after: TeamLineageReceipt;
+  teamCode: string;
+}): void {
+  const beforeIdentity = {
+    sourceWorldId: before.source?.snapshotWorldId ?? null,
+    sourceDigest: before.source?.snapshotDigest ?? null,
+    checkedSnapshots: before.checkedSnapshots,
+  };
+  const afterIdentity = {
+    sourceWorldId: after.source?.snapshotWorldId ?? null,
+    sourceDigest: after.source?.snapshotDigest ?? null,
+    checkedSnapshots: after.checkedSnapshots,
+  };
+  if (
+    mutationSnapshotDigest(beforeIdentity) !==
+    mutationSnapshotDigest(afterIdentity)
+  ) {
+    throw new Error(
+      `Team snapshot for ${teamCode} changed while the Offer Sheet creation state was loading. Reload and try again.`
+    );
+  }
+}
+
+function toOfferSheetCreationTeamReceipt(
+  receipt: TeamLineageReceipt,
+  worldId: string
+): MutationDocumentSnapshotReceipt {
+  const [local, ...ancestorLineage] = receipt.checkedSnapshots;
+  if (!local || local.worldId !== worldId) {
+    throw new Error(
+      'Offer Sheet creation could not retain its exact Team lineage receipt.'
+    );
+  }
+  return Object.freeze({
+    exists: local.exists,
+    digest: local.digest,
+    sourceWorldId: receipt.source?.snapshotWorldId ?? null,
+    sourceDigest: receipt.source?.snapshotDigest ?? null,
+    sourceLineage: Object.freeze(
+      local.exists ? [] : ancestorLineage.map((entry) => Object.freeze(entry))
+    ),
+  });
+}
 
 export async function resolveStoreOfferSheetAuthority({
   worldId,
@@ -73,15 +140,18 @@ export async function resolveStoreOfferSheetAuthority({
   offeringTeamCode: string;
   playerId: string;
 }) {
-  const [offeringTeam, lineageWorldIds] = await Promise.all([
-    getTeam(worldId, offeringTeamCode).then((team) =>
+  const lineageWorldIds = await resolveWorldLineage(worldId);
+  const offeringLineageBefore =
+    await getWorldTeamSnapshotLineageReceipt(
+      lineageWorldIds,
+      offeringTeamCode
+    );
+  const offeringTeam = await getTeam(worldId, offeringTeamCode).then((team) =>
       toCurrentStateTeam(
         team as MutationCurrentStateOfferSheetTeamIngress | null,
         'signing'
       )
-    ),
-    resolveWorldLineage(worldId),
-  ]);
+    );
 
   if (!offeringTeam) {
     throw new Error(
@@ -92,11 +162,11 @@ export async function resolveStoreOfferSheetAuthority({
   const ownershipCandidates = (
     await Promise.all(
       AUTHORITATIVE_WORLD_TEAM_CODES.map(async (teamCode) => {
-        const snapshotEntry =
-          await getFirstExplicitWorldTeamSnapshotFromLineage(
-            lineageWorldIds,
-            teamCode
-          );
+        const lineageReceipt = await getWorldTeamSnapshotLineageReceipt(
+          lineageWorldIds,
+          teamCode
+        );
+        const snapshotEntry = lineageReceipt.source;
         if (!snapshotEntry) {
           return null;
         }
@@ -132,10 +202,11 @@ export async function resolveStoreOfferSheetAuthority({
           playersMatch,
           capHoldMatch,
           snapshotPlayer,
-        } as StoreOfferSheetOwnershipCandidate;
+          lineageReceipt,
+        } as StoreOfferSheetOwnershipCandidateWithReceipt;
       })
     )
-  ).filter(Boolean) as StoreOfferSheetOwnershipCandidate[];
+  ).filter(Boolean) as StoreOfferSheetOwnershipCandidateWithReceipt[];
 
   const rosterOwners = ownershipCandidates.filter(
     (candidate) => candidate.rosterMatch === true
@@ -147,7 +218,8 @@ export async function resolveStoreOfferSheetAuthority({
     (candidate) => candidate.capHoldMatch === true
   );
 
-  let resolvedOwner: StoreOfferSheetOwnershipCandidate | null = null;
+  let resolvedOwner: StoreOfferSheetOwnershipCandidateWithReceipt | null =
+    null;
 
   if (rosterOwners.length === 1) {
     resolvedOwner = rosterOwners[0];
@@ -228,6 +300,24 @@ export async function resolveStoreOfferSheetAuthority({
     );
   }
 
+  const [offeringLineageAfter, homeLineageAfter] = await Promise.all([
+    getWorldTeamSnapshotLineageReceipt(lineageWorldIds, offeringTeamCode),
+    getWorldTeamSnapshotLineageReceipt(
+      lineageWorldIds,
+      resolvedOwner.teamCode
+    ),
+  ]);
+  requireStableTeamLineageReceipt({
+    before: offeringLineageBefore,
+    after: offeringLineageAfter,
+    teamCode: offeringTeamCode,
+  });
+  requireStableTeamLineageReceipt({
+    before: resolvedOwner.lineageReceipt,
+    after: homeLineageAfter,
+    teamCode: resolvedOwner.teamCode,
+  });
+
   return {
     team: offeringTeam,
     player: {
@@ -246,6 +336,18 @@ export async function resolveStoreOfferSheetAuthority({
     },
     teamCode: offeringTeamCode,
     homeTeam: resolvedOwner.team,
+    offerSheetCreationSnapshots: Object.freeze({
+      homeTeamCode: resolvedOwner.teamCode,
+      offeringTeamCode,
+      homeTeam: toOfferSheetCreationTeamReceipt(
+        homeLineageAfter,
+        worldId
+      ),
+      offeringTeam: toOfferSheetCreationTeamReceipt(
+        offeringLineageAfter,
+        worldId
+      ),
+    }),
   };
 }
 
@@ -264,6 +366,94 @@ function findRawOfferSheetById(
           String(sheet.dedupKey || '') === offerSheetId)
     ) || null
   );
+}
+
+function requireImmutableOfferSheetResolutionAuthority({
+  worldId,
+  offerSheetId,
+  homeTeamCode,
+  offeringTeamCode,
+  homeSheet,
+  offeringSheet,
+  immutableBasePlayer,
+  authorizationDocument,
+}: {
+  worldId: string;
+  offerSheetId: string;
+  homeTeamCode: string;
+  offeringTeamCode: string;
+  homeSheet: Record<string, unknown> | null;
+  offeringSheet: Record<string, unknown> | null;
+  immutableBasePlayer: unknown;
+  authorizationDocument: {
+    exists: () => boolean;
+    data: () => unknown;
+  };
+}) {
+  const homeLifecycle = GovernedOfferSheetLifecycleZ.safeParse(
+    homeSheet?.governedLifecycle
+  );
+  const offeringLifecycle = GovernedOfferSheetLifecycleZ.safeParse(
+    offeringSheet?.governedLifecycle
+  );
+  const dedupKey = String(homeSheet?.dedupKey || '').trim();
+  if (
+    !homeLifecycle.success ||
+    !offeringLifecycle.success ||
+    homeLifecycle.data.status !== 'pending-match' ||
+    offeringLifecycle.data.status !== 'pending-match' ||
+    String(homeSheet?.id || '').trim() !== offerSheetId ||
+    String(offeringSheet?.id || '').trim() !== offerSheetId ||
+    String(offeringSheet?.dedupKey || '').trim() !== dedupKey ||
+    mutationSnapshotDigest(homeLifecycle.data) !==
+      mutationSnapshotDigest(offeringLifecycle.data)
+  ) {
+    throw new Error(
+      'Offer Sheet resolution requires two identical pending mirrors before immutable authorization can be verified.'
+    );
+  }
+
+  const expectedAuthorization = buildGovernedOfferSheetAuthorization({
+    lifecycle: homeLifecycle.data,
+    offerSheetId,
+    dedupKey,
+  });
+  const storedAuthorization = authorizationDocument.exists()
+    ? GovernedOfferSheetAuthorizationZ.safeParse(authorizationDocument.data())
+    : null;
+  if (
+    !storedAuthorization?.success ||
+    mutationSnapshotDigest(storedAuthorization.data) !==
+      mutationSnapshotDigest(expectedAuthorization) ||
+    storedAuthorization.data.worldId !== worldId ||
+    storedAuthorization.data.homeTeamId !== homeTeamCode ||
+    storedAuthorization.data.offeringTeamId !== offeringTeamCode
+  ) {
+    throw new Error(
+      'Offer Sheet resolution authorization does not match the immutable creation anchor.'
+    );
+  }
+
+  const basePlayer = toCurrentStatePlayer(
+    immutableBasePlayer as MutationCurrentStatePlayerIngress | null
+  );
+  const immutableEvidence = GovernedOfferSheetEvidenceZ.safeParse(
+    basePlayer?.rfaContext?.governedEvidence
+  );
+  if (
+    !immutableEvidence.success ||
+    mutationSnapshotDigest(immutableEvidence.data) !==
+      expectedAuthorization.immutableEvidenceDigest
+  ) {
+    throw new Error(
+      'Offer Sheet resolution authorization does not match immutable base evidence.'
+    );
+  }
+
+  return Object.freeze({
+    authorization: localDocumentSnapshotReceipt(authorizationDocument),
+    immutableEvidenceDigest: expectedAuthorization.immutableEvidenceDigest,
+  });
 }
 
 function localDocumentSnapshotReceipt(snapshot: {
@@ -711,19 +901,24 @@ export async function loadStateForMutation(
       const offeringTeamDataBefore = offeringTeamDocumentBefore.exists()
         ? offeringTeamDocumentBefore.data()
         : {};
-      const rawOfferSheet =
-        findRawOfferSheetById(
-          (homeTeamDataBefore as Record<string, unknown>).incomingOfferSheets,
-          offerSheetId
-        ) ||
-        findRawOfferSheetById(
-          (offeringTeamDataBefore as Record<string, unknown>).offerSheets,
-          offerSheetId
-        );
+      const rawHomeOfferSheet = findRawOfferSheetById(
+        (homeTeamDataBefore as Record<string, unknown>).incomingOfferSheets,
+        offerSheetId
+      );
+      const rawOfferingOfferSheet = findRawOfferSheetById(
+        (offeringTeamDataBefore as Record<string, unknown>).offerSheets,
+        offerSheetId
+      );
+      const rawOfferSheet = rawHomeOfferSheet || rawOfferingOfferSheet;
       const resolutionPlayerId = String(
         payload.playerId || rawOfferSheet?.playerId || ''
       ).trim();
-      const [homePlayerDocumentBefore, offeringPlayerDocumentBefore] =
+      const [
+        homePlayerDocumentBefore,
+        offeringPlayerDocumentBefore,
+        authorizationDocument,
+        immutableBasePlayer,
+      ] =
         resolutionPlayerId
           ? await Promise.all([
               getDoc(
@@ -732,8 +927,28 @@ export async function loadStateForMutation(
               getDoc(
                 worldPlayerRef(worldId, offeringTeamCode, resolutionPlayerId)
               ),
+              getDoc(
+                worldOfferSheetAuthorizationRef(worldId, offerSheetId)
+              ),
+              getPlayer(null, homeTeamCode, resolutionPlayerId),
             ])
-          : [null, null];
+          : [null, null, null, null];
+      if (!authorizationDocument) {
+        throw new Error(
+          'Offer Sheet resolution requires a stable player identity for immutable authorization.'
+        );
+      }
+      const immutableAuthority =
+        requireImmutableOfferSheetResolutionAuthority({
+          worldId,
+          offerSheetId,
+          homeTeamCode,
+          offeringTeamCode,
+          homeSheet: rawHomeOfferSheet,
+          offeringSheet: rawOfferingOfferSheet,
+          immutableBasePlayer,
+          authorizationDocument,
+        });
 
       const [homeTeamRaw, offeringTeamRaw] = await Promise.all([
         getTeam(worldId, homeTeamCode),
@@ -828,6 +1043,9 @@ export async function loadStateForMutation(
           offeringTeam: offeringTeamReceipt,
           homePlayer: homePlayerReceipt,
           offeringPlayer: offeringPlayerReceipt,
+          authorization: immutableAuthority.authorization,
+          immutableEvidenceDigest:
+            immutableAuthority.immutableEvidenceDigest,
         },
       };
     }

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -8,10 +8,7 @@
  * Wave 48 Step 1: Lineage helpers extracted to submodule.
  */
 
-import {
-  getTeam,
-  getPlayer,
-} from '@/features/architect/utils/teamLoader';
+import { getTeam, getPlayer } from '@/features/architect/utils/teamLoader';
 import { getDoc } from 'firebase/firestore';
 import {
   worldPlayerRef,
@@ -28,12 +25,11 @@ import {
   removeUndefinedDeep,
   toCurrentStatePlayer,
 } from './mutationPipeline.helpers';
-import {
-  toCurrentStateTeam,
-} from './mutationPipeline.read.normalizeTeam';
+import { toCurrentStateTeam } from './mutationPipeline.read.normalizeTeam';
 import { loadWorldGovernedOptionAuthority } from '@/features/architect/utils/optionDecisions';
 import { loadWorldGovernedExtensionAuthority } from '@/features/architect/utils/extensions';
 import { mutationSnapshotDigest } from './mutationPipeline.snapshotDigest';
+import type { GovernedOfferSheetLifecycle } from '@/schemas/governedOfferSheet';
 
 // Wave 48 Step 1: lineage helpers extracted to submodule
 export * from './mutationPipeline.read.stateLoader.lineage';
@@ -286,7 +282,9 @@ function rawRosterEntryId(entry: unknown): string {
   }
   if (entry && typeof entry === 'object') {
     const record = entry as Record<string, unknown>;
-    return String(record.playerId || record.player_id || record.id || '').trim();
+    return String(
+      record.playerId || record.player_id || record.id || ''
+    ).trim();
   }
   return '';
 }
@@ -324,9 +322,7 @@ async function ensureOfferSheetPlayerOnHomeTeamSnapshot({
   const offerSheet =
     findRawOfferSheetById(homeTeam.incomingOfferSheets, offerSheetId) ||
     findRawOfferSheetById(offeringTeam?.offerSheets, offerSheetId);
-  const playerId = String(
-    payloadPlayerId || offerSheet?.playerId || ''
-  ).trim();
+  const playerId = String(payloadPlayerId || offerSheet?.playerId || '').trim();
   if (!playerId) {
     return homeTeam;
   }
@@ -377,7 +373,6 @@ async function ensureOfferSheetPlayerOnHomeTeamSnapshot({
     roster: rosterHasPlayer ? existingRoster : [...existingRoster, playerId],
   };
 }
-
 
 // ==============================================================================
 // MAIN ENTRY POINT
@@ -542,10 +537,7 @@ export async function loadStateForMutation(
         await Promise.all([
           teamDocumentExists
             ? Promise.resolve({ source: null, checkedSnapshots: [] })
-            : getWorldTeamSnapshotLineageReceipt(
-                ancestorWorldIds,
-                teamCode
-              ),
+            : getWorldTeamSnapshotLineageReceipt(ancestorWorldIds, teamCode),
           playerDocumentExists
             ? Promise.resolve({ source: null, checkedSnapshots: [] })
             : getWorldPlayerSnapshotLineageReceipt(
@@ -580,10 +572,10 @@ export async function loadStateForMutation(
           digest: teamDocumentDigest,
           sourceWorldId: teamDocumentExists
             ? worldId
-            : ancestorTeamDocument?.snapshotWorldId ?? null,
+            : (ancestorTeamDocument?.snapshotWorldId ?? null),
           sourceDigest: teamDocumentExists
             ? teamDocumentDigest
-            : ancestorTeamDocument?.snapshotDigest ?? null,
+            : (ancestorTeamDocument?.snapshotDigest ?? null),
           sourceLineage: ancestorTeamResolution.checkedSnapshots,
         },
         extensionPlayerSnapshot: {
@@ -591,10 +583,10 @@ export async function loadStateForMutation(
           digest: playerDocumentDigest,
           sourceWorldId: playerDocumentExists
             ? worldId
-            : ancestorPlayerDocument?.overrideWorldId ?? null,
+            : (ancestorPlayerDocument?.overrideWorldId ?? null),
           sourceDigest: playerDocumentExists
             ? playerDocumentDigest
-            : ancestorPlayerDocument?.snapshotDigest ?? null,
+            : (ancestorPlayerDocument?.snapshotDigest ?? null),
           sourceLineage: ancestorPlayerResolution.checkedSnapshots,
         },
       };
@@ -854,11 +846,6 @@ export type MutationPlayerIdCarrier = Pick<
   'player_id' | 'playerId' | 'id'
 >;
 
-
-
-
-
-
 export function matchesOfferSheetIdentity(
   offerSheet: ArchitectMutationOfferSheet | null | undefined,
   offerSheetId: string,
@@ -910,12 +897,14 @@ export function buildNormalizedOfferSheetFinalContract({
   signedUsing,
   timestamp,
   signingDate,
+  governedLifecycle,
 }: {
   offerSheet: ArchitectMutationOfferSheet;
   signingTeam: string;
   signedUsing: string;
   timestamp: number;
   signingDate?: string;
+  governedLifecycle?: GovernedOfferSheetLifecycle;
 }) {
   const salariesByYear = (offerSheet.salariesByYear || [])
     .map(normalizeSalaryRow)
@@ -943,6 +932,23 @@ export function buildNormalizedOfferSheetFinalContract({
         ? computedTotalValue
         : undefined;
 
+  const resolutionEvent = governedLifecycle?.events.at(-1);
+  const matchRestriction =
+    governedLifecycle && resolutionEvent?.eventKind === 'offer-sheet-matched'
+      ? {
+          restrictionVersion: 1 as const,
+          lifecycleId: governedLifecycle.ledgerId,
+          eventId: resolutionEvent.eventId,
+          matchedAt: resolutionEvent.executedAt,
+          restrictedUntil: resolutionEvent.restrictionsUntil,
+          offeringTeamId: governedLifecycle.offeringTeamId,
+          playerTradeConsentRequired:
+            resolutionEvent.playerTradeConsentRequired,
+          offeringTeamTradeBarred: resolutionEvent.offeringTeamTradeBarred,
+          signAndTradeBarred: resolutionEvent.signAndTradeBarred,
+        }
+      : undefined;
+
   const normalizedContract = normalizeContractForWorld({
     contractType: 'Standard',
     signedUsing,
@@ -956,6 +962,13 @@ export function buildNormalizedOfferSheetFinalContract({
     rfaOfferSheet: undefined,
     rfaOfferSheetOnly: undefined,
     rfaOfferSheetStatus: undefined,
+    tradeRestrictions: matchRestriction
+      ? [
+          `Matched Offer Sheet: player consent required and offering-Team trade barred through ${matchRestriction.restrictedUntil}`,
+          `Matched Offer Sheet: contract amendment and sign-and-trade barred through ${matchRestriction.restrictedUntil}`,
+        ]
+      : undefined,
+    offerSheetMatchRestriction: matchRestriction,
   }) as ArchitectMutationContract | null;
 
   return removeUndefinedDeep(normalizedContract) as ArchitectMutationContract;

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -212,6 +212,11 @@ export async function resolveStoreOfferSheetAuthority({
         )
       : null;
   const sourcePlayer = resolvedOwner.snapshotPlayer || capHoldRightsPlayer;
+  // BZE-283 authority is source-owned. A mutable world player override may
+  // alter ordinary player/contract state, but it may never author or replace
+  // the authenticated RFA/QO evidence used to permit an Offer Sheet.
+  const sourceGovernedOfferSheetEvidence =
+    sourcePlayer?.rfaContext?.governedEvidence;
 
   const canonicalPlayer = overrideEntry
     ? normalizeCurrentStatePlayerSnapshot(
@@ -232,6 +237,14 @@ export async function resolveStoreOfferSheetAuthority({
     team: offeringTeam,
     player: {
       ...canonicalPlayer,
+      ...(sourceGovernedOfferSheetEvidence !== undefined
+        ? {
+            rfaContext: {
+              ...(canonicalPlayer.rfaContext || {}),
+              governedEvidence: sourceGovernedOfferSheetEvidence,
+            },
+          }
+        : {}),
       teamCode: resolvedOwner.teamCode,
       teamName: resolvedOwner.team.teamName || canonicalPlayer.teamName || null,
     },
@@ -896,11 +909,13 @@ export function buildNormalizedOfferSheetFinalContract({
   signingTeam,
   signedUsing,
   timestamp,
+  signingDate,
 }: {
   offerSheet: ArchitectMutationOfferSheet;
   signingTeam: string;
   signedUsing: string;
   timestamp: number;
+  signingDate?: string;
 }) {
   const salariesByYear = (offerSheet.salariesByYear || [])
     .map(normalizeSalaryRow)
@@ -932,7 +947,7 @@ export function buildNormalizedOfferSheetFinalContract({
     contractType: 'Standard',
     signedUsing,
     signingTeam,
-    signingDate: new Date(timestamp).toISOString(),
+    signingDate: signingDate || new Date(timestamp).toISOString(),
     contractLength: contractYearsCandidate,
     years: contractYearsCandidate,
     totalValue,

--- a/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
+++ b/src/features/architect/utils/mutationPipeline.read.stateLoader.ts
@@ -266,6 +266,33 @@ function findRawOfferSheetById(
   );
 }
 
+function localDocumentSnapshotReceipt(snapshot: {
+  exists: () => boolean;
+  data: () => unknown;
+}) {
+  const exists = snapshot.exists();
+  return Object.freeze({
+    exists,
+    digest: exists ? mutationSnapshotDigest(snapshot.data()) : null,
+  });
+}
+
+function requireStableLocalSnapshotReceipt({
+  before,
+  after,
+  label,
+}: {
+  before: Readonly<{ exists: boolean; digest: string | null }>;
+  after: Readonly<{ exists: boolean; digest: string | null }>;
+  label: string;
+}): void {
+  if (before.exists !== after.exists || before.digest !== after.digest) {
+    throw new Error(
+      `${label} changed while the Offer Sheet resolution state was loading. Reload and try again.`
+    );
+  }
+}
+
 function rawTeamPlayerId(player: Record<string, unknown>): string {
   const bio =
     player.bio && typeof player.bio === 'object'
@@ -664,6 +691,50 @@ export async function loadStateForMutation(
       if (!offeringTeamCode) throw new Error(`Missing offeringTeamCode`);
       if (!offerSheetId) throw new Error(`Missing offerSheetId`);
 
+      // Capture the exact local documents before and after merged state loading.
+      // The double read closes the gap between teamLoader's merged snapshot and
+      // the raw receipt later checked inside the persistence transaction.
+      const [homeTeamDocumentBefore, offeringTeamDocumentBefore] =
+        await Promise.all([
+          getDoc(worldTeamRef(worldId, homeTeamCode)),
+          getDoc(worldTeamRef(worldId, offeringTeamCode)),
+        ]);
+      const homeTeamReceiptBefore = localDocumentSnapshotReceipt(
+        homeTeamDocumentBefore
+      );
+      const offeringTeamReceiptBefore = localDocumentSnapshotReceipt(
+        offeringTeamDocumentBefore
+      );
+      const homeTeamDataBefore = homeTeamDocumentBefore.exists()
+        ? homeTeamDocumentBefore.data()
+        : {};
+      const offeringTeamDataBefore = offeringTeamDocumentBefore.exists()
+        ? offeringTeamDocumentBefore.data()
+        : {};
+      const rawOfferSheet =
+        findRawOfferSheetById(
+          (homeTeamDataBefore as Record<string, unknown>).incomingOfferSheets,
+          offerSheetId
+        ) ||
+        findRawOfferSheetById(
+          (offeringTeamDataBefore as Record<string, unknown>).offerSheets,
+          offerSheetId
+        );
+      const resolutionPlayerId = String(
+        payload.playerId || rawOfferSheet?.playerId || ''
+      ).trim();
+      const [homePlayerDocumentBefore, offeringPlayerDocumentBefore] =
+        resolutionPlayerId
+          ? await Promise.all([
+              getDoc(
+                worldPlayerRef(worldId, homeTeamCode, resolutionPlayerId)
+              ),
+              getDoc(
+                worldPlayerRef(worldId, offeringTeamCode, resolutionPlayerId)
+              ),
+            ])
+          : [null, null];
+
       const [homeTeamRaw, offeringTeamRaw] = await Promise.all([
         getTeam(worldId, homeTeamCode),
         getTeam(worldId, offeringTeamCode),
@@ -688,6 +759,59 @@ export async function loadStateForMutation(
         payloadPlayerId: payload.playerId as string | null | undefined,
       });
 
+      const [
+        homeTeamDocument,
+        offeringTeamDocument,
+        homePlayerDocument,
+        offeringPlayerDocument,
+      ] = await Promise.all([
+        getDoc(worldTeamRef(worldId, homeTeamCode)),
+        getDoc(worldTeamRef(worldId, offeringTeamCode)),
+        resolutionPlayerId
+          ? getDoc(
+              worldPlayerRef(worldId, homeTeamCode, resolutionPlayerId)
+            )
+          : Promise.resolve(null),
+        resolutionPlayerId
+          ? getDoc(
+              worldPlayerRef(worldId, offeringTeamCode, resolutionPlayerId)
+            )
+          : Promise.resolve(null),
+      ]);
+      const homeTeamReceipt = localDocumentSnapshotReceipt(homeTeamDocument);
+      const offeringTeamReceipt =
+        localDocumentSnapshotReceipt(offeringTeamDocument);
+      const homePlayerReceipt = homePlayerDocument
+        ? localDocumentSnapshotReceipt(homePlayerDocument)
+        : { exists: false, digest: null };
+      const offeringPlayerReceipt = offeringPlayerDocument
+        ? localDocumentSnapshotReceipt(offeringPlayerDocument)
+        : { exists: false, digest: null };
+      requireStableLocalSnapshotReceipt({
+        before: homeTeamReceiptBefore,
+        after: homeTeamReceipt,
+        label: `Team snapshot for ${homeTeamCode}`,
+      });
+      requireStableLocalSnapshotReceipt({
+        before: offeringTeamReceiptBefore,
+        after: offeringTeamReceipt,
+        label: `Team snapshot for ${offeringTeamCode}`,
+      });
+      requireStableLocalSnapshotReceipt({
+        before: homePlayerDocumentBefore
+          ? localDocumentSnapshotReceipt(homePlayerDocumentBefore)
+          : { exists: false, digest: null },
+        after: homePlayerReceipt,
+        label: `Player snapshot for ${resolutionPlayerId} on ${homeTeamCode}`,
+      });
+      requireStableLocalSnapshotReceipt({
+        before: offeringPlayerDocumentBefore
+          ? localDocumentSnapshotReceipt(offeringPlayerDocumentBefore)
+          : { exists: false, digest: null },
+        after: offeringPlayerReceipt,
+        label: `Player snapshot for ${resolutionPlayerId} on ${offeringTeamCode}`,
+      });
+
       return {
         homeTeam: toCurrentStateTeam(homeTeam, 'offerSheetResolution'),
         offeringTeam: toCurrentStateTeam(
@@ -696,6 +820,15 @@ export async function loadStateForMutation(
           'offerSheetResolution'
         ),
         offerSheetId,
+        offerSheetResolutionSnapshots: {
+          playerId: resolutionPlayerId,
+          homeTeamCode,
+          offeringTeamCode,
+          homeTeam: homeTeamReceipt,
+          offeringTeam: offeringTeamReceipt,
+          homePlayer: homePlayerReceipt,
+          offeringPlayer: offeringPlayerReceipt,
+        },
       };
     }
 

--- a/src/features/architect/utils/mutationPipeline.types.currentState.ts
+++ b/src/features/architect/utils/mutationPipeline.types.currentState.ts
@@ -217,6 +217,7 @@ export type CurrentStatePlayerRfaContext = {
   pendingHomeTeamCode?: string;
   offerSheetId?: string;
   retainedUntilFinalize?: boolean;
+  governedEvidence?: unknown;
 };
 export type CurrentStatePlayerComputeCore = Omit<
   Pick<

--- a/src/features/architect/utils/mutationPipeline.types.currentState.ts
+++ b/src/features/architect/utils/mutationPipeline.types.currentState.ts
@@ -61,6 +61,7 @@ const CURRENT_STATE_PLAYER_CONTRACT_KEYS = [
   'tradeKicker',
   'tradeRestrictions',
   'tradeEligibility',
+  'offerSheetMatchRestriction',
 ] as const;
 // These current-contract fields remain on the normalized player seam because
 // option/signing flows spread the existing contract before canonicalization and
@@ -155,6 +156,7 @@ export type MutationCurrentStatePlayerContractIngress = {
   tradeKicker?: MutationCurrentStateContractNumberish;
   tradeRestrictions?: string[] | null;
   tradeEligibility?: CurrentStatePlayerContractTradeEligibility | null;
+  offerSheetMatchRestriction?: unknown;
 };
 export type MutationCurrentStatePlayerFutureContractIngress = {
   salariesByYear?: MutationCurrentStatePlayerContractSalaryRowIngress[] | null;
@@ -403,17 +405,22 @@ export type CurrentStateTeamMutationCoreFieldMap = Pick<
   | 'hardCapTriggeredBy'
 >;
 export type CurrentStateTeamRosterFieldMap = Pick<CurrentStateTeam, 'roster'>;
-export type CurrentStateTeamExceptionsFieldMap = Pick<CurrentStateTeam, 'exceptions'>;
+export type CurrentStateTeamExceptionsFieldMap = Pick<
+  CurrentStateTeam,
+  'exceptions'
+>;
 export type CurrentStateOfferSheetTeamLiveFieldMap = Pick<
   CurrentStateTeam,
   'offerSheets' | 'incomingOfferSheets'
 >;
-export type CurrentStatePlayerOpsTeamCompute = CurrentStateTeamIdentityFieldMap &
-  CurrentStateTeamMutationCoreFieldMap &
-  CurrentStateTeamRosterFieldMap;
-export type CurrentStateManualCapTeamCompute = CurrentStateTeamIdentityFieldMap &
-  CurrentStateTeamMutationCoreFieldMap &
-  CurrentStateTeamExceptionsFieldMap;
+export type CurrentStatePlayerOpsTeamCompute =
+  CurrentStateTeamIdentityFieldMap &
+    CurrentStateTeamMutationCoreFieldMap &
+    CurrentStateTeamRosterFieldMap;
+export type CurrentStateManualCapTeamCompute =
+  CurrentStateTeamIdentityFieldMap &
+    CurrentStateTeamMutationCoreFieldMap &
+    CurrentStateTeamExceptionsFieldMap;
 export type CurrentStateSigningTeamCompute = CurrentStatePlayerOpsTeamCompute &
   CurrentStateTeamExceptionsFieldMap &
   Pick<CurrentStateTeam, 'offerSheets'>;
@@ -466,15 +473,16 @@ export type CurrentStateBaseTeamDraftPicksCarrier = {
 export type CurrentStateBaseTeamEntitlementIdsCarrier = {
   [CURRENT_STATE_BASE_TEAM_ENTITLEMENT_IDS_FIELD_KEY]?: CurrentStateBaseTeamPreservedFieldMap['entitlementIds'];
 };
-export type CurrentStateBaseTeamRoundTripCarrier = CurrentStateBaseTeamRosterCarrier &
-  CurrentStateBaseTeamExceptionsCarrier &
-  CurrentStateBaseTeamOfferSheetsCarrier &
-  CurrentStateBaseTeamIncomingOfferSheetsCarrier &
-  CurrentStateBaseTeamTradeExceptionsCarrier &
-  CurrentStateBaseTeamCashLedgerCarrier &
-  CurrentStateBaseTeamExceptionHistoryCarrier &
-  CurrentStateBaseTeamDraftPicksCarrier &
-  CurrentStateBaseTeamEntitlementIdsCarrier;
+export type CurrentStateBaseTeamRoundTripCarrier =
+  CurrentStateBaseTeamRosterCarrier &
+    CurrentStateBaseTeamExceptionsCarrier &
+    CurrentStateBaseTeamOfferSheetsCarrier &
+    CurrentStateBaseTeamIncomingOfferSheetsCarrier &
+    CurrentStateBaseTeamTradeExceptionsCarrier &
+    CurrentStateBaseTeamCashLedgerCarrier &
+    CurrentStateBaseTeamExceptionHistoryCarrier &
+    CurrentStateBaseTeamDraftPicksCarrier &
+    CurrentStateBaseTeamEntitlementIdsCarrier;
 export type CurrentStateBaseTeamPreservedCarrierLike =
   CurrentStateBaseTeamRoundTripCarrier;
 export type CurrentStatePlayerOpsTeam = CurrentStatePlayerOpsTeamCompute &
@@ -502,7 +510,9 @@ export type CurrentStateNonTradeTeamRoundTripMaterializable =
   | CurrentStateSigningTeam
   | CurrentStateOfferSheetMirrorTeam
   | CurrentStateOfferSheetResolutionTeam;
-export type BaseTeamLike = CurrentStatePlayerOpsTeam | CurrentStateManualCapTeam;
+export type BaseTeamLike =
+  | CurrentStatePlayerOpsTeam
+  | CurrentStateManualCapTeam;
 export type OfferSheetTeamLike =
   | CurrentStateSigningTeam
   | CurrentStateOfferSheetMirrorTeam

--- a/src/features/architect/utils/mutationPipeline.types.ingress.ts
+++ b/src/features/architect/utils/mutationPipeline.types.ingress.ts
@@ -164,6 +164,7 @@ export type MutationCurrentStateClosedShape = {
   extensionAuthority?: undefined;
   extensionTeamSnapshot?: undefined;
   extensionPlayerSnapshot?: undefined;
+  offerSheetCreationSnapshots?: undefined;
   offerSheetResolutionSnapshots?: undefined;
 };
 export type MutationDocumentSnapshotReceipt = Readonly<{
@@ -176,6 +177,12 @@ export type MutationDocumentSnapshotReceipt = Readonly<{
     exists: boolean;
     digest: string | null;
   }>[];
+}>;
+export type ArchitectOfferSheetCreationSnapshotReceipts = Readonly<{
+  homeTeamCode: string;
+  offeringTeamCode: string;
+  homeTeam: MutationDocumentSnapshotReceipt;
+  offeringTeam: MutationDocumentSnapshotReceipt;
 }>;
 export type MutationCurrentStateTradeTeamEntryInput = {
   teamCode?: string | null;
@@ -214,12 +221,13 @@ export type MutationTeamAndPlayerCurrentStateIngress = Omit<
 };
 export type MutationSigningCurrentStateIngress = Omit<
   MutationCurrentStateClosedShape,
-  'team' | 'player' | 'homeTeam' | 'teamCode'
+  'team' | 'player' | 'homeTeam' | 'teamCode' | 'offerSheetCreationSnapshots'
 > & {
   team?: MutationCurrentStateOfferSheetTeamIngress | null;
   player?: MutationCurrentStatePlayerIngress | null;
   homeTeam?: MutationCurrentStateOfferSheetTeamIngress | null;
   teamCode?: string | null;
+  offerSheetCreationSnapshots?: ArchitectOfferSheetCreationSnapshotReceipts | null;
 };
 export type MutationOfferSheetMirrorCurrentStateIngress = Omit<
   MutationCurrentStateClosedShape,
@@ -272,6 +280,7 @@ export type MutationCurrentState = {
   extensionAuthority?: GovernedExtensionLedgerAuthority | null;
   extensionTeamSnapshot?: MutationDocumentSnapshotReceipt | null;
   extensionPlayerSnapshot?: MutationDocumentSnapshotReceipt | null;
+  offerSheetCreationSnapshots?: ArchitectOfferSheetCreationSnapshotReceipts | null;
   offerSheetResolutionSnapshots?: ArchitectOfferSheetResolutionSnapshotReceipts | null;
 };
 export type MutationTradeCurrentState = Omit<
@@ -311,9 +320,12 @@ export type MutationTeamAndPlayerCurrentState = Omit<
   };
 export type MutationOfferSheetTeamAndPlayerCurrentState = Omit<
   MutationCurrentStateClosedShape,
-  'team' | 'player' | 'homeTeam' | 'teamCode'
+  'team' | 'player' | 'homeTeam' | 'teamCode' | 'offerSheetCreationSnapshots'
 > &
-  Pick<MutationCurrentState, 'team' | 'player' | 'homeTeam' | 'teamCode'> & {
+  Pick<
+    MutationCurrentState,
+    'team' | 'player' | 'homeTeam' | 'teamCode' | 'offerSheetCreationSnapshots'
+  > & {
     team?: CurrentStateSigningTeam | null;
     player?: PlayerLike | null;
     homeTeam?: CurrentStateOfferSheetMirrorTeam | null;
@@ -321,9 +333,12 @@ export type MutationOfferSheetTeamAndPlayerCurrentState = Omit<
 export type MutationSigningTeamLike = CurrentStateSigningTeam | TradeTeamLike;
 export type MutationSigningCurrentState = Omit<
   MutationCurrentStateClosedShape,
-  'team' | 'player' | 'homeTeam' | 'teamCode'
+  'team' | 'player' | 'homeTeam' | 'teamCode' | 'offerSheetCreationSnapshots'
 > &
-  Pick<MutationCurrentState, 'team' | 'player' | 'homeTeam' | 'teamCode'> & {
+  Pick<
+    MutationCurrentState,
+    'team' | 'player' | 'homeTeam' | 'teamCode' | 'offerSheetCreationSnapshots'
+  > & {
     team?: MutationSigningTeamLike | null;
     player?: PlayerLike | null;
     homeTeam?: CurrentStateOfferSheetMirrorTeam | null;

--- a/src/features/architect/utils/mutationPipeline.types.ingress.ts
+++ b/src/features/architect/utils/mutationPipeline.types.ingress.ts
@@ -54,6 +54,7 @@ import type {
   TradeTeamLike,
 } from './mutationPipeline.types.currentState';
 import type {
+  ArchitectOfferSheetResolutionSnapshotReceipts,
   MutationCurrentStateTeamEntry,
   SupportedComputeMutationType,
 } from './mutationPipeline.types.result';
@@ -163,6 +164,7 @@ export type MutationCurrentStateClosedShape = {
   extensionAuthority?: undefined;
   extensionTeamSnapshot?: undefined;
   extensionPlayerSnapshot?: undefined;
+  offerSheetResolutionSnapshots?: undefined;
 };
 export type MutationDocumentSnapshotReceipt = Readonly<{
   exists: boolean;
@@ -229,11 +231,15 @@ export type MutationOfferSheetMirrorCurrentStateIngress = Omit<
 };
 export type MutationOfferSheetResolutionCurrentStateIngress = Omit<
   MutationCurrentStateClosedShape,
-  'homeTeam' | 'offeringTeam' | 'offerSheetId'
+  | 'homeTeam'
+  | 'offeringTeam'
+  | 'offerSheetId'
+  | 'offerSheetResolutionSnapshots'
 > & {
   homeTeam?: MutationCurrentStateOfferSheetTeamIngress | null;
   offeringTeam?: MutationCurrentStateOfferSheetTeamIngress | null;
   offerSheetId?: string | null;
+  offerSheetResolutionSnapshots?: ArchitectOfferSheetResolutionSnapshotReceipts | null;
 };
 export type MutationSignAndTradeCurrentStateIngress = Omit<
   MutationCurrentStateClosedShape,
@@ -266,6 +272,7 @@ export type MutationCurrentState = {
   extensionAuthority?: GovernedExtensionLedgerAuthority | null;
   extensionTeamSnapshot?: MutationDocumentSnapshotReceipt | null;
   extensionPlayerSnapshot?: MutationDocumentSnapshotReceipt | null;
+  offerSheetResolutionSnapshots?: ArchitectOfferSheetResolutionSnapshotReceipts | null;
 };
 export type MutationTradeCurrentState = Omit<
   MutationCurrentStateClosedShape,
@@ -331,9 +338,18 @@ export type MutationOfferSheetMirrorCurrentState = Omit<
   };
 export type MutationOfferSheetResolutionCurrentState = Omit<
   MutationCurrentStateClosedShape,
-  'homeTeam' | 'offeringTeam' | 'offerSheetId'
+  | 'homeTeam'
+  | 'offeringTeam'
+  | 'offerSheetId'
+  | 'offerSheetResolutionSnapshots'
 > &
-  Pick<MutationCurrentState, 'homeTeam' | 'offeringTeam' | 'offerSheetId'> & {
+  Pick<
+    MutationCurrentState,
+    | 'homeTeam'
+    | 'offeringTeam'
+    | 'offerSheetId'
+    | 'offerSheetResolutionSnapshots'
+  > & {
     homeTeam?: CurrentStateOfferSheetResolutionTeam | null;
     offeringTeam?: CurrentStateOfferSheetResolutionTeam | null;
   };

--- a/src/features/architect/utils/mutationPipeline.types.record.ts
+++ b/src/features/architect/utils/mutationPipeline.types.record.ts
@@ -256,6 +256,7 @@ export type ArchitectMutationContract = {
   tradeKicker?: number | null;
   tradeRestrictions?: string[] | null;
   tradeEligibility?: ArchitectMutationTradeEligibility | null;
+  offerSheetMatchRestriction?: unknown;
   isMaxContract?: boolean | null;
   maxType?: string | null;
   estimatedCapPercentage?: number | null;
@@ -538,7 +539,13 @@ export type ArchitectTradePayloadTeamRef = {
 // Only read by leagueInvariants.extractIncomingPlayers for cross-team duplicate detection.
 export type ArchitectTradePayloadLegacyReceivingPlayer = Pick<
   ArchitectMutationPlayerRecord,
-  'player_id' | 'id' | 'playerId' | 'bio' | 'displayName' | 'name' | 'playerName'
+  | 'player_id'
+  | 'id'
+  | 'playerId'
+  | 'bio'
+  | 'displayName'
+  | 'name'
+  | 'playerName'
 >;
 
 export type ArchitectTradePayloadTeamIngress = {
@@ -650,7 +657,10 @@ export type ArchitectMutationPayload = {
   extension?: ArchitectMutationContract | null;
   extensionProposal?: GovernedExtensionProposal | null;
   offerSheetProposal?: GovernedOfferSheetProposal | null;
-  offerSheetAveragingElection?: import('@/schemas/governedOfferSheet').GovernedOfferSheetAveragingElection | null;
+  offerSheetAveragingElection?:
+    | import('@/schemas/governedOfferSheet').GovernedOfferSheetAveragingElection
+    | null;
+  offerSheetResolutionAt?: string | number | null;
   signedUsing?: string | null;
   accepted?: boolean;
   signAndTrade?: boolean;
@@ -698,11 +708,7 @@ export type PublicWaiveMutationPayloadInput = PublicMutationPayloadSlice<
   | 'isGracePeriod'
 >;
 export type PublicExtensionMutationPayloadInput = PublicMutationPayloadSlice<
-  | 'teamCode'
-  | 'playerId'
-  | 'contractId'
-  | 'extension'
-  | 'extensionProposal'
+  'teamCode' | 'playerId' | 'contractId' | 'extension' | 'extensionProposal'
 >;
 export type PublicOptionMutationPayloadInput = PublicMutationPayloadSlice<
   | 'teamCode'
@@ -715,18 +721,20 @@ export type PublicOptionMutationPayloadInput = PublicMutationPayloadSlice<
 export type PublicRenounceMutationPayloadInput = PublicMutationPayloadSlice<
   'teamCode' | 'playerId'
 >;
-export type PublicStoreOfferSheetMutationPayloadInput = PublicMutationPayloadSlice<
-  | 'teamCode'
-  | 'playerId'
-  | 'contract'
-  | 'signedUsing'
-  | 'offerSheetId'
-  | 'offerSheetProposal'
-  | 'worldId'
->;
-export type PublicOfferSheetMirrorMutationPayloadInput = PublicMutationPayloadSlice<
-  'teamCode' | 'homeTeamCode' | 'offeringTeamCode' | 'offerSheetId'
->;
+export type PublicStoreOfferSheetMutationPayloadInput =
+  PublicMutationPayloadSlice<
+    | 'teamCode'
+    | 'playerId'
+    | 'contract'
+    | 'signedUsing'
+    | 'offerSheetId'
+    | 'offerSheetProposal'
+    | 'worldId'
+  >;
+export type PublicOfferSheetMirrorMutationPayloadInput =
+  PublicMutationPayloadSlice<
+    'teamCode' | 'homeTeamCode' | 'offeringTeamCode' | 'offerSheetId'
+  >;
 export type PublicOfferSheetResolutionMutationPayloadInput =
   PublicMutationPayloadSlice<
     | 'teamCode'
@@ -735,6 +743,7 @@ export type PublicOfferSheetResolutionMutationPayloadInput =
     | 'offerSheetId'
     | 'dedupKey'
     | 'offerSheetAveragingElection'
+    | 'offerSheetResolutionAt'
   >;
 export type PublicSignAndTradeMutationPayloadInput = PublicMutationPayloadSlice<
   'teamCode' | 'destinationTeamCode' | 'playerId' | 'contract' | 'signedUsing'
@@ -742,9 +751,8 @@ export type PublicSignAndTradeMutationPayloadInput = PublicMutationPayloadSlice<
 export type PublicSetDeadCapMutationPayloadInput = PublicMutationPayloadSlice<
   'teamCode' | 'deadCap' | 'deadCapChanges'
 >;
-export type PublicSetExceptionsMutationPayloadInput = PublicMutationPayloadSlice<
-  'teamCode' | 'exceptions' | 'exceptionChanges'
->;
+export type PublicSetExceptionsMutationPayloadInput =
+  PublicMutationPayloadSlice<'teamCode' | 'exceptions' | 'exceptionChanges'>;
 export type SigningMutationPayloadInput = NormalizedMutationPayloadSlice<
   'playerId' | 'contract' | 'signedUsing'
 >;
@@ -757,14 +765,18 @@ export type ExtensionMutationPayloadInput = NormalizedMutationPayloadSlice<
 export type OptionMutationPayloadInput = NormalizedMutationPayloadSlice<
   'playerId' | 'accepted' | 'targetYear' | 'contractId' | 'optionNotice'
 >;
-export type RenounceMutationPayloadInput = NormalizedMutationPayloadSlice<'playerId'>;
-export type StoreOfferSheetMutationPayloadInput = NormalizedMutationPayloadSlice<
-  'contract' | 'offerSheetId' | 'offerSheetProposal' | 'worldId'
->;
+export type RenounceMutationPayloadInput =
+  NormalizedMutationPayloadSlice<'playerId'>;
+export type StoreOfferSheetMutationPayloadInput =
+  NormalizedMutationPayloadSlice<
+    'contract' | 'offerSheetId' | 'offerSheetProposal' | 'worldId'
+  >;
 export type OfferSheetMirrorMutationPayloadInput =
   NormalizedMutationPayloadSlice<never>;
 export type OfferSheetResolutionMutationPayloadInput =
-  NormalizedMutationPayloadSlice<'dedupKey' | 'offerSheetAveragingElection'>;
+  NormalizedMutationPayloadSlice<
+    'dedupKey' | 'offerSheetAveragingElection' | 'offerSheetResolutionAt'
+  >;
 export type SignAndTradeMutationPayloadInput = NormalizedMutationPayloadSlice<
   'teamCode' | 'destinationTeamCode' | 'playerId' | 'contract' | 'signedUsing'
 >;

--- a/src/features/architect/utils/mutationPipeline.types.record.ts
+++ b/src/features/architect/utils/mutationPipeline.types.record.ts
@@ -37,6 +37,7 @@ import type { RightsEventLedgerPayload } from '@/schemas/rightsEventLedger';
 import type { ContractEventLedgerPayload } from '@/schemas/contractEventLedger';
 import type { GovernedOptionNoticeInput } from '@/schemas/governedOptionDecision';
 import type { GovernedExtensionProposal } from '@/schemas/governedExtension';
+import type { GovernedOfferSheetProposal } from '@/schemas/governedOfferSheet';
 import type { TradeSalaryMatchingElection } from '@/schemas/tradeSalaryMatchingPath';
 import type { TradeSalaryPathEvaluation } from '@/features/architect/utils/tradeMachine/utils/tradeSalaryMatchingPaths';
 
@@ -341,6 +342,8 @@ export type ArchitectMutationOfferSheet = {
   createdAt?: string | number | Date | null;
   matchedAt?: string | null;
   declinedAt?: string | null;
+  /** BZE-283: strict mirrored RFA/QO/Offer Sheet authority and lifecycle. */
+  governedLifecycle?: unknown;
 };
 
 export type ArchitectMutationCapHold = {
@@ -362,6 +365,8 @@ export type ArchitectMutationPlayerRfaContextIngress = {
   pendingHomeTeamCode?: string | null;
   offerSheetId?: string | null;
   retainedUntilFinalize?: boolean | null;
+  /** BZE-283: authenticated QO/RFA evidence read from canonical player truth. */
+  governedEvidence?: unknown;
 } & Record<string, unknown>;
 
 export type ArchitectMutationPlayerRecord = {
@@ -644,6 +649,8 @@ export type ArchitectMutationPayload = {
   contract?: ArchitectMutationContract | null;
   extension?: ArchitectMutationContract | null;
   extensionProposal?: GovernedExtensionProposal | null;
+  offerSheetProposal?: GovernedOfferSheetProposal | null;
+  offerSheetAveragingElection?: import('@/schemas/governedOfferSheet').GovernedOfferSheetAveragingElection | null;
   signedUsing?: string | null;
   accepted?: boolean;
   signAndTrade?: boolean;
@@ -714,6 +721,7 @@ export type PublicStoreOfferSheetMutationPayloadInput = PublicMutationPayloadSli
   | 'contract'
   | 'signedUsing'
   | 'offerSheetId'
+  | 'offerSheetProposal'
   | 'worldId'
 >;
 export type PublicOfferSheetMirrorMutationPayloadInput = PublicMutationPayloadSlice<
@@ -726,6 +734,7 @@ export type PublicOfferSheetResolutionMutationPayloadInput =
     | 'offeringTeamCode'
     | 'offerSheetId'
     | 'dedupKey'
+    | 'offerSheetAveragingElection'
   >;
 export type PublicSignAndTradeMutationPayloadInput = PublicMutationPayloadSlice<
   'teamCode' | 'destinationTeamCode' | 'playerId' | 'contract' | 'signedUsing'
@@ -750,12 +759,12 @@ export type OptionMutationPayloadInput = NormalizedMutationPayloadSlice<
 >;
 export type RenounceMutationPayloadInput = NormalizedMutationPayloadSlice<'playerId'>;
 export type StoreOfferSheetMutationPayloadInput = NormalizedMutationPayloadSlice<
-  'contract' | 'offerSheetId' | 'worldId'
+  'contract' | 'offerSheetId' | 'offerSheetProposal' | 'worldId'
 >;
 export type OfferSheetMirrorMutationPayloadInput =
   NormalizedMutationPayloadSlice<never>;
 export type OfferSheetResolutionMutationPayloadInput =
-  NormalizedMutationPayloadSlice<'dedupKey'>;
+  NormalizedMutationPayloadSlice<'dedupKey' | 'offerSheetAveragingElection'>;
 export type SignAndTradeMutationPayloadInput = NormalizedMutationPayloadSlice<
   'teamCode' | 'destinationTeamCode' | 'playerId' | 'contract' | 'signedUsing'
 >;

--- a/src/features/architect/utils/mutationPipeline.types.result.ts
+++ b/src/features/architect/utils/mutationPipeline.types.result.ts
@@ -308,6 +308,19 @@ export type ArchitectWorldMutationContractSummary = {
   endYear?: string;
   signedUsing?: string;
 };
+export type ArchitectMutationLocalDocumentSnapshotReceipt = Readonly<{
+  exists: boolean;
+  digest: string | null;
+}>;
+export type ArchitectOfferSheetResolutionSnapshotReceipts = Readonly<{
+  playerId: string;
+  homeTeamCode: string;
+  offeringTeamCode: string;
+  homeTeam: ArchitectMutationLocalDocumentSnapshotReceipt;
+  offeringTeam: ArchitectMutationLocalDocumentSnapshotReceipt;
+  homePlayer: ArchitectMutationLocalDocumentSnapshotReceipt;
+  offeringPlayer: ArchitectMutationLocalDocumentSnapshotReceipt;
+}>;
 export type ArchitectWorldMutationHistoryMetadata = {
   mutationType: string;
   category: string;
@@ -349,6 +362,7 @@ export type ArchitectWorldMutationHistoryMetadata = {
     exists: boolean;
     digest: string | null;
   }>[];
+  expectedOfferSheetResolutionSnapshots?: ArchitectOfferSheetResolutionSnapshotReceipts;
   optionType?: string;
   accepted?: boolean;
   contract: ArchitectWorldMutationContractSummary;

--- a/src/features/architect/utils/mutationPipeline.types.result.ts
+++ b/src/features/architect/utils/mutationPipeline.types.result.ts
@@ -320,6 +320,8 @@ export type ArchitectOfferSheetResolutionSnapshotReceipts = Readonly<{
   offeringTeam: ArchitectMutationLocalDocumentSnapshotReceipt;
   homePlayer: ArchitectMutationLocalDocumentSnapshotReceipt;
   offeringPlayer: ArchitectMutationLocalDocumentSnapshotReceipt;
+  authorization: ArchitectMutationLocalDocumentSnapshotReceipt;
+  immutableEvidenceDigest: string;
 }>;
 export type ArchitectWorldMutationHistoryMetadata = {
   mutationType: string;
@@ -362,6 +364,32 @@ export type ArchitectWorldMutationHistoryMetadata = {
     exists: boolean;
     digest: string | null;
   }>[];
+  expectedOfferSheetCreationSnapshots?: Readonly<{
+    homeTeamCode: string;
+    offeringTeamCode: string;
+    homeTeam: Readonly<{
+      exists: boolean;
+      digest: string | null;
+      sourceWorldId: string | null;
+      sourceDigest: string | null;
+      sourceLineage: readonly Readonly<{
+        worldId: string;
+        exists: boolean;
+        digest: string | null;
+      }>[];
+    }>;
+    offeringTeam: Readonly<{
+      exists: boolean;
+      digest: string | null;
+      sourceWorldId: string | null;
+      sourceDigest: string | null;
+      sourceLineage: readonly Readonly<{
+        worldId: string;
+        exists: boolean;
+        digest: string | null;
+      }>[];
+    }>;
+  }>;
   expectedOfferSheetResolutionSnapshots?: ArchitectOfferSheetResolutionSnapshotReceipts;
   optionType?: string;
   accepted?: boolean;

--- a/src/features/architect/utils/mutationPipeline.types.result.ts
+++ b/src/features/architect/utils/mutationPipeline.types.result.ts
@@ -117,6 +117,7 @@ export type ArchitectGeneralMutationDashboardReloadOfferSheet = {
   totalValue?: number | string | null;
   status: string;
   createdAt?: string | number | Date | null;
+  governedLifecycle?: unknown;
 };
 export type ArchitectGeneralMutationDashboardReloadContractFreeAgency = {
   year?: number | null;

--- a/src/features/architect/utils/nonTradeMutationValidationStage.ts
+++ b/src/features/architect/utils/nonTradeMutationValidationStage.ts
@@ -18,9 +18,7 @@ import {
   validateDeadCap,
   validateExceptions,
 } from '@/features/architect/utils/capLegalityValidation';
-import {
-  validateGovernedPriorTeamOptionSigning,
-} from '@/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning';
+import { validateGovernedPriorTeamOptionSigning } from '@/features/architect/utils/capLegalityValidation/governedPriorTeamOptionSigning';
 import { toEndYear } from '@/features/architect/utils/seasonFormat';
 import type {
   ArchitectMutationOfferSheet,
@@ -208,7 +206,10 @@ function validateSigningSideMutation({
   dateDefaulted?: boolean;
   pipelineWarnings: Array<Record<string, unknown>>;
 }): StageValidationResult {
-  const { team, player } = requireTeamAndPlayerState(currentState, mutationType);
+  const { team, player } = requireTeamAndPlayerState(
+    currentState,
+    mutationType
+  );
   const governedOptionSigningResult =
     mutationType === 'signFreeAgent'
       ? validateGovernedPriorTeamOptionSigning({
@@ -264,7 +265,10 @@ function validateRosterAndContractMutation({
   currentYear: number;
   asOfDate?: string | null;
 }): StageValidationResult {
-  const { team, player } = requireTeamAndPlayerState(currentState, mutationType);
+  const { team, player } = requireTeamAndPlayerState(
+    currentState,
+    mutationType
+  );
 
   switch (mutationType) {
     case 'waivePlayer': {
@@ -290,6 +294,7 @@ function validateRosterAndContractMutation({
         player,
         extension: payload.extension,
         year: currentYear,
+        asOfDate: asOfDate ?? undefined,
       });
 
       return formatValidatorResult({
@@ -301,12 +306,11 @@ function validateRosterAndContractMutation({
 
     case 'optionDecision': {
       const teamCode = team.teamCode || null;
-      const playerId = getPlayerId(
-        player as Parameters<typeof getPlayerId>[0]
-      );
+      const playerId = getPlayerId(player as Parameters<typeof getPlayerId>[0]);
       const updatedTeam = teamCode
-        ? computeResult?.teamUpdates?.find((update) => update.teamCode === teamCode)
-            ?.team
+        ? computeResult?.teamUpdates?.find(
+            (update) => update.teamCode === teamCode
+          )?.team
         : null;
       const updatedPlayer = playerId
         ? computeResult?.playerUpdates?.find(

--- a/src/features/architect/utils/nonTradeMutationValidationStage.ts
+++ b/src/features/architect/utils/nonTradeMutationValidationStage.ts
@@ -463,6 +463,10 @@ function validateOfferSheetResolutionMutation({
           actingTeamCode,
           action: 'match',
           asOfDate: asOfDate ?? undefined,
+          resolutionAt:
+            typeof payload.offerSheetResolutionAt === 'string'
+              ? payload.offerSheetResolutionAt
+              : undefined,
         })
       : mutationType === 'declineOfferSheet'
         ? validateOfferSheetResolution({
@@ -470,12 +474,20 @@ function validateOfferSheetResolutionMutation({
             actingTeamCode,
             action: 'decline',
             asOfDate: asOfDate ?? undefined,
+            resolutionAt:
+              typeof payload.offerSheetResolutionAt === 'string'
+                ? payload.offerSheetResolutionAt
+                : undefined,
           })
         : validateOfferSheetResolution({
             offerSheet,
             actingTeamCode,
             action: 'finalize',
             asOfDate: asOfDate ?? undefined,
+            resolutionAt:
+              typeof payload.offerSheetResolutionAt === 'string'
+                ? payload.offerSheetResolutionAt
+                : undefined,
           });
 
   return formatValidatorResult({

--- a/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
@@ -1,0 +1,443 @@
+/** Fail-closed creation and resolution of a mirrored RFA Offer Sheet lifecycle. */
+
+import {
+  GovernedOfferSheetEvidenceZ,
+  GovernedOfferSheetAveragingElectionZ,
+  GovernedOfferSheetLifecycleZ,
+  GovernedOfferSheetProposalZ,
+  type GovernedOfferSheetLifecycle,
+} from '@/schemas/governedOfferSheet';
+import { projectRightsStateAsOf } from '@/features/architect/utils/rightsHistory';
+import { evaluateDatedSalaryLedgers } from '@/features/architect/utils/capTotals';
+import { toSeasonCode } from '@/features/architect/utils/seasonFormat';
+import {
+  synchronizeTeamTotalsSnapshotOrTeam,
+} from '@/features/architect/utils/mutationPipeline.helpers';
+import { mutationSnapshotDigest } from '@/features/architect/utils/mutationPipeline.snapshotDigest';
+import type {
+  ArchitectMutationContract,
+  ArchitectMutationOfferSheet,
+  MutationOfferSheetResolutionCurrentState,
+  MutationOfferSheetTeamAndPlayerCurrentState,
+} from '@/features/architect/utils/mutationPipeline';
+import {
+  businessDaysBetween,
+  compareInstant,
+  exerciseNoticeDeadline,
+  oneYearAfter,
+  qualifyingOfferDeadlines,
+  requireEasternInstant,
+  worldDateContainsInstant,
+} from './governedOfferSheetTime';
+import { validateGovernedOfferSheetTerms } from './governedOfferSheetTerms';
+
+type FailureStatus = 'blocked' | 'needs-input' | 'incompatible';
+type Failure = { success: false; status: FailureStatus; reasons: readonly string[] };
+type CreationSuccess = {
+  success: true;
+  lifecycle: GovernedOfferSheetLifecycle;
+  receivedAt: string;
+};
+type ResolutionSuccess = {
+  success: true;
+  lifecycle: GovernedOfferSheetLifecycle;
+};
+
+function failure(status: FailureStatus, reasons: readonly string[]): Failure {
+  return Object.freeze({
+    success: false,
+    status,
+    reasons: Object.freeze([...new Set(reasons)]),
+  });
+}
+
+function lifecycleFromSheet(sheet: ArchitectMutationOfferSheet | undefined) {
+  return GovernedOfferSheetLifecycleZ.safeParse(sheet?.governedLifecycle);
+}
+
+function activeReservations(
+  offerSheets: readonly ArchitectMutationOfferSheet[],
+  season: string,
+  ignoredDedupKey: string,
+  reasons: string[]
+): number {
+  let total = 0;
+  for (const sheet of offerSheets) {
+    if (sheet.status !== 'PENDING_MATCH' || sheet.dedupKey === ignoredDedupKey) continue;
+    const parsed = lifecycleFromSheet(sheet);
+    if (!parsed.success || parsed.data.status !== 'pending-match') {
+      reasons.push('An existing outstanding Offer Sheet has incompatible governed reservation data.');
+      continue;
+    }
+    total +=
+      parsed.data.reservations.offeringTeam.find((row) => row.season === season)
+        ?.amount ?? 0;
+  }
+  return total;
+}
+
+function validateEvidenceRules(
+  evidence: ReturnType<typeof GovernedOfferSheetEvidenceZ.parse>,
+  signedAt: string,
+  reasons: string[]
+) {
+  const deadlines = qualifyingOfferDeadlines(evidence.salaryCapYear);
+  const qo = evidence.qualifyingOffer;
+  if (qo.recordStatus !== 'current' || qo.source.recordStatus !== 'current') {
+    reasons.push('The Qualifying Offer evidence is stale.');
+  }
+  if (evidence.league.source.recordStatus !== 'current') {
+    reasons.push('The financial authority used by this Offer Sheet is stale.');
+  }
+  if (qo.amount !== qo.calculation.certifiedAmount) {
+    reasons.push('The Qualifying Offer amount does not match its certified calculation.');
+  }
+  if (qo.branch === 'maximum' && qo.amount !== evidence.league.maximumSalary) {
+    reasons.push('The Maximum Qualifying Offer amount does not equal the governed maximum Salary.');
+  }
+  if (
+    (qo.branch === 'two-way') !== (qo.calculation.basis === 'two-way') ||
+    (qo.calculation.basis === 'two-way' &&
+      qo.calculation.twoWayQualifyingAmount !== qo.amount)
+  ) {
+    reasons.push('The Two-Way Qualifying Offer branch and calculation do not agree.');
+  }
+  if (compareInstant(qo.deliveredAt, deadlines.delivery) > 0) {
+    reasons.push('The Qualifying Offer was not delivered by June 29 at 5:00 p.m. Eastern.');
+  }
+  if (
+    compareInstant(qo.openThrough, deadlines.ordinaryOpenThrough) < 0 ||
+    compareInstant(qo.openThrough, deadlines.absoluteOpenThrough) > 0
+  ) {
+    reasons.push('The Qualifying Offer open period is outside the October 1 through March 1 limits.');
+  }
+  if (compareInstant(qo.openThrough, signedAt) < 0) {
+    reasons.push('The Qualifying Offer was not open when the Offer Sheet was signed.');
+  }
+  if (qo.withdrawnAt && compareInstant(qo.withdrawnAt, signedAt) <= 0) {
+    reasons.push('The Qualifying Offer had been withdrawn before this Offer Sheet.');
+  }
+  if (
+    qo.withdrawnAt &&
+    compareInstant(qo.withdrawnAt, deadlines.consentWithdrawalStarts) >= 0 &&
+    (!qo.withdrawalConsentAt || compareInstant(qo.withdrawalConsentAt, qo.withdrawnAt) > 0)
+  ) {
+    reasons.push('A July 14-or-later QO withdrawal lacks timely written player consent.');
+  }
+  if (qo.branch === 'standard' &&
+      (qo.contractYears !== 1 || !qo.fullyProtected || !qo.requiredTermsPresent)) {
+    reasons.push('The standard Qualifying Offer lacks its required one-year protected terms.');
+  }
+  if (qo.branch === 'maximum' &&
+      (qo.contractYears !== 5 || qo.annualRaiseBasisPoints !== 800 ||
+        !qo.fullyProtected || qo.hasOptionOrEto)) {
+    reasons.push('The Maximum Qualifying Offer lacks its required five-year, 8%, fully protected, no-option terms.');
+  }
+  const eligibility = evidence.eligibility;
+  if (
+    (eligibility.category === 'first-round-year-four' &&
+      !eligibility.firstRoundRookieScaleYearFourCompleted) ||
+    (eligibility.category === 'qualifying-two-way' && !eligibility.qualifyingTwoWayService) ||
+    (eligibility.category === 'three-or-fewer-yos' &&
+      (!eligibility.otherPlayerEligible || eligibility.yearsOfService > 3))
+  ) {
+    reasons.push('The retained evidence does not establish an eligible RFA category.');
+  }
+}
+
+export function createGovernedOfferSheetLifecycle({
+  state,
+  contract,
+  proposalInput,
+  worldId,
+  salaryCapYear,
+  worldAsOfDate,
+  timestamp,
+  offerSheetId,
+  dedupKey,
+}: {
+  state: MutationOfferSheetTeamAndPlayerCurrentState;
+  contract: ArchitectMutationContract;
+  proposalInput: unknown;
+  worldId: string;
+  salaryCapYear: number;
+  worldAsOfDate?: string | number | null;
+  timestamp: number;
+  offerSheetId: string;
+  dedupKey: string;
+}): Failure | CreationSuccess {
+  const proposalParse = GovernedOfferSheetProposalZ.safeParse(proposalInput);
+  if (!proposalParse.success) {
+    return failure('needs-input', ['Signed Principal Terms and exact Offer Sheet notice evidence are required.']);
+  }
+  const evidenceInput = state.player?.rfaContext?.governedEvidence;
+  const evidenceParse = GovernedOfferSheetEvidenceZ.safeParse(evidenceInput);
+  if (!evidenceParse.success) {
+    return failure(evidenceInput == null ? 'needs-input' : 'incompatible', [
+      'Authenticated RFA and Qualifying Offer evidence is missing or malformed.',
+    ]);
+  }
+  const proposal = proposalParse.data;
+  const evidence = evidenceParse.data;
+  if (evidence.status === 'unknown') {
+    return failure('needs-input', [
+      'Authenticated RFA and Qualifying Offer evidence is incomplete.',
+    ]);
+  }
+  if (evidence.status === 'conflicting') {
+    return failure('incompatible', [
+      'Authenticated RFA and Qualifying Offer evidence conflicts.',
+    ]);
+  }
+  const reasons: string[] = [];
+  const signedAt = requireEasternInstant(proposal.signedAt, 'Offer Sheet signing', reasons);
+  const receivedAt = requireEasternInstant(proposal.receivedAt, 'Offer Sheet receipt', reasons);
+  if (!signedAt || !receivedAt) return failure('blocked', reasons);
+  if (!worldDateContainsInstant(worldAsOfDate, signedAt)) {
+    reasons.push('The signed Offer Sheet instant does not match the governed Team Plan date.');
+  }
+  if (compareInstant(signedAt, receivedAt) > 0) {
+    reasons.push('The Offer Sheet cannot be received before it is signed.');
+  }
+  if (compareInstant(signedAt, qualifyingOfferDeadlines(salaryCapYear).offerSheetLastSignedAt) > 0) {
+    reasons.push('The ordinary March 1 Offer Sheet signing deadline has passed.');
+  }
+  if (
+    evidence.worldId !== worldId ||
+    evidence.homeTeamId !== state.homeTeam?.teamCode ||
+    evidence.playerId !== state.player?.player_id && evidence.playerId !== state.player?.id ||
+    evidence.salaryCapYear !== salaryCapYear
+  ) {
+    reasons.push('RFA/QO evidence does not match this world, home Team, player, and Salary Cap Year.');
+  }
+  if (compareInstant(evidence.observedAt, signedAt) > 0 ||
+      compareInstant(evidence.qualifyingOffer.source.retrievedAt, signedAt) > 0 ||
+      compareInstant(evidence.league.source.retrievedAt, signedAt) > 0) {
+    reasons.push('Offer Sheet authority was observed after the transaction instant.');
+  }
+  validateEvidenceRules(evidence, signedAt, reasons);
+  const rights = projectRightsStateAsOf({
+    ledger: state.homeTeam?.rightsLedger,
+    worldId,
+    teamId: String(state.homeTeam?.teamCode || ''),
+    playerId: evidence.playerId,
+    // Rights authority is date-granular; the Offer Sheet notice remains exact.
+    // Do not promote date-only rights events to an invented midnight instant.
+    asOfDate: signedAt.slice(0, 10),
+    salaryCapYear,
+  });
+  if (rights.status !== 'available' || rights.freeAgentStatus !== 'RFA' || rights.rightOfFirstRefusal !== 'active') {
+    reasons.push(...(rights.reasons.length ? rights.reasons : ['The home Team has no active governed Right of First Refusal.']));
+  }
+  const termResult = validateGovernedOfferSheetTerms({ proposal, evidence, contract });
+  reasons.push(...termResult.reasons);
+  const existing = [...(state.team?.offerSheets ?? []), ...(state.homeTeam?.incomingOfferSheets ?? [])]
+    .filter((sheet) => sheet.status === 'PENDING_MATCH' && String(sheet.playerId) === evidence.playerId);
+  for (const sheet of existing) {
+    if (sheet.dedupKey !== dedupKey) reasons.push('The player already has another outstanding Offer Sheet.');
+    else {
+      const parsed = lifecycleFromSheet(sheet);
+      const root = parsed.success ? parsed.data.events[0] : null;
+      if (!parsed.success || root?.eventKind !== 'offer-sheet-signed' || JSON.stringify(root.proposal) !== JSON.stringify(proposal)) {
+        reasons.push('An idempotent Offer Sheet retry changed its signed Principal Terms.');
+      } else if (reasons.length === 0) {
+        return { success: true, lifecycle: parsed.data, receivedAt };
+      }
+    }
+  }
+  const season = toSeasonCode(salaryCapYear);
+  const currentReservation = termResult.offeringReservations.find((row) => row.season === season)?.amount;
+  if (currentReservation == null) reasons.push(`Principal Terms do not include ${season}.`);
+  activeReservations(state.team?.offerSheets ?? [], season, dedupKey, reasons);
+  const totals = state.team ? synchronizeTeamTotalsSnapshotOrTeam(state.team, salaryCapYear).totals : null;
+  const allocations = Number(totals?.totalCapAllocations);
+  const teamCode = String(state.team?.teamCode || '');
+  const teamStateReference = state.team
+    ? `${worldId}:${teamCode}:${mutationSnapshotDigest(state.team)}`
+    : '';
+  const salaryEvaluation = evaluateDatedSalaryLedgers({
+    context: {
+      asOfDate: signedAt,
+      salaryCapYear,
+      team: { teamId: teamCode, teamCode },
+    },
+    ledgers: {
+      teamSalary: Number.isFinite(allocations)
+        ? {
+            status: 'ready',
+            lineItems: [
+              {
+                id: `pre-offer-sheet-team-salary:${teamCode}:${salaryCapYear}`,
+                ledger: 'team-salary',
+                label: 'Pre-Offer-Sheet Team Salary',
+                amount: allocations,
+                effectiveFrom: `${salaryCapYear - 1}-07-01T00:00:00-04:00`,
+                canonLeafIds: ['CBA2-L04.3'],
+                source: {
+                  authority: 'team-state',
+                  reference: teamStateReference,
+                },
+              },
+            ],
+          }
+        : {
+            status: 'needs-input',
+            missingInputs: ['ledgers.teamSalary.lineItems'],
+            reason: 'Offering Team Salary cannot be resolved.',
+          },
+      apronTeamSalary: {
+        status: 'not-evaluated',
+        reason: 'Offer Sheet Room does not use Apron Team Salary.',
+      },
+      taxSalary: {
+        status: 'not-evaluated',
+        reason: 'Offer Sheet Room does not use Tax Salary.',
+      },
+    },
+  });
+  const governedTeamSalary = salaryEvaluation.ledgers.teamSalary;
+  if (governedTeamSalary.status !== 'complete' || governedTeamSalary.total == null) {
+    reasons.push('Offering Team Salary cannot be resolved on the governed transaction date.');
+  } else if (
+    (currentReservation ?? 0) >
+    evidence.league.salaryCap - governedTeamSalary.total
+  ) {
+    reasons.push('The offering Team does not preserve sufficient governed Room for this Offer Sheet.');
+  }
+  if (reasons.length > 0 || !rights.ledgerReference || !rights.stateReference) return failure('blocked', reasons);
+  const recordedAt = new Date(timestamp).toISOString();
+  const lifecycle: GovernedOfferSheetLifecycle = {
+    payloadVersion: 1,
+    ledgerId: `offer-sheet-ledger:${worldId}:${offerSheetId}`,
+    ledgerVersion: 1,
+    worldId,
+    playerId: evidence.playerId,
+    homeTeamId: evidence.homeTeamId,
+    offeringTeamId: teamCode,
+    salaryCapYear,
+    status: 'pending-match',
+    evidenceReference: { evidenceId: evidence.evidenceId, evidenceRecordVersion: evidence.evidenceRecordVersion },
+    evidenceSnapshot: evidence,
+    rightsReference: { ...rights.ledgerReference, ...rights.stateReference },
+    reservations: {
+      offeringTeam: [...termResult.offeringReservations],
+      offeringTeamSalaryReference: {
+        ledgerKind: 'team-salary',
+        asOfDate: signedAt,
+        salaryCap: evidence.league.salaryCap,
+        totalBeforeOfferSheet: governedTeamSalary.total ?? 0,
+        teamStateReference,
+        canonLeafIds: ['CBA2-L04.3'],
+      },
+      homeTeamAuthority: 'right-of-first-refusal',
+      arenasApplies: termResult.isArenas,
+      offeringTeamAccounting: termResult.isArenas ? 'average-annual-salary' : 'stated-schedule',
+      homeTeamAccounting: 'stated-schedule',
+    },
+    events: [{
+      eventKind: 'offer-sheet-signed',
+      eventId: `${offerSheetId}:signed:v1`,
+      eventVersion: 1,
+      executedAt: signedAt,
+      recordedAt,
+      qualifyingOfferId: evidence.qualifyingOffer.offerId,
+      qualifyingOfferVersion: evidence.qualifyingOffer.offerVersion,
+      exerciseNoticeDeadline: exerciseNoticeDeadline(receivedAt),
+      proposal,
+    }],
+  };
+  const verified = GovernedOfferSheetLifecycleZ.safeParse(lifecycle);
+  return verified.success ? { success: true, lifecycle: verified.data, receivedAt } : failure('incompatible', ['The governed Offer Sheet lifecycle could not be certified.']);
+}
+
+export function resolveGovernedOfferSheetLifecycle({
+  state,
+  action,
+  resolutionAt,
+  averagingElectionInput,
+  timestamp,
+}: {
+  state: MutationOfferSheetResolutionCurrentState;
+  action: 'match' | 'decline';
+  resolutionAt?: string | number | null;
+  averagingElectionInput?: unknown;
+  timestamp: number;
+}): Failure | ResolutionSuccess {
+  const homeSheet = state.homeTeam?.incomingOfferSheets?.find((sheet) => String(sheet.id) === state.offerSheetId);
+  const offeringSheet = state.offeringTeam?.offerSheets?.find((sheet) => String(sheet.id) === state.offerSheetId);
+  const home = lifecycleFromSheet(homeSheet);
+  const offering = lifecycleFromSheet(offeringSheet);
+  if (!home.success || !offering.success) return failure('incompatible', ['Both Team mirrors require a readable governed Offer Sheet lifecycle.']);
+  if (JSON.stringify(home.data) !== JSON.stringify(offering.data)) return failure('incompatible', ['The two Team Offer Sheet lifecycle mirrors disagree.']);
+  const lifecycle = home.data;
+  if (lifecycle.status !== 'pending-match') return failure('blocked', ['Only a pending Offer Sheet can be resolved.']);
+  const reasons: string[] = [];
+  const exactAt = requireEasternInstant(resolutionAt, 'Offer Sheet resolution', reasons);
+  if (!exactAt) return failure('needs-input', reasons);
+  const signedEvent = lifecycle.events[0];
+  if (signedEvent.eventKind !== 'offer-sheet-signed') return failure('incompatible', ['The lifecycle has no signed Offer Sheet root event.']);
+  if (action === 'match' && compareInstant(exactAt, signedEvent.exerciseNoticeDeadline) > 0) {
+    reasons.push('The exact Exercise Notice deadline has passed.');
+  }
+  const electionParse =
+    averagingElectionInput == null
+      ? null
+      : GovernedOfferSheetAveragingElectionZ.safeParse(averagingElectionInput);
+  if (electionParse && !electionParse.success) {
+    return failure('needs-input', [
+      'The averaging election requires its written statement and exact NBA receipt and Players Association relay times.',
+    ]);
+  }
+  const election = electionParse?.success ? electionParse.data : null;
+  if (action === 'decline' && election) {
+    reasons.push('An averaging election can accompany only an Exercise Notice.');
+  }
+  if (election) {
+    if (!lifecycle.reservations.arenasApplies) reasons.push('Only an Arenas match may elect Average Annual Salary.');
+    if (compareInstant(election.deliveredToNbaAt, exactAt) !== 0) reasons.push('The averaging election was not delivered with the Exercise Notice.');
+    if (
+      compareInstant(election.relayedToPlayersAssociationAt, election.deliveredToNbaAt) < 0 ||
+      businessDaysBetween(
+        election.deliveredToNbaAt,
+        election.relayedToPlayersAssociationAt
+      ) > 1
+    ) reasons.push('The averaging-election statement was not relayed within one business day.');
+  }
+  if (reasons.length > 0) return failure('blocked', reasons);
+  const version = lifecycle.ledgerVersion + 1;
+  const recordedAt = new Date(timestamp).toISOString();
+  const next: GovernedOfferSheetLifecycle = {
+    ...lifecycle,
+    ledgerVersion: version,
+    status: action === 'match' ? 'matched' : 'declined',
+    reservations: {
+      ...lifecycle.reservations,
+      homeTeamAccounting: action === 'match' && election ? 'average-annual-salary' : 'stated-schedule',
+    },
+    events: [
+      ...lifecycle.events,
+      action === 'match'
+        ? {
+            eventKind: 'offer-sheet-matched',
+            eventId: `${lifecycle.ledgerId}:matched:v${version}`,
+            eventVersion: 1,
+            executedAt: exactAt,
+            recordedAt,
+            restrictionsUntil: oneYearAfter(exactAt),
+            playerTradeConsentRequired: true,
+            offeringTeamTradeBarred: true,
+            signAndTradeBarred: true,
+            averagingElection: election,
+          }
+        : {
+            eventKind: 'offer-sheet-declined',
+            eventId: `${lifecycle.ledgerId}:declined:v${version}`,
+            eventVersion: 1,
+            executedAt: exactAt,
+            recordedAt,
+          },
+    ],
+  };
+  const parsed = GovernedOfferSheetLifecycleZ.safeParse(next);
+  return parsed.success ? { success: true, lifecycle: parsed.data } : failure('incompatible', ['The resolved Offer Sheet lifecycle could not be certified.']);
+}

--- a/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
@@ -6,13 +6,12 @@ import {
   GovernedOfferSheetLifecycleZ,
   GovernedOfferSheetProposalZ,
   type GovernedOfferSheetLifecycle,
+  type GovernedOfferSheetTeamSalaryReference,
 } from '@/schemas/governedOfferSheet';
 import { projectRightsStateAsOf } from '@/features/architect/utils/rightsHistory';
 import { evaluateDatedSalaryLedgers } from '@/features/architect/utils/capTotals';
 import { toSeasonCode } from '@/features/architect/utils/seasonFormat';
-import {
-  synchronizeTeamTotalsSnapshotOrTeam,
-} from '@/features/architect/utils/mutationPipeline.helpers';
+import { synchronizeTeamTotalsSnapshotOrTeam } from '@/features/architect/utils/mutationPipeline.helpers';
 import { mutationSnapshotDigest } from '@/features/architect/utils/mutationPipeline.snapshotDigest';
 import type {
   ArchitectMutationContract,
@@ -28,11 +27,16 @@ import {
   qualifyingOfferDeadlines,
   requireEasternInstant,
   worldDateContainsInstant,
+  worldDateHasReachedInstant,
 } from './governedOfferSheetTime';
 import { validateGovernedOfferSheetTerms } from './governedOfferSheetTerms';
 
 type FailureStatus = 'blocked' | 'needs-input' | 'incompatible';
-type Failure = { success: false; status: FailureStatus; reasons: readonly string[] };
+type Failure = {
+  success: false;
+  status: FailureStatus;
+  reasons: readonly string[];
+};
 type CreationSuccess = {
   success: true;
   lifecycle: GovernedOfferSheetLifecycle;
@@ -63,10 +67,13 @@ function activeReservations(
 ): number {
   let total = 0;
   for (const sheet of offerSheets) {
-    if (sheet.status !== 'PENDING_MATCH' || sheet.dedupKey === ignoredDedupKey) continue;
+    if (sheet.status !== 'PENDING_MATCH' || sheet.dedupKey === ignoredDedupKey)
+      continue;
     const parsed = lifecycleFromSheet(sheet);
     if (!parsed.success || parsed.data.status !== 'pending-match') {
-      reasons.push('An existing outstanding Offer Sheet has incompatible governed reservation data.');
+      reasons.push(
+        'An existing outstanding Offer Sheet has incompatible governed reservation data.'
+      );
       continue;
     }
     total +=
@@ -83,6 +90,26 @@ function validateEvidenceRules(
 ) {
   const deadlines = qualifyingOfferDeadlines(evidence.salaryCapYear);
   const qo = evidence.qualifyingOffer;
+  requireEasternInstant(qo.deliveredAt, 'Qualifying Offer delivery', reasons);
+  requireEasternInstant(
+    qo.openThrough,
+    'Qualifying Offer open-through time',
+    reasons
+  );
+  if (qo.withdrawnAt) {
+    requireEasternInstant(
+      qo.withdrawnAt,
+      'Qualifying Offer withdrawal',
+      reasons
+    );
+  }
+  if (qo.withdrawalConsentAt) {
+    requireEasternInstant(
+      qo.withdrawalConsentAt,
+      'Qualifying Offer withdrawal consent',
+      reasons
+    );
+  }
   if (qo.recordStatus !== 'current' || qo.source.recordStatus !== 'current') {
     reasons.push('The Qualifying Offer evidence is stale.');
   }
@@ -90,58 +117,194 @@ function validateEvidenceRules(
     reasons.push('The financial authority used by this Offer Sheet is stale.');
   }
   if (qo.amount !== qo.calculation.certifiedAmount) {
-    reasons.push('The Qualifying Offer amount does not match its certified calculation.');
+    reasons.push(
+      'The Qualifying Offer amount does not match its certified calculation.'
+    );
+  }
+  if (
+    qo.annualBaseSchedule.length !== qo.contractYears ||
+    qo.annualBaseSchedule[0] !== qo.amount
+  ) {
+    reasons.push(
+      'The Qualifying Offer annual Base schedule does not match its term and first-year amount.'
+    );
+  }
+  if (qo.calculation.calculationYear !== evidence.salaryCapYear) {
+    reasons.push(
+      'The Qualifying Offer calculation uses the wrong Salary Cap Year.'
+    );
+  }
+  const calculationHasRequiredInputs =
+    (qo.calculation.basis === 'draft-slot' &&
+      qo.calculation.draftSlot != null &&
+      qo.calculation.draftSlotAmount != null) ||
+    (qo.calculation.basis === 'prior-salary' &&
+      qo.calculation.priorSalary != null) ||
+    (qo.calculation.basis === 'starter-criteria' &&
+      qo.calculation.officialStarts != null &&
+      qo.calculation.officialMinutes != null &&
+      qo.calculation.starterStartsThreshold != null &&
+      qo.calculation.starterMinutesThreshold != null &&
+      qo.calculation.starterCriteriaAmount != null &&
+      (qo.calculation.officialStarts >= qo.calculation.starterStartsThreshold ||
+        qo.calculation.officialMinutes >=
+          qo.calculation.starterMinutesThreshold)) ||
+    (qo.calculation.basis === 'two-way' &&
+      qo.calculation.twoWayQualifyingAmount != null);
+  if (!calculationHasRequiredInputs) {
+    reasons.push(
+      'The Qualifying Offer calculation lacks its draft-slot, prior-Salary, starter, or Two-Way inputs.'
+    );
   }
   if (qo.branch === 'maximum' && qo.amount !== evidence.league.maximumSalary) {
-    reasons.push('The Maximum Qualifying Offer amount does not equal the governed maximum Salary.');
+    reasons.push(
+      'The Maximum Qualifying Offer amount does not equal the governed maximum Salary.'
+    );
   }
   if (
     (qo.branch === 'two-way') !== (qo.calculation.basis === 'two-way') ||
     (qo.calculation.basis === 'two-way' &&
       qo.calculation.twoWayQualifyingAmount !== qo.amount)
   ) {
-    reasons.push('The Two-Way Qualifying Offer branch and calculation do not agree.');
+    reasons.push(
+      'The Two-Way Qualifying Offer branch and calculation do not agree.'
+    );
   }
   if (compareInstant(qo.deliveredAt, deadlines.delivery) > 0) {
-    reasons.push('The Qualifying Offer was not delivered by June 29 at 5:00 p.m. Eastern.');
+    reasons.push(
+      'The Qualifying Offer was not delivered by June 29 at 5:00 p.m. Eastern.'
+    );
   }
   if (
     compareInstant(qo.openThrough, deadlines.ordinaryOpenThrough) < 0 ||
     compareInstant(qo.openThrough, deadlines.absoluteOpenThrough) > 0
   ) {
-    reasons.push('The Qualifying Offer open period is outside the October 1 through March 1 limits.');
+    reasons.push(
+      'The Qualifying Offer open period is outside the October 1 through March 1 limits.'
+    );
+  }
+  if (
+    compareInstant(qo.openThrough, deadlines.ordinaryOpenThrough) > 0 &&
+    !qo.extensionDocumentId
+  ) {
+    reasons.push(
+      'A Qualifying Offer kept open after October 1 lacks its written extension record.'
+    );
   }
   if (compareInstant(qo.openThrough, signedAt) < 0) {
-    reasons.push('The Qualifying Offer was not open when the Offer Sheet was signed.');
+    reasons.push(
+      'The Qualifying Offer was not open when the Offer Sheet was signed.'
+    );
   }
   if (qo.withdrawnAt && compareInstant(qo.withdrawnAt, signedAt) <= 0) {
-    reasons.push('The Qualifying Offer had been withdrawn before this Offer Sheet.');
+    reasons.push(
+      'The Qualifying Offer had been withdrawn before this Offer Sheet.'
+    );
   }
   if (
     qo.withdrawnAt &&
     compareInstant(qo.withdrawnAt, deadlines.consentWithdrawalStarts) >= 0 &&
-    (!qo.withdrawalConsentAt || compareInstant(qo.withdrawalConsentAt, qo.withdrawnAt) > 0)
+    (!qo.withdrawalConsentAt ||
+      !qo.withdrawalConsentDocumentId ||
+      compareInstant(qo.withdrawalConsentAt, qo.withdrawnAt) > 0)
   ) {
-    reasons.push('A July 14-or-later QO withdrawal lacks timely written player consent.');
+    reasons.push(
+      'A July 14-or-later QO withdrawal lacks timely written player consent.'
+    );
   }
-  if (qo.branch === 'standard' &&
-      (qo.contractYears !== 1 || !qo.fullyProtected || !qo.requiredTermsPresent)) {
-    reasons.push('The standard Qualifying Offer lacks its required one-year protected terms.');
+  if (
+    qo.branch === 'standard' &&
+    (qo.contractYears !== 1 ||
+      !qo.fullyProtected ||
+      !qo.requiredTermsPresent ||
+      qo.hasOptionOrEto)
+  ) {
+    reasons.push(
+      'The standard Qualifying Offer lacks its required one-year protected terms.'
+    );
   }
-  if (qo.branch === 'maximum' &&
-      (qo.contractYears !== 5 || qo.annualRaiseBasisPoints !== 800 ||
-        !qo.fullyProtected || qo.hasOptionOrEto)) {
-    reasons.push('The Maximum Qualifying Offer lacks its required five-year, 8%, fully protected, no-option terms.');
+  if (
+    qo.branch === 'maximum' &&
+    (qo.contractYears !== 5 ||
+      qo.annualRaiseBasisPoints !== 800 ||
+      !qo.fullyProtected ||
+      !qo.requiredTermsPresent ||
+      qo.hasOptionOrEto)
+  ) {
+    reasons.push(
+      'The Maximum Qualifying Offer lacks its required five-year, 8%, fully protected, no-option terms.'
+    );
+  }
+  if (
+    qo.branch === 'maximum' &&
+    qo.annualBaseSchedule.some(
+      (amount, index) => amount !== Math.round(qo.amount * (1 + index * 0.08))
+    )
+  ) {
+    reasons.push(
+      'The Maximum Qualifying Offer annual Base schedule does not use 8% of first-year Base.'
+    );
+  }
+  if (
+    qo.branch === 'two-way' &&
+    (qo.contractYears !== 1 ||
+      qo.annualBaseSchedule.length !== 1 ||
+      !qo.requiredTermsPresent ||
+      qo.hasOptionOrEto)
+  ) {
+    reasons.push(
+      'The Two-Way Qualifying Offer lacks its separate one-year form and terms.'
+    );
   }
   const eligibility = evidence.eligibility;
   if (
     (eligibility.category === 'first-round-year-four' &&
-      !eligibility.firstRoundRookieScaleYearFourCompleted) ||
-    (eligibility.category === 'qualifying-two-way' && !eligibility.qualifyingTwoWayService) ||
+      (!eligibility.firstRoundRookieScaleYearFourCompleted ||
+        eligibility.yearsOfService !== 4)) ||
+    (eligibility.category === 'qualifying-two-way' &&
+      !eligibility.qualifyingTwoWayService) ||
     (eligibility.category === 'three-or-fewer-yos' &&
       (!eligibility.otherPlayerEligible || eligibility.yearsOfService > 3))
   ) {
-    reasons.push('The retained evidence does not establish an eligible RFA category.');
+    reasons.push(
+      'The retained evidence does not establish an eligible RFA category.'
+    );
+  }
+  if (
+    eligibility.firstRoundRookieScaleYearFourCompleted !==
+      (eligibility.category === 'first-round-year-four') ||
+    eligibility.qualifyingTwoWayService !==
+      (eligibility.category === 'qualifying-two-way') ||
+    eligibility.otherPlayerEligible !==
+      (eligibility.category === 'three-or-fewer-yos')
+  ) {
+    reasons.push(
+      'The retained RFA category evidence is internally conflicting.'
+    );
+  }
+  if (
+    (eligibility.category === 'qualifying-two-way') !==
+    (qo.branch === 'two-way')
+  ) {
+    reasons.push(
+      'The qualifying Two-Way category and Qualifying Offer branch do not agree.'
+    );
+  }
+  if (
+    evidence.league.arenasYearOneMaximum !== evidence.league.nonTaxpayerMle ||
+    evidence.league.arenasYearTwoMaximum !==
+      Math.round(evidence.league.arenasYearOneMaximum * 1.05 * 100) / 100
+  ) {
+    reasons.push('The governed Arenas first-two-year maximums conflict.');
+  }
+  if (
+    evidence.league.maximumSalaryBySeason.find(
+      (row) => row.season === toSeasonCode(evidence.salaryCapYear)
+    )?.amount !== evidence.league.maximumSalary
+  ) {
+    reasons.push(
+      'The governed current-year maximum Salary authorities conflict.'
+    );
   }
 }
 
@@ -168,7 +331,9 @@ export function createGovernedOfferSheetLifecycle({
 }): Failure | CreationSuccess {
   const proposalParse = GovernedOfferSheetProposalZ.safeParse(proposalInput);
   if (!proposalParse.success) {
-    return failure('needs-input', ['Signed Principal Terms and exact Offer Sheet notice evidence are required.']);
+    return failure('needs-input', [
+      'Signed Principal Terms and exact Offer Sheet notice evidence are required.',
+    ]);
   }
   const evidenceInput = state.player?.rfaContext?.governedEvidence;
   const evidenceParse = GovernedOfferSheetEvidenceZ.safeParse(evidenceInput);
@@ -190,30 +355,59 @@ export function createGovernedOfferSheetLifecycle({
     ]);
   }
   const reasons: string[] = [];
-  const signedAt = requireEasternInstant(proposal.signedAt, 'Offer Sheet signing', reasons);
-  const receivedAt = requireEasternInstant(proposal.receivedAt, 'Offer Sheet receipt', reasons);
+  const signedAt = requireEasternInstant(
+    proposal.signedAt,
+    'Offer Sheet signing',
+    reasons
+  );
+  const receivedAt = requireEasternInstant(
+    proposal.receivedAt,
+    'Offer Sheet receipt',
+    reasons
+  );
   if (!signedAt || !receivedAt) return failure('blocked', reasons);
   if (!worldDateContainsInstant(worldAsOfDate, signedAt)) {
-    reasons.push('The signed Offer Sheet instant does not match the governed Team Plan date.');
+    reasons.push(
+      'The signed Offer Sheet instant does not match the governed Team Plan date.'
+    );
+  }
+  if (!worldDateContainsInstant(worldAsOfDate, receivedAt)) {
+    reasons.push(
+      'The Offer Sheet receipt instant does not match the governed Team Plan date.'
+    );
   }
   if (compareInstant(signedAt, receivedAt) > 0) {
     reasons.push('The Offer Sheet cannot be received before it is signed.');
   }
-  if (compareInstant(signedAt, qualifyingOfferDeadlines(salaryCapYear).offerSheetLastSignedAt) > 0) {
-    reasons.push('The ordinary March 1 Offer Sheet signing deadline has passed.');
+  if (
+    compareInstant(
+      signedAt,
+      qualifyingOfferDeadlines(salaryCapYear).offerSheetLastSignedAt
+    ) > 0
+  ) {
+    reasons.push(
+      'The ordinary March 1 Offer Sheet signing deadline has passed.'
+    );
   }
   if (
     evidence.worldId !== worldId ||
     evidence.homeTeamId !== state.homeTeam?.teamCode ||
-    evidence.playerId !== state.player?.player_id && evidence.playerId !== state.player?.id ||
+    (evidence.playerId !== state.player?.player_id &&
+      evidence.playerId !== state.player?.id) ||
     evidence.salaryCapYear !== salaryCapYear
   ) {
-    reasons.push('RFA/QO evidence does not match this world, home Team, player, and Salary Cap Year.');
+    reasons.push(
+      'RFA/QO evidence does not match this world, home Team, player, and Salary Cap Year.'
+    );
   }
-  if (compareInstant(evidence.observedAt, signedAt) > 0 ||
-      compareInstant(evidence.qualifyingOffer.source.retrievedAt, signedAt) > 0 ||
-      compareInstant(evidence.league.source.retrievedAt, signedAt) > 0) {
-    reasons.push('Offer Sheet authority was observed after the transaction instant.');
+  if (
+    compareInstant(evidence.observedAt, signedAt) > 0 ||
+    compareInstant(evidence.qualifyingOffer.source.retrievedAt, signedAt) > 0 ||
+    compareInstant(evidence.league.source.retrievedAt, signedAt) > 0
+  ) {
+    reasons.push(
+      'Offer Sheet authority was observed after the transaction instant.'
+    );
   }
   validateEvidenceRules(evidence, signedAt, reasons);
   const rights = projectRightsStateAsOf({
@@ -226,30 +420,96 @@ export function createGovernedOfferSheetLifecycle({
     asOfDate: signedAt.slice(0, 10),
     salaryCapYear,
   });
-  if (rights.status !== 'available' || rights.freeAgentStatus !== 'RFA' || rights.rightOfFirstRefusal !== 'active') {
-    reasons.push(...(rights.reasons.length ? rights.reasons : ['The home Team has no active governed Right of First Refusal.']));
+  if (
+    rights.status !== 'available' ||
+    rights.freeAgentStatus !== 'RFA' ||
+    rights.rightOfFirstRefusal !== 'active'
+  ) {
+    reasons.push(
+      ...(rights.reasons.length
+        ? rights.reasons
+        : ['The home Team has no active governed Right of First Refusal.'])
+    );
   }
-  const termResult = validateGovernedOfferSheetTerms({ proposal, evidence, contract });
+  const termResult = validateGovernedOfferSheetTerms({
+    proposal,
+    evidence,
+    contract,
+  });
   reasons.push(...termResult.reasons);
-  const existing = [...(state.team?.offerSheets ?? []), ...(state.homeTeam?.incomingOfferSheets ?? [])]
-    .filter((sheet) => sheet.status === 'PENDING_MATCH' && String(sheet.playerId) === evidence.playerId);
-  for (const sheet of existing) {
-    if (sheet.dedupKey !== dedupKey) reasons.push('The player already has another outstanding Offer Sheet.');
-    else {
-      const parsed = lifecycleFromSheet(sheet);
-      const root = parsed.success ? parsed.data.events[0] : null;
-      if (!parsed.success || root?.eventKind !== 'offer-sheet-signed' || JSON.stringify(root.proposal) !== JSON.stringify(proposal)) {
-        reasons.push('An idempotent Offer Sheet retry changed its signed Principal Terms.');
-      } else if (reasons.length === 0) {
-        return { success: true, lifecycle: parsed.data, receivedAt };
-      }
+  const exerciseDeadline = exerciseNoticeDeadline(receivedAt);
+  const matchingAuthority = evidence.homeTeamMatchingAuthority;
+  if (
+    matchingAuthority.recordStatus !== 'current' ||
+    matchingAuthority.source.recordStatus !== 'current'
+  ) {
+    reasons.push('The home Team matching authority is stale.');
+  }
+  if (
+    compareInstant(matchingAuthority.source.retrievedAt, signedAt) > 0 ||
+    compareInstant(matchingAuthority.effectiveFrom, signedAt) > 0 ||
+    compareInstant(matchingAuthority.effectiveThrough, exerciseDeadline) < 0
+  ) {
+    reasons.push(
+      'The home Team did not preserve matching authority throughout the Exercise Notice period.'
+    );
+  }
+  if (matchingAuthority.amount < termResult.firstYearMatchAmount) {
+    reasons.push(
+      'The home Team matching authority is insufficient for the signed Principal Terms.'
+    );
+  }
+  const existingOffering = (state.team?.offerSheets ?? []).filter(
+    (sheet) =>
+      sheet.status === 'PENDING_MATCH' &&
+      String(sheet.playerId) === evidence.playerId
+  );
+  const existingHome = (state.homeTeam?.incomingOfferSheets ?? []).filter(
+    (sheet) =>
+      sheet.status === 'PENDING_MATCH' &&
+      String(sheet.playerId) === evidence.playerId
+  );
+  const existing = [...existingOffering, ...existingHome];
+  if (existing.some((sheet) => sheet.dedupKey !== dedupKey)) {
+    reasons.push('The player already has another outstanding Offer Sheet.');
+  } else if (existing.length > 0) {
+    if (existingOffering.length !== 1 || existingHome.length !== 1) {
+      reasons.push(
+        'An idempotent Offer Sheet retry requires exactly one readable mirror on each Team.'
+      );
+    }
+    const parsed = existing.map(lifecycleFromSheet);
+    const roots = parsed.map((entry) =>
+      entry.success ? entry.data.events[0] : null
+    );
+    if (
+      parsed.some((entry) => !entry.success) ||
+      roots.some(
+        (root) =>
+          root?.eventKind !== 'offer-sheet-signed' ||
+          JSON.stringify(root.proposal) !== JSON.stringify(proposal)
+      ) ||
+      (parsed[0]?.success &&
+        parsed[1]?.success &&
+        JSON.stringify(parsed[0].data) !== JSON.stringify(parsed[1].data))
+    ) {
+      reasons.push(
+        'An idempotent Offer Sheet retry changed its signed Principal Terms or mirrored lifecycle.'
+      );
+    } else if (reasons.length === 0 && parsed[0]?.success) {
+      return { success: true, lifecycle: parsed[0].data, receivedAt };
     }
   }
   const season = toSeasonCode(salaryCapYear);
-  const currentReservation = termResult.offeringReservations.find((row) => row.season === season)?.amount;
-  if (currentReservation == null) reasons.push(`Principal Terms do not include ${season}.`);
+  const currentReservation = termResult.offeringReservations.find(
+    (row) => row.season === season
+  )?.amount;
+  if (currentReservation == null)
+    reasons.push(`Principal Terms do not include ${season}.`);
   activeReservations(state.team?.offerSheets ?? [], season, dedupKey, reasons);
-  const totals = state.team ? synchronizeTeamTotalsSnapshotOrTeam(state.team, salaryCapYear).totals : null;
+  const totals = state.team
+    ? synchronizeTeamTotalsSnapshotOrTeam(state.team, salaryCapYear).totals
+    : null;
   const allocations = Number(totals?.totalCapAllocations);
   const teamCode = String(state.team?.teamCode || '');
   const teamStateReference = state.team
@@ -296,15 +556,23 @@ export function createGovernedOfferSheetLifecycle({
     },
   });
   const governedTeamSalary = salaryEvaluation.ledgers.teamSalary;
-  if (governedTeamSalary.status !== 'complete' || governedTeamSalary.total == null) {
-    reasons.push('Offering Team Salary cannot be resolved on the governed transaction date.');
+  if (
+    governedTeamSalary.status !== 'complete' ||
+    governedTeamSalary.total == null
+  ) {
+    reasons.push(
+      'Offering Team Salary cannot be resolved on the governed transaction date.'
+    );
   } else if (
     (currentReservation ?? 0) >
     evidence.league.salaryCap - governedTeamSalary.total
   ) {
-    reasons.push('The offering Team does not preserve sufficient governed Room for this Offer Sheet.');
+    reasons.push(
+      'The offering Team does not preserve sufficient governed Room for this Offer Sheet.'
+    );
   }
-  if (reasons.length > 0 || !rights.ledgerReference || !rights.stateReference) return failure('blocked', reasons);
+  if (reasons.length > 0 || !rights.ledgerReference || !rights.stateReference)
+    return failure('blocked', reasons);
   const recordedAt = new Date(timestamp).toISOString();
   const lifecycle: GovernedOfferSheetLifecycle = {
     payloadVersion: 1,
@@ -316,7 +584,10 @@ export function createGovernedOfferSheetLifecycle({
     offeringTeamId: teamCode,
     salaryCapYear,
     status: 'pending-match',
-    evidenceReference: { evidenceId: evidence.evidenceId, evidenceRecordVersion: evidence.evidenceRecordVersion },
+    evidenceReference: {
+      evidenceId: evidence.evidenceId,
+      evidenceRecordVersion: evidence.evidenceRecordVersion,
+    },
     evidenceSnapshot: evidence,
     rightsReference: { ...rights.ledgerReference, ...rights.stateReference },
     reservations: {
@@ -329,54 +600,95 @@ export function createGovernedOfferSheetLifecycle({
         teamStateReference,
         canonLeafIds: ['CBA2-L04.3'],
       },
-      homeTeamAuthority: 'right-of-first-refusal',
+      homeTeamAuthority: matchingAuthority.kind,
       arenasApplies: termResult.isArenas,
-      offeringTeamAccounting: termResult.isArenas ? 'average-annual-salary' : 'stated-schedule',
+      offeringTeamAccounting: termResult.isArenas
+        ? 'average-annual-salary'
+        : 'stated-schedule',
       homeTeamAccounting: 'stated-schedule',
     },
-    events: [{
-      eventKind: 'offer-sheet-signed',
-      eventId: `${offerSheetId}:signed:v1`,
-      eventVersion: 1,
-      executedAt: signedAt,
-      recordedAt,
-      qualifyingOfferId: evidence.qualifyingOffer.offerId,
-      qualifyingOfferVersion: evidence.qualifyingOffer.offerVersion,
-      exerciseNoticeDeadline: exerciseNoticeDeadline(receivedAt),
-      proposal,
-    }],
+    events: [
+      {
+        eventKind: 'offer-sheet-signed',
+        eventId: `${offerSheetId}:signed:v1`,
+        eventVersion: 1,
+        executedAt: signedAt,
+        recordedAt,
+        qualifyingOfferId: evidence.qualifyingOffer.offerId,
+        qualifyingOfferVersion: evidence.qualifyingOffer.offerVersion,
+        exerciseNoticeDeadline: exerciseDeadline,
+        proposal,
+      },
+    ],
   };
   const verified = GovernedOfferSheetLifecycleZ.safeParse(lifecycle);
-  return verified.success ? { success: true, lifecycle: verified.data, receivedAt } : failure('incompatible', ['The governed Offer Sheet lifecycle could not be certified.']);
+  return verified.success
+    ? { success: true, lifecycle: verified.data, receivedAt }
+    : failure('incompatible', [
+        'The governed Offer Sheet lifecycle could not be certified.',
+      ]);
 }
 
 export function resolveGovernedOfferSheetLifecycle({
   state,
   action,
   resolutionAt,
+  worldAsOfDate,
   averagingElectionInput,
   timestamp,
 }: {
   state: MutationOfferSheetResolutionCurrentState;
   action: 'match' | 'decline';
   resolutionAt?: string | number | null;
+  worldAsOfDate?: string | number | null;
   averagingElectionInput?: unknown;
   timestamp: number;
 }): Failure | ResolutionSuccess {
-  const homeSheet = state.homeTeam?.incomingOfferSheets?.find((sheet) => String(sheet.id) === state.offerSheetId);
-  const offeringSheet = state.offeringTeam?.offerSheets?.find((sheet) => String(sheet.id) === state.offerSheetId);
+  const homeSheet = state.homeTeam?.incomingOfferSheets?.find(
+    (sheet) => String(sheet.id) === state.offerSheetId
+  );
+  const offeringSheet = state.offeringTeam?.offerSheets?.find(
+    (sheet) => String(sheet.id) === state.offerSheetId
+  );
   const home = lifecycleFromSheet(homeSheet);
   const offering = lifecycleFromSheet(offeringSheet);
-  if (!home.success || !offering.success) return failure('incompatible', ['Both Team mirrors require a readable governed Offer Sheet lifecycle.']);
-  if (JSON.stringify(home.data) !== JSON.stringify(offering.data)) return failure('incompatible', ['The two Team Offer Sheet lifecycle mirrors disagree.']);
+  if (!home.success || !offering.success)
+    return failure('incompatible', [
+      'Both Team mirrors require a readable governed Offer Sheet lifecycle.',
+    ]);
+  if (JSON.stringify(home.data) !== JSON.stringify(offering.data))
+    return failure('incompatible', [
+      'The two Team Offer Sheet lifecycle mirrors disagree.',
+    ]);
   const lifecycle = home.data;
-  if (lifecycle.status !== 'pending-match') return failure('blocked', ['Only a pending Offer Sheet can be resolved.']);
+  if (lifecycle.status !== 'pending-match')
+    return failure('blocked', ['Only a pending Offer Sheet can be resolved.']);
   const reasons: string[] = [];
-  const exactAt = requireEasternInstant(resolutionAt, 'Offer Sheet resolution', reasons);
+  const exactAt = requireEasternInstant(
+    resolutionAt,
+    'Offer Sheet resolution',
+    reasons
+  );
   if (!exactAt) return failure('needs-input', reasons);
+  if (!worldDateHasReachedInstant(worldAsOfDate, exactAt)) {
+    reasons.push(
+      'The Exercise Notice instant is after the governed Team Plan date.'
+    );
+  }
   const signedEvent = lifecycle.events[0];
-  if (signedEvent.eventKind !== 'offer-sheet-signed') return failure('incompatible', ['The lifecycle has no signed Offer Sheet root event.']);
-  if (action === 'match' && compareInstant(exactAt, signedEvent.exerciseNoticeDeadline) > 0) {
+  if (signedEvent.eventKind !== 'offer-sheet-signed')
+    return failure('incompatible', [
+      'The lifecycle has no signed Offer Sheet root event.',
+    ]);
+  if (compareInstant(exactAt, signedEvent.proposal.receivedAt) < 0) {
+    reasons.push(
+      'An Offer Sheet cannot be resolved before the home Team receives it.'
+    );
+  }
+  if (
+    action === 'match' &&
+    compareInstant(exactAt, signedEvent.exerciseNoticeDeadline) > 0
+  ) {
     reasons.push('The exact Exercise Notice deadline has passed.');
   }
   const electionParse =
@@ -389,19 +701,135 @@ export function resolveGovernedOfferSheetLifecycle({
     ]);
   }
   const election = electionParse?.success ? electionParse.data : null;
+  let matchingTeamSalaryReference: GovernedOfferSheetTeamSalaryReference | null =
+    null;
   if (action === 'decline' && election) {
-    reasons.push('An averaging election can accompany only an Exercise Notice.');
+    reasons.push(
+      'An averaging election can accompany only an Exercise Notice.'
+    );
   }
   if (election) {
-    if (!lifecycle.reservations.arenasApplies) reasons.push('Only an Arenas match may elect Average Annual Salary.');
-    if (compareInstant(election.deliveredToNbaAt, exactAt) !== 0) reasons.push('The averaging election was not delivered with the Exercise Notice.');
+    if (!lifecycle.reservations.arenasApplies)
+      reasons.push('Only an Arenas match may elect Average Annual Salary.');
     if (
-      compareInstant(election.relayedToPlayersAssociationAt, election.deliveredToNbaAt) < 0 ||
+      !requireEasternInstant(
+        election.deliveredToNbaAt,
+        'Averaging election delivery',
+        reasons
+      )
+    ) {
+      reasons.push('The averaging election delivery time cannot be certified.');
+    } else if (
+      election.deliveredToNbaAt.slice(0, 10) !== exactAt.slice(0, 10)
+    ) {
+      reasons.push(
+        'The averaging election was not delivered on the Exercise Notice date.'
+      );
+    }
+    if (
+      !worldDateHasReachedInstant(
+        worldAsOfDate,
+        election.relayedToPlayersAssociationAt
+      )
+    ) {
+      reasons.push(
+        'The Players Association relay is after the governed Team Plan date.'
+      );
+    }
+    requireEasternInstant(
+      election.relayedToPlayersAssociationAt,
+      'Players Association relay',
+      reasons
+    );
+    if (
+      compareInstant(
+        election.relayedToPlayersAssociationAt,
+        election.deliveredToNbaAt
+      ) < 0 ||
       businessDaysBetween(
         election.deliveredToNbaAt,
         election.relayedToPlayersAssociationAt
       ) > 1
-    ) reasons.push('The averaging-election statement was not relayed within one business day.');
+    )
+      reasons.push(
+        'The averaging-election statement was not relayed within one business day.'
+      );
+    const matchingTeamCode = String(state.homeTeam?.teamCode || '');
+    const matchingTotals = state.homeTeam
+      ? synchronizeTeamTotalsSnapshotOrTeam(
+          state.homeTeam,
+          lifecycle.salaryCapYear
+        ).totals
+      : null;
+    const matchingAllocations = Number(matchingTotals?.totalCapAllocations);
+    const matchingStateReference = state.homeTeam
+      ? `${lifecycle.worldId}:${matchingTeamCode}:${mutationSnapshotDigest(state.homeTeam)}`
+      : '';
+    const matchingSalaryEvaluation = evaluateDatedSalaryLedgers({
+      context: {
+        asOfDate: exactAt,
+        salaryCapYear: lifecycle.salaryCapYear,
+        team: { teamId: matchingTeamCode, teamCode: matchingTeamCode },
+      },
+      ledgers: {
+        teamSalary: Number.isFinite(matchingAllocations)
+          ? {
+              status: 'ready',
+              lineItems: [
+                {
+                  id: `pre-match-team-salary:${matchingTeamCode}:${lifecycle.salaryCapYear}`,
+                  ledger: 'team-salary',
+                  label: 'Pre-Match Team Salary',
+                  amount: matchingAllocations,
+                  effectiveFrom: `${lifecycle.salaryCapYear - 1}-07-01T00:00:00-04:00`,
+                  canonLeafIds: ['CBA2-C15.10'],
+                  source: {
+                    authority: 'team-state',
+                    reference: matchingStateReference,
+                  },
+                },
+              ],
+            }
+          : {
+              status: 'needs-input',
+              missingInputs: ['ledgers.teamSalary.lineItems'],
+              reason: 'Matching Team Salary cannot be resolved.',
+            },
+        apronTeamSalary: {
+          status: 'not-evaluated',
+          reason:
+            'The Arenas election tests Team Salary against the Salary Cap.',
+        },
+        taxSalary: {
+          status: 'not-evaluated',
+          reason: 'The Arenas election does not use Tax Salary.',
+        },
+      },
+    });
+    const matchingTeamSalary = matchingSalaryEvaluation.ledgers.teamSalary;
+    if (
+      matchingTeamSalary.status !== 'complete' ||
+      matchingTeamSalary.total == null
+    ) {
+      reasons.push(
+        'Matching Team Salary cannot be resolved for the averaging election.'
+      );
+    } else if (
+      matchingTeamSalary.total >= lifecycle.evidenceSnapshot.league.salaryCap
+    ) {
+      reasons.push(
+        'Only a below-cap matching Team may elect Average Annual Salary.'
+      );
+    } else {
+      matchingTeamSalaryReference = {
+        ledgerKind: 'team-salary',
+        asOfDate: exactAt,
+        salaryCap: lifecycle.evidenceSnapshot.league.salaryCap,
+        totalBeforeOfferSheet: matchingTeamSalary.total,
+        teamStateReference: matchingStateReference,
+        canonLeafIds: ['CBA2-C15.10'],
+      };
+    }
   }
   if (reasons.length > 0) return failure('blocked', reasons);
   const version = lifecycle.ledgerVersion + 1;
@@ -412,7 +840,10 @@ export function resolveGovernedOfferSheetLifecycle({
     status: action === 'match' ? 'matched' : 'declined',
     reservations: {
       ...lifecycle.reservations,
-      homeTeamAccounting: action === 'match' && election ? 'average-annual-salary' : 'stated-schedule',
+      homeTeamAccounting:
+        action === 'match' && election
+          ? 'average-annual-salary'
+          : 'stated-schedule',
     },
     events: [
       ...lifecycle.events,
@@ -428,6 +859,7 @@ export function resolveGovernedOfferSheetLifecycle({
             offeringTeamTradeBarred: true,
             signAndTradeBarred: true,
             averagingElection: election,
+            matchingTeamSalaryReference,
           }
         : {
             eventKind: 'offer-sheet-declined',
@@ -439,5 +871,9 @@ export function resolveGovernedOfferSheetLifecycle({
     ],
   };
   const parsed = GovernedOfferSheetLifecycleZ.safeParse(next);
-  return parsed.success ? { success: true, lifecycle: parsed.data } : failure('incompatible', ['The resolved Offer Sheet lifecycle could not be certified.']);
+  return parsed.success
+    ? { success: true, lifecycle: parsed.data }
+    : failure('incompatible', [
+        'The resolved Offer Sheet lifecycle could not be certified.',
+      ]);
 }

--- a/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
@@ -45,6 +45,11 @@ type CreationSuccess = {
 type ResolutionSuccess = {
   success: true;
   lifecycle: GovernedOfferSheetLifecycle;
+  expectedLifecycle: Readonly<{
+    ledgerId: string;
+    ledgerVersion: number;
+    digest: string;
+  }>;
 };
 
 function failure(status: FailureStatus, reasons: readonly string[]): Failure {
@@ -951,7 +956,15 @@ export function resolveGovernedOfferSheetLifecycle({
   };
   const parsed = GovernedOfferSheetLifecycleZ.safeParse(next);
   return parsed.success
-    ? { success: true, lifecycle: parsed.data }
+    ? {
+        success: true,
+        lifecycle: parsed.data,
+        expectedLifecycle: Object.freeze({
+          ledgerId: lifecycle.ledgerId,
+          ledgerVersion: lifecycle.ledgerVersion,
+          digest: mutationSnapshotDigest(lifecycle),
+        }),
+      }
     : failure('incompatible', [
         'The resolved Offer Sheet lifecycle could not be certified.',
       ]);

--- a/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
@@ -2,10 +2,12 @@
 
 import {
   GovernedOfferSheetEvidenceZ,
+  GovernedOfferSheetAuthorizationZ,
   GovernedOfferSheetAveragingElectionZ,
   GovernedOfferSheetLifecycleZ,
   GovernedOfferSheetProposalZ,
   type GovernedOfferSheetLifecycle,
+  type GovernedOfferSheetAuthorization,
   type GovernedOfferSheetTeamSalaryReference,
 } from '@/schemas/governedOfferSheet';
 import { projectRightsStateAsOf } from '@/features/architect/utils/rightsHistory';
@@ -62,6 +64,40 @@ function failure(status: FailureStatus, reasons: readonly string[]): Failure {
 
 function lifecycleFromSheet(sheet: ArchitectMutationOfferSheet | undefined) {
   return GovernedOfferSheetLifecycleZ.safeParse(sheet?.governedLifecycle);
+}
+
+export function buildGovernedOfferSheetAuthorization({
+  lifecycle,
+  offerSheetId,
+  dedupKey,
+}: {
+  lifecycle: GovernedOfferSheetLifecycle;
+  offerSheetId: string;
+  dedupKey: string;
+}): GovernedOfferSheetAuthorization {
+  if (
+    lifecycle.status !== 'pending-match' ||
+    !offerSheetId.trim() ||
+    !dedupKey.trim()
+  ) {
+    throw new Error(
+      'Offer Sheet authorization requires one pending lifecycle with stable envelope identity.'
+    );
+  }
+  return GovernedOfferSheetAuthorizationZ.parse({
+    authorizationVersion: 1,
+    worldId: lifecycle.worldId,
+    offerSheetId: offerSheetId.trim(),
+    dedupKey: dedupKey.trim(),
+    playerId: lifecycle.playerId,
+    homeTeamId: lifecycle.homeTeamId,
+    offeringTeamId: lifecycle.offeringTeamId,
+    salaryCapYear: lifecycle.salaryCapYear,
+    pendingLifecycleDigest: mutationSnapshotDigest(lifecycle),
+    immutableEvidenceDigest: mutationSnapshotDigest(
+      lifecycle.evidenceSnapshot
+    ),
+  });
 }
 
 function activeReservations(

--- a/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
@@ -506,11 +506,27 @@ export function createGovernedOfferSheetLifecycle({
   )?.amount;
   if (currentReservation == null)
     reasons.push(`Principal Terms do not include ${season}.`);
-  activeReservations(state.team?.offerSheets ?? [], season, dedupKey, reasons);
+  const outstandingReservations = activeReservations(
+    state.team?.offerSheets ?? [],
+    season,
+    dedupKey,
+    reasons
+  );
   const totals = state.team
     ? synchronizeTeamTotalsSnapshotOrTeam(state.team, salaryCapYear).totals
     : null;
   const allocations = Number(totals?.totalCapAllocations);
+  const snapshotOutstandingReservations = Number(
+    totals?.outstandingOfferSheetTotal
+  );
+  if (
+    Number.isFinite(snapshotOutstandingReservations) &&
+    snapshotOutstandingReservations !== outstandingReservations
+  ) {
+    reasons.push(
+      'Outstanding Offer Sheet reservations do not reconcile with governed Team Salary.'
+    );
+  }
   const teamCode = String(state.team?.teamCode || '');
   const teamStateReference = state.team
     ? `${worldId}:${teamCode}:${mutationSnapshotDigest(state.team)}`
@@ -564,6 +580,9 @@ export function createGovernedOfferSheetLifecycle({
       'Offering Team Salary cannot be resolved on the governed transaction date.'
     );
   } else if (
+    // governedTeamSalary.total already includes every outstanding Offer Sheet
+    // reservation. Add only the new sheet here so existing Room is not counted
+    // twice.
     (currentReservation ?? 0) >
     evidence.league.salaryCap - governedTeamSalary.total
   ) {
@@ -571,8 +590,13 @@ export function createGovernedOfferSheetLifecycle({
       'The offering Team does not preserve sufficient governed Room for this Offer Sheet.'
     );
   }
-  if (reasons.length > 0 || !rights.ledgerReference || !rights.stateReference)
-    return failure('blocked', reasons);
+  if (!rights.ledgerReference || !rights.stateReference) {
+    return failure('blocked', [
+      ...reasons,
+      'The authenticated RFA rights ledger and projected state references are required.',
+    ]);
+  }
+  if (reasons.length > 0) return failure('blocked', reasons);
   const recordedAt = new Date(timestamp).toISOString();
   const lifecycle: GovernedOfferSheetLifecycle = {
     payloadVersion: 1,
@@ -632,6 +656,7 @@ export function createGovernedOfferSheetLifecycle({
 export function resolveGovernedOfferSheetLifecycle({
   state,
   action,
+  dedupKey,
   resolutionAt,
   worldAsOfDate,
   averagingElectionInput,
@@ -639,17 +664,33 @@ export function resolveGovernedOfferSheetLifecycle({
 }: {
   state: MutationOfferSheetResolutionCurrentState;
   action: 'match' | 'decline';
+  dedupKey?: string | null;
   resolutionAt?: string | number | null;
   worldAsOfDate?: string | number | null;
   averagingElectionInput?: unknown;
   timestamp: number;
 }): Failure | ResolutionSuccess {
-  const homeSheet = state.homeTeam?.incomingOfferSheets?.find(
-    (sheet) => String(sheet.id) === state.offerSheetId
+  const matchesRequestedIdentity = (sheet: ArchitectMutationOfferSheet) => {
+    const normalizedDedupKey = String(dedupKey || '').trim();
+    return (
+      String(sheet.id || '') === state.offerSheetId ||
+      (normalizedDedupKey.length > 0 &&
+        String(sheet.dedupKey || '') === normalizedDedupKey)
+    );
+  };
+  const homeMatches = (state.homeTeam?.incomingOfferSheets ?? []).filter(
+    matchesRequestedIdentity
   );
-  const offeringSheet = state.offeringTeam?.offerSheets?.find(
-    (sheet) => String(sheet.id) === state.offerSheetId
+  const offeringMatches = (state.offeringTeam?.offerSheets ?? []).filter(
+    matchesRequestedIdentity
   );
+  if (homeMatches.length !== 1 || offeringMatches.length !== 1) {
+    return failure('incompatible', [
+      'Offer Sheet resolution requires exactly one matching mirror on each Team.',
+    ]);
+  }
+  const [homeSheet] = homeMatches;
+  const [offeringSheet] = offeringMatches;
   const home = lifecycleFromSheet(homeSheet);
   const offering = lifecycleFromSheet(offeringSheet);
   if (!home.success || !offering.success)
@@ -661,6 +702,29 @@ export function resolveGovernedOfferSheetLifecycle({
       'The two Team Offer Sheet lifecycle mirrors disagree.',
     ]);
   const lifecycle = home.data;
+  const expectedSeason = toSeasonCode(lifecycle.salaryCapYear);
+  const expectedEnvelopeStatuses =
+    action === 'match'
+      ? new Set(['PENDING_MATCH', 'MATCHED'])
+      : new Set(['PENDING_MATCH', 'DECLINED']);
+  const envelopeMatchesLifecycle = (sheet: ArchitectMutationOfferSheet) =>
+    String(sheet.playerId || '') === lifecycle.playerId &&
+    String(sheet.homeTeamCode || '') === lifecycle.homeTeamId &&
+    String(sheet.offeringTeamCode || '') === lifecycle.offeringTeamId &&
+    String(sheet.seasonKey || '') === expectedSeason &&
+    Number(sheet.year) === lifecycle.salaryCapYear &&
+    expectedEnvelopeStatuses.has(String(sheet.status || ''));
+  if (
+    String(homeSheet.id || '') !== String(offeringSheet.id || '') ||
+    String(homeSheet.dedupKey || '') !== String(offeringSheet.dedupKey || '') ||
+    String(homeSheet.status || '') !== String(offeringSheet.status || '') ||
+    !envelopeMatchesLifecycle(homeSheet) ||
+    !envelopeMatchesLifecycle(offeringSheet)
+  ) {
+    return failure('incompatible', [
+      'The two Team Offer Sheet envelopes do not match the authenticated lifecycle identity.',
+    ]);
+  }
   if (lifecycle.status !== 'pending-match')
     return failure('blocked', ['Only a pending Offer Sheet can be resolved.']);
   const reasons: string[] = [];

--- a/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetLifecycle.ts
@@ -702,6 +702,14 @@ export function resolveGovernedOfferSheetLifecycle({
       'The two Team Offer Sheet lifecycle mirrors disagree.',
     ]);
   const lifecycle = home.data;
+  if (
+    String(state.homeTeam?.teamCode || '') !== lifecycle.homeTeamId ||
+    String(state.offeringTeam?.teamCode || '') !== lifecycle.offeringTeamId
+  ) {
+    return failure('incompatible', [
+      'The Offer Sheet mirrors are stored in Team containers that do not match the authenticated lifecycle identity.',
+    ]);
+  }
   const expectedSeason = toSeasonCode(lifecycle.salaryCapYear);
   const expectedEnvelopeStatuses =
     action === 'match'
@@ -898,6 +906,36 @@ export function resolveGovernedOfferSheetLifecycle({
   if (reasons.length > 0) return failure('blocked', reasons);
   const version = lifecycle.ledgerVersion + 1;
   const recordedAt = new Date(timestamp).toISOString();
+  let resolutionEvent: GovernedOfferSheetLifecycle['events'][number];
+  if (action === 'match') {
+    const restrictionsUntil = oneYearAfter(exactAt);
+    if (!restrictionsUntil) {
+      return failure('incompatible', [
+        'The matched-player restriction anniversary is not a valid Eastern-time instant.',
+      ]);
+    }
+    resolutionEvent = {
+      eventKind: 'offer-sheet-matched',
+      eventId: `${lifecycle.ledgerId}:matched:v${version}`,
+      eventVersion: 1,
+      executedAt: exactAt,
+      recordedAt,
+      restrictionsUntil,
+      playerTradeConsentRequired: true,
+      offeringTeamTradeBarred: true,
+      signAndTradeBarred: true,
+      averagingElection: election,
+      matchingTeamSalaryReference,
+    };
+  } else {
+    resolutionEvent = {
+      eventKind: 'offer-sheet-declined',
+      eventId: `${lifecycle.ledgerId}:declined:v${version}`,
+      eventVersion: 1,
+      executedAt: exactAt,
+      recordedAt,
+    };
+  }
   const next: GovernedOfferSheetLifecycle = {
     ...lifecycle,
     ledgerVersion: version,
@@ -909,30 +947,7 @@ export function resolveGovernedOfferSheetLifecycle({
           ? 'average-annual-salary'
           : 'stated-schedule',
     },
-    events: [
-      ...lifecycle.events,
-      action === 'match'
-        ? {
-            eventKind: 'offer-sheet-matched',
-            eventId: `${lifecycle.ledgerId}:matched:v${version}`,
-            eventVersion: 1,
-            executedAt: exactAt,
-            recordedAt,
-            restrictionsUntil: oneYearAfter(exactAt),
-            playerTradeConsentRequired: true,
-            offeringTeamTradeBarred: true,
-            signAndTradeBarred: true,
-            averagingElection: election,
-            matchingTeamSalaryReference,
-          }
-        : {
-            eventKind: 'offer-sheet-declined',
-            eventId: `${lifecycle.ledgerId}:declined:v${version}`,
-            eventVersion: 1,
-            executedAt: exactAt,
-            recordedAt,
-          },
-    ],
+    events: [...lifecycle.events, resolutionEvent],
   };
   const parsed = GovernedOfferSheetLifecycleZ.safeParse(next);
   return parsed.success

--- a/src/features/architect/utils/offerSheets/governedOfferSheetRestrictions.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetRestrictions.ts
@@ -25,6 +25,8 @@ export function inspectGovernedOfferSheetMatchRestriction(
   if (asOf == null) return { status: 'needs-input' };
 
   if (typeof asOf === 'string' && isDateOnly(asOf)) {
+    // Date-only Team Plan evaluations keep the restriction active for the
+    // entire local calendar date named by restrictedUntil.
     return asOf <= parsed.data.restrictedUntil.slice(0, 10)
       ? { status: 'active', restriction: parsed.data }
       : { status: 'expired' };
@@ -42,6 +44,8 @@ export function inspectGovernedOfferSheetMatchRestriction(
     return { status: 'needs-input' };
   }
 
+  // Exact instants expire at restrictedUntil itself; there is no extra
+  // end-of-day grace period on timestamped transaction evaluations.
   return asOfMilliseconds < restrictionMilliseconds
     ? { status: 'active', restriction: parsed.data }
     : { status: 'expired' };

--- a/src/features/architect/utils/offerSheets/governedOfferSheetRestrictions.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetRestrictions.ts
@@ -1,0 +1,48 @@
+/** Read and date-test the one-year restrictions created by an Offer Sheet match. */
+
+import {
+  GovernedOfferSheetMatchRestrictionZ,
+  type GovernedOfferSheetMatchRestriction,
+} from '@/schemas/governedOfferSheet';
+
+export type GovernedOfferSheetRestrictionState =
+  | { status: 'absent' | 'expired' }
+  | { status: 'active'; restriction: GovernedOfferSheetMatchRestriction }
+  | { status: 'incompatible' | 'needs-input' };
+
+function isDateOnly(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+export function inspectGovernedOfferSheetMatchRestriction(
+  value: unknown,
+  asOf: string | number | Date | null | undefined
+): GovernedOfferSheetRestrictionState {
+  if (value == null) return { status: 'absent' };
+
+  const parsed = GovernedOfferSheetMatchRestrictionZ.safeParse(value);
+  if (!parsed.success) return { status: 'incompatible' };
+  if (asOf == null) return { status: 'needs-input' };
+
+  if (typeof asOf === 'string' && isDateOnly(asOf)) {
+    return asOf <= parsed.data.restrictedUntil.slice(0, 10)
+      ? { status: 'active', restriction: parsed.data }
+      : { status: 'expired' };
+  }
+
+  const asOfMilliseconds =
+    asOf instanceof Date ? asOf.getTime() : new Date(asOf).getTime();
+  const restrictionMilliseconds = new Date(
+    parsed.data.restrictedUntil
+  ).getTime();
+  if (
+    !Number.isFinite(asOfMilliseconds) ||
+    !Number.isFinite(restrictionMilliseconds)
+  ) {
+    return { status: 'needs-input' };
+  }
+
+  return asOfMilliseconds < restrictionMilliseconds
+    ? { status: 'active', restriction: parsed.data }
+    : { status: 'expired' };
+}

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
@@ -1,0 +1,160 @@
+/** Principal-term and Arenas validation for governed RFA Offer Sheets. */
+
+import type {
+  GovernedOfferSheetEvidence,
+  GovernedOfferSheetProposal,
+} from '@/schemas/governedOfferSheet';
+import type { ArchitectMutationContract } from '@/features/architect/utils/mutationPipeline';
+
+export interface GovernedOfferSheetTermResult {
+  readonly reasons: readonly string[];
+  readonly offeringReservations: readonly { season: string; amount: number }[];
+  readonly averageAnnualSalary: number;
+  readonly isArenas: boolean;
+}
+
+function bonusTotal(
+  row: GovernedOfferSheetProposal['salariesByYear'][number],
+  classification?: 'likely' | 'unlikely'
+): number {
+  return row.bonuses
+    .filter((bonus) => !classification || bonus.classification === classification)
+    .reduce((sum, bonus) => sum + bonus.amount, 0);
+}
+
+function money(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function validateProposalAgainstContract(
+  proposal: GovernedOfferSheetProposal,
+  contract: ArchitectMutationContract,
+  reasons: string[]
+) {
+  const contractRows = contract.salariesByYear ?? [];
+  if (contractRows.length !== proposal.salariesByYear.length) {
+    reasons.push('Principal Terms must match every Contract Salary Cap Year.');
+    return;
+  }
+  for (const [index, row] of proposal.salariesByYear.entries()) {
+    const contractRow = contractRows[index];
+    if (
+      contractRow?.season !== row.season ||
+      Number(contractRow.salary ?? contractRow.capHit) !== row.regularSalary
+    ) {
+      reasons.push(
+        `Principal Terms do not match the saved Contract in Season ${row.season}.`
+      );
+    }
+  }
+}
+
+function validateAnnualChange(
+  first: number,
+  second: number,
+  label: string,
+  reasons: string[]
+) {
+  if (Math.abs(second - first) > money(first * 0.05)) {
+    reasons.push(`Second-year ${label} changes by more than 5%.`);
+  }
+}
+
+function validateArenas(
+  proposal: GovernedOfferSheetProposal,
+  evidence: GovernedOfferSheetEvidence,
+  reasons: string[]
+) {
+  const [first, second, third, fourth] = proposal.salariesByYear;
+  if (!first || !second) {
+    reasons.push('A one- or two-YOS Offer Sheet needs at least two Seasons.');
+    return;
+  }
+  if (first.regularSalary + bonusTotal(first, 'unlikely') > evidence.league.nonTaxpayerMle) {
+    reasons.push('First-year Salary plus Unlikely Bonuses exceeds the NTMLE.');
+  }
+  validateAnnualChange(
+    first.salaryExcludingIncentive,
+    second.salaryExcludingIncentive,
+    'Salary excluding Incentive Compensation',
+    reasons
+  );
+  validateAnnualChange(first.regularSalary, second.regularSalary, 'Regular Salary', reasons);
+  const firstBonuses = new Map(first.bonuses.map((bonus) => [bonus.bonusId, bonus]));
+  const secondBonuses = new Map(second.bonuses.map((bonus) => [bonus.bonusId, bonus]));
+  if (firstBonuses.size !== secondBonuses.size) {
+    reasons.push('Every first-year bonus must have one second-year counterpart.');
+  }
+  for (const [bonusId, firstBonus] of firstBonuses) {
+    const secondBonus = secondBonuses.get(bonusId);
+    if (!secondBonus || secondBonus.classification !== firstBonus.classification) {
+      reasons.push(`Bonus ${bonusId} is missing or changes classification in Year 2.`);
+    } else {
+      validateAnnualChange(firstBonus.amount, secondBonus.amount, `bonus ${bonusId}`, reasons);
+    }
+  }
+  if (third) {
+    const hasJump = third.regularSalary > money(second.regularSalary * 1.05);
+    if (
+      hasJump &&
+      (first.regularSalary !== evidence.league.nonTaxpayerMle ||
+        second.regularSalary !== money(first.regularSalary * 1.05))
+    ) {
+      reasons.push('A third-year Arenas jump requires the maximum permitted first two Seasons.');
+    }
+    if (third.regularSalary > evidence.league.maximumSalary) {
+      reasons.push('Third-year Salary exceeds the offering Team maximum.');
+    }
+  }
+  if (third && fourth && Math.abs(fourth.regularSalary - third.regularSalary) > money(third.regularSalary * 0.045)) {
+    reasons.push('Fourth-year Salary changes by more than 4.5% of third-year Regular Salary.');
+  }
+  for (const row of [third, fourth].filter(Boolean)) {
+    if (
+      bonusTotal(row!) !== 0 ||
+      !row!.guaranteedForLackOfSkill ||
+      !row!.guaranteedForInjuryOrIllness ||
+      row!.individuallyNegotiatedProtectionConditions
+    ) {
+      reasons.push('Arenas Years 3 and 4 must have no bonuses and full unconditional protection.');
+    }
+  }
+}
+
+export function validateGovernedOfferSheetTerms({
+  proposal,
+  evidence,
+  contract,
+}: {
+  proposal: GovernedOfferSheetProposal;
+  evidence: GovernedOfferSheetEvidence;
+  contract: ArchitectMutationContract;
+}): GovernedOfferSheetTermResult {
+  const reasons: string[] = [];
+  validateProposalAgainstContract(proposal, contract, reasons);
+  const nonOptionSeasons = proposal.salariesByYear.filter((row) => row.option === null).length;
+  const minimumSeasons = evidence.qualifyingOffer.branch === 'maximum' ? 3 : 2;
+  if (nonOptionSeasons < minimumSeasons) {
+    reasons.push(`This Offer Sheet requires at least ${minimumSeasons} Seasons excluding options.`);
+  }
+  const isArenas = evidence.eligibility.yearsOfService >= 1 && evidence.eligibility.yearsOfService <= 2;
+  if (isArenas) validateArenas(proposal, evidence, reasons);
+  const total = proposal.salariesByYear.reduce(
+    (sum, row) => sum + row.salaryExcludingIncentive + bonusTotal(row),
+    0
+  );
+  const averageAnnualSalary = money(total / proposal.salariesByYear.length);
+  return Object.freeze({
+    reasons: Object.freeze(reasons),
+    offeringReservations: Object.freeze(
+      proposal.salariesByYear.map((row) =>
+        Object.freeze({
+          season: row.season,
+          amount: isArenas ? averageAnnualSalary : row.regularSalary,
+        })
+      )
+    ),
+    averageAnnualSalary,
+    isArenas,
+  });
+}

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
@@ -166,13 +166,17 @@ function validateArenas(
       'Fourth-year Salary changes by more than 4.5% of third-year Regular Salary.'
     );
   }
-  for (const row of [third, fourth].filter(Boolean)) {
+  const arenasTailRows = [third, fourth].filter(
+    (row): row is GovernedOfferSheetProposal['salariesByYear'][number] =>
+      row != null
+  );
+  for (const row of arenasTailRows) {
     if (
-      governedOfferSheetBonusTotal(row!) !== 0 ||
-      !row!.guaranteedForLackOfSkill ||
-      !row!.guaranteedForInjuryOrIllness ||
-      row!.individuallyNegotiatedProtectionConditions ||
-      row!.option !== null
+      governedOfferSheetBonusTotal(row) !== 0 ||
+      !row.guaranteedForLackOfSkill ||
+      !row.guaranteedForInjuryOrIllness ||
+      row.individuallyNegotiatedProtectionConditions ||
+      row.option !== null
     ) {
       reasons.push(
         'Arenas Years 3 and 4 must have no bonuses or options and full unconditional protection.'

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
@@ -197,6 +197,14 @@ export function validateGovernedOfferSheetTerms({
   const reasons: string[] = [];
   validateProposalAgainstContract(proposal, contract, reasons);
   for (const row of proposal.salariesByYear) {
+    const likelyBonuses = governedOfferSheetBonusTotal(row, 'likely');
+    if (
+      money(row.salaryExcludingIncentive + likelyBonuses) !== row.regularSalary
+    ) {
+      reasons.push(
+        `Salary excluding Incentive Compensation plus Likely Bonuses must equal Regular Salary in Season ${row.season}.`
+      );
+    }
     if (
       new Set(row.bonuses.map((bonus) => bonus.bonusId)).size !==
       row.bonuses.length

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTerms.ts
@@ -5,20 +5,25 @@ import type {
   GovernedOfferSheetProposal,
 } from '@/schemas/governedOfferSheet';
 import type { ArchitectMutationContract } from '@/features/architect/utils/mutationPipeline';
+import { toSeasonCode } from '@/features/architect/utils/seasonFormat';
+import { canonicalizeOptionType } from '@/shared/utils/contracts/optionType';
 
 export interface GovernedOfferSheetTermResult {
   readonly reasons: readonly string[];
   readonly offeringReservations: readonly { season: string; amount: number }[];
   readonly averageAnnualSalary: number;
   readonly isArenas: boolean;
+  readonly firstYearMatchAmount: number;
 }
 
-function bonusTotal(
+export function governedOfferSheetBonusTotal(
   row: GovernedOfferSheetProposal['salariesByYear'][number],
   classification?: 'likely' | 'unlikely'
 ): number {
   return row.bonuses
-    .filter((bonus) => !classification || bonus.classification === classification)
+    .filter(
+      (bonus) => !classification || bonus.classification === classification
+    )
     .reduce((sum, bonus) => sum + bonus.amount, 0);
 }
 
@@ -38,9 +43,19 @@ function validateProposalAgainstContract(
   }
   for (const [index, row] of proposal.salariesByYear.entries()) {
     const contractRow = contractRows[index];
+    const contractLikely = Number(contractRow?.incentives?.likely ?? 0);
+    const contractUnlikely = Number(contractRow?.incentives?.unlikely ?? 0);
     if (
       contractRow?.season !== row.season ||
-      Number(contractRow.salary ?? contractRow.capHit) !== row.regularSalary
+      Number(contractRow.salary ?? contractRow.capHit) !== row.regularSalary ||
+      contractLikely !== governedOfferSheetBonusTotal(row, 'likely') ||
+      contractUnlikely !== governedOfferSheetBonusTotal(row, 'unlikely') ||
+      contractRow.guaranteed !==
+        (row.guaranteedForLackOfSkill &&
+          row.guaranteedForInjuryOrIllness &&
+          !row.individuallyNegotiatedProtectionConditions) ||
+      canonicalizeOptionType(contractRow.option ?? contractRow.optionType) !==
+        row.option
     ) {
       reasons.push(
         `Principal Terms do not match the saved Contract in Season ${row.season}.`
@@ -70,7 +85,10 @@ function validateArenas(
     reasons.push('A one- or two-YOS Offer Sheet needs at least two Seasons.');
     return;
   }
-  if (first.regularSalary + bonusTotal(first, 'unlikely') > evidence.league.nonTaxpayerMle) {
+  if (
+    first.regularSalary + governedOfferSheetBonusTotal(first, 'unlikely') >
+    evidence.league.nonTaxpayerMle
+  ) {
     reasons.push('First-year Salary plus Unlikely Bonuses exceeds the NTMLE.');
   }
   validateAnnualChange(
@@ -79,44 +97,86 @@ function validateArenas(
     'Salary excluding Incentive Compensation',
     reasons
   );
-  validateAnnualChange(first.regularSalary, second.regularSalary, 'Regular Salary', reasons);
-  const firstBonuses = new Map(first.bonuses.map((bonus) => [bonus.bonusId, bonus]));
-  const secondBonuses = new Map(second.bonuses.map((bonus) => [bonus.bonusId, bonus]));
+  validateAnnualChange(
+    first.regularSalary,
+    second.regularSalary,
+    'Regular Salary',
+    reasons
+  );
+  const firstBonuses = new Map(
+    first.bonuses.map((bonus) => [bonus.bonusId, bonus])
+  );
+  const secondBonuses = new Map(
+    second.bonuses.map((bonus) => [bonus.bonusId, bonus])
+  );
   if (firstBonuses.size !== secondBonuses.size) {
-    reasons.push('Every first-year bonus must have one second-year counterpart.');
+    reasons.push(
+      'Every first-year bonus must have one second-year counterpart.'
+    );
   }
   for (const [bonusId, firstBonus] of firstBonuses) {
     const secondBonus = secondBonuses.get(bonusId);
-    if (!secondBonus || secondBonus.classification !== firstBonus.classification) {
-      reasons.push(`Bonus ${bonusId} is missing or changes classification in Year 2.`);
+    if (
+      !secondBonus ||
+      secondBonus.classification !== firstBonus.classification
+    ) {
+      reasons.push(
+        `Bonus ${bonusId} is missing or changes classification in Year 2.`
+      );
     } else {
-      validateAnnualChange(firstBonus.amount, secondBonus.amount, `bonus ${bonusId}`, reasons);
+      validateAnnualChange(
+        firstBonus.amount,
+        secondBonus.amount,
+        `bonus ${bonusId}`,
+        reasons
+      );
     }
   }
   if (third) {
+    const thirdYearMaximum = evidence.league.maximumSalaryBySeason.find(
+      (row) => row.season === third.season
+    )?.amount;
     const hasJump = third.regularSalary > money(second.regularSalary * 1.05);
+    const firstPermittedAmount =
+      first.regularSalary + governedOfferSheetBonusTotal(first, 'unlikely');
+    const secondPermittedAmount =
+      second.regularSalary + governedOfferSheetBonusTotal(second, 'unlikely');
     if (
       hasJump &&
-      (first.regularSalary !== evidence.league.nonTaxpayerMle ||
-        second.regularSalary !== money(first.regularSalary * 1.05))
+      (firstPermittedAmount !== evidence.league.arenasYearOneMaximum ||
+        secondPermittedAmount !== evidence.league.arenasYearTwoMaximum)
     ) {
-      reasons.push('A third-year Arenas jump requires the maximum permitted first two Seasons.');
+      reasons.push(
+        'A third-year Arenas jump requires the maximum permitted first two Seasons.'
+      );
     }
-    if (third.regularSalary > evidence.league.maximumSalary) {
+    if (thirdYearMaximum == null) {
+      reasons.push('The third-year offering Team maximum is missing.');
+    } else if (third.regularSalary > thirdYearMaximum) {
       reasons.push('Third-year Salary exceeds the offering Team maximum.');
     }
   }
-  if (third && fourth && Math.abs(fourth.regularSalary - third.regularSalary) > money(third.regularSalary * 0.045)) {
-    reasons.push('Fourth-year Salary changes by more than 4.5% of third-year Regular Salary.');
+  if (
+    third &&
+    fourth &&
+    Math.abs(fourth.regularSalary - third.regularSalary) >
+      money(third.regularSalary * 0.045)
+  ) {
+    reasons.push(
+      'Fourth-year Salary changes by more than 4.5% of third-year Regular Salary.'
+    );
   }
   for (const row of [third, fourth].filter(Boolean)) {
     if (
-      bonusTotal(row!) !== 0 ||
+      governedOfferSheetBonusTotal(row!) !== 0 ||
       !row!.guaranteedForLackOfSkill ||
       !row!.guaranteedForInjuryOrIllness ||
-      row!.individuallyNegotiatedProtectionConditions
+      row!.individuallyNegotiatedProtectionConditions ||
+      row!.option !== null
     ) {
-      reasons.push('Arenas Years 3 and 4 must have no bonuses and full unconditional protection.');
+      reasons.push(
+        'Arenas Years 3 and 4 must have no bonuses or options and full unconditional protection.'
+      );
     }
   }
 }
@@ -132,18 +192,53 @@ export function validateGovernedOfferSheetTerms({
 }): GovernedOfferSheetTermResult {
   const reasons: string[] = [];
   validateProposalAgainstContract(proposal, contract, reasons);
-  const nonOptionSeasons = proposal.salariesByYear.filter((row) => row.option === null).length;
-  const minimumSeasons = evidence.qualifyingOffer.branch === 'maximum' ? 3 : 2;
-  if (nonOptionSeasons < minimumSeasons) {
-    reasons.push(`This Offer Sheet requires at least ${minimumSeasons} Seasons excluding options.`);
+  for (const row of proposal.salariesByYear) {
+    if (
+      new Set(row.bonuses.map((bonus) => bonus.bonusId)).size !==
+      row.bonuses.length
+    ) {
+      reasons.push(
+        `Principal Terms contain duplicate bonus IDs in Season ${row.season}.`
+      );
+    }
   }
-  const isArenas = evidence.eligibility.yearsOfService >= 1 && evidence.eligibility.yearsOfService <= 2;
+  for (const [index, row] of proposal.salariesByYear.entries()) {
+    const expectedSeason = toSeasonCode(evidence.salaryCapYear + index);
+    if (row.season !== expectedSeason) {
+      reasons.push(
+        `Principal Terms must use consecutive Salary Cap Years beginning with ${toSeasonCode(evidence.salaryCapYear)}.`
+      );
+      break;
+    }
+  }
+  const guaranteedSeasons = proposal.salariesByYear.filter(
+    (row) =>
+      row.option === null &&
+      row.guaranteedForLackOfSkill &&
+      row.guaranteedForInjuryOrIllness &&
+      !row.individuallyNegotiatedProtectionConditions
+  ).length;
+  const minimumSeasons =
+    evidence.qualifyingOffer.requiredOfferSheetGuaranteedSeasons;
+  if (guaranteedSeasons < minimumSeasons) {
+    reasons.push(
+      `This Offer Sheet requires at least ${minimumSeasons} fully protected Seasons excluding options.`
+    );
+  }
+  const isArenas =
+    evidence.eligibility.yearsOfService >= 1 &&
+    evidence.eligibility.yearsOfService <= 2;
   if (isArenas) validateArenas(proposal, evidence, reasons);
   const total = proposal.salariesByYear.reduce(
-    (sum, row) => sum + row.salaryExcludingIncentive + bonusTotal(row),
+    (sum, row) =>
+      sum + row.salaryExcludingIncentive + governedOfferSheetBonusTotal(row),
     0
   );
   const averageAnnualSalary = money(total / proposal.salariesByYear.length);
+  const first = proposal.salariesByYear[0];
+  const firstYearMatchAmount = first
+    ? first.salaryExcludingIncentive + governedOfferSheetBonusTotal(first)
+    : 0;
   return Object.freeze({
     reasons: Object.freeze(reasons),
     offeringReservations: Object.freeze(
@@ -156,5 +251,6 @@ export function validateGovernedOfferSheetTerms({
     ),
     averageAnnualSalary,
     isArenas,
+    firstYearMatchAmount,
   });
 }

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
@@ -1,19 +1,33 @@
 /** Exact Eastern-time rules used by governed RFA Offer Sheet decisions. */
 
 import {
+  GOVERNING_TIME_ZONE,
   isDateOnly,
   isZonedDateTime,
   parseZonedDateTime,
 } from '@/features/architect/utils/governedSeason';
 
-const EASTERN_OFFSET = /(?:-04:00|-05:00)$/;
+function easternOffsetAt(value: string): string | null {
+  const timeZoneName = new Intl.DateTimeFormat('en-US', {
+    timeZone: GOVERNING_TIME_ZONE,
+    timeZoneName: 'longOffset',
+  })
+    .formatToParts(new Date(value))
+    .find((part) => part.type === 'timeZoneName')?.value;
+  const offset = timeZoneName?.replace('GMT', '');
+  return offset && /^[+-]\d{2}:\d{2}$/.test(offset) ? offset : null;
+}
+
+export function isEasternInstant(value: unknown): value is string {
+  return isZonedDateTime(value) && easternOffsetAt(value) === value.slice(-6);
+}
 
 export function requireEasternInstant(
   value: unknown,
   label: string,
   reasons: string[]
 ): string | null {
-  if (!isZonedDateTime(value) || !EASTERN_OFFSET.test(value)) {
+  if (!isEasternInstant(value)) {
     reasons.push(`${label} must be an exact Eastern-time instant.`);
     return null;
   }
@@ -21,8 +35,9 @@ export function requireEasternInstant(
 }
 
 export function compareInstant(left: string, right: string): number {
-  return (parseZonedDateTime(left) as number) -
-    (parseZonedDateTime(right) as number);
+  return (
+    (parseZonedDateTime(left) as number) - (parseZonedDateTime(right) as number)
+  );
 }
 
 function localParts(value: string) {
@@ -61,7 +76,21 @@ export function worldDateContainsInstant(
 ): boolean {
   if (isDateOnly(worldAsOfDate)) return worldAsOfDate === instant.slice(0, 10);
   return (
-    isZonedDateTime(worldAsOfDate) && compareInstant(instant, worldAsOfDate) <= 0
+    isZonedDateTime(worldAsOfDate) &&
+    compareInstant(instant, worldAsOfDate) <= 0
+  );
+}
+
+export function worldDateHasReachedInstant(
+  worldAsOfDate: unknown,
+  instant: string
+): boolean {
+  if (isDateOnly(worldAsOfDate)) {
+    return worldAsOfDate >= instant.slice(0, 10);
+  }
+  return (
+    isZonedDateTime(worldAsOfDate) &&
+    compareInstant(worldAsOfDate, instant) >= 0
   );
 }
 

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
@@ -35,9 +35,12 @@ export function requireEasternInstant(
 }
 
 export function compareInstant(left: string, right: string): number {
-  return (
-    (parseZonedDateTime(left) as number) - (parseZonedDateTime(right) as number)
-  );
+  const leftMilliseconds = parseZonedDateTime(left);
+  const rightMilliseconds = parseZonedDateTime(right);
+  if (leftMilliseconds == null || rightMilliseconds == null) {
+    return Number.NaN;
+  }
+  return leftMilliseconds - rightMilliseconds;
 }
 
 function localParts(value: string) {
@@ -56,18 +59,40 @@ function dateAfterDays(value: string, days: number): string {
   return date.toISOString().slice(0, 10);
 }
 
+function composeEasternInstant(localDateTime: string): string {
+  for (const offset of ['-05:00', '-04:00']) {
+    const candidate = `${localDateTime}${offset}`;
+    if (easternOffsetAt(candidate) === offset) return candidate;
+  }
+
+  // A nonexistent local wall-clock time (for example during the spring DST
+  // gap) must remain visibly invalid so the governed schema fails closed.
+  return `${localDateTime}-05:00`;
+}
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
 export function exerciseNoticeDeadline(receivedAt: string): string {
-  const { year, month, day, hour, offset } = localParts(receivedAt);
+  const { year, month, day, hour } = localParts(receivedAt);
   if (month === 7 && day >= 1 && day <= 6) {
     return `${year}-07-07T23:59:59-04:00`;
   }
   const days = hour < 12 ? 1 : 2;
-  return `${dateAfterDays(receivedAt, days)}T23:59:59${offset}`;
+  return composeEasternInstant(`${dateAfterDays(receivedAt, days)}T23:59:59`);
 }
 
 export function oneYearAfter(value: string): string {
-  const nextYear = Number(value.slice(0, 4)) + 1;
-  return `${nextYear}${value.slice(4)}`;
+  const { year, month, day } = localParts(value);
+  const nextYear = year + 1;
+  const normalizedDay =
+    month === 2 && day === 29 && !isLeapYear(nextYear) ? 28 : day;
+  const localDate = `${nextYear}-${String(month).padStart(2, '0')}-${String(
+    normalizedDay
+  ).padStart(2, '0')}`;
+  const localTime = value.slice(11, -6);
+  return composeEasternInstant(`${localDate}T${localTime}`);
 }
 
 export function worldDateContainsInstant(

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
@@ -1,0 +1,93 @@
+/** Exact Eastern-time rules used by governed RFA Offer Sheet decisions. */
+
+import {
+  isDateOnly,
+  isZonedDateTime,
+  parseZonedDateTime,
+} from '@/features/architect/utils/governedSeason';
+
+const EASTERN_OFFSET = /(?:-04:00|-05:00)$/;
+
+export function requireEasternInstant(
+  value: unknown,
+  label: string,
+  reasons: string[]
+): string | null {
+  if (!isZonedDateTime(value) || !EASTERN_OFFSET.test(value)) {
+    reasons.push(`${label} must be an exact Eastern-time instant.`);
+    return null;
+  }
+  return value;
+}
+
+export function compareInstant(left: string, right: string): number {
+  return (parseZonedDateTime(left) as number) -
+    (parseZonedDateTime(right) as number);
+}
+
+function localParts(value: string) {
+  return {
+    year: Number(value.slice(0, 4)),
+    month: Number(value.slice(5, 7)),
+    day: Number(value.slice(8, 10)),
+    hour: Number(value.slice(11, 13)),
+    offset: value.slice(-6),
+  };
+}
+
+function dateAfterDays(value: string, days: number): string {
+  const { year, month, day } = localParts(value);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return date.toISOString().slice(0, 10);
+}
+
+export function exerciseNoticeDeadline(receivedAt: string): string {
+  const { year, month, day, hour, offset } = localParts(receivedAt);
+  if (month === 7 && day >= 1 && day <= 6) {
+    return `${year}-07-07T23:59:59-04:00`;
+  }
+  const days = hour < 12 ? 1 : 2;
+  return `${dateAfterDays(receivedAt, days)}T23:59:59${offset}`;
+}
+
+export function oneYearAfter(value: string): string {
+  const nextYear = Number(value.slice(0, 4)) + 1;
+  return `${nextYear}${value.slice(4)}`;
+}
+
+export function worldDateContainsInstant(
+  worldAsOfDate: unknown,
+  instant: string
+): boolean {
+  if (isDateOnly(worldAsOfDate)) return worldAsOfDate === instant.slice(0, 10);
+  return (
+    isZonedDateTime(worldAsOfDate) && compareInstant(instant, worldAsOfDate) <= 0
+  );
+}
+
+export function qualifyingOfferDeadlines(salaryCapYear: number) {
+  const startYear = salaryCapYear - 1;
+  return {
+    delivery: `${startYear}-06-29T17:00:00-04:00`,
+    unilateralWithdrawalEnds: `${startYear}-07-13T23:59:59-04:00`,
+    consentWithdrawalStarts: `${startYear}-07-14T00:00:00-04:00`,
+    ordinaryOpenThrough: `${startYear}-10-01T23:59:59-04:00`,
+    absoluteOpenThrough: `${salaryCapYear}-03-01T23:59:59-05:00`,
+    offerSheetLastSignedAt: `${salaryCapYear}-03-01T23:59:59-05:00`,
+  };
+}
+
+export function businessDaysBetween(from: string, through: string): number {
+  const start = new Date(`${from.slice(0, 10)}T12:00:00Z`);
+  const end = new Date(`${through.slice(0, 10)}T12:00:00Z`);
+  let count = 0;
+  for (
+    let cursor = new Date(start.getTime() + 86_400_000);
+    cursor <= end;
+    cursor = new Date(cursor.getTime() + 86_400_000)
+  ) {
+    const day = cursor.getUTCDay();
+    if (day !== 0 && day !== 6) count += 1;
+  }
+  return count;
+}

--- a/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
+++ b/src/features/architect/utils/offerSheets/governedOfferSheetTime.ts
@@ -59,15 +59,13 @@ function dateAfterDays(value: string, days: number): string {
   return date.toISOString().slice(0, 10);
 }
 
-function composeEasternInstant(localDateTime: string): string {
+function composeEasternInstant(localDateTime: string): string | null {
   for (const offset of ['-05:00', '-04:00']) {
     const candidate = `${localDateTime}${offset}`;
     if (easternOffsetAt(candidate) === offset) return candidate;
   }
 
-  // A nonexistent local wall-clock time (for example during the spring DST
-  // gap) must remain visibly invalid so the governed schema fails closed.
-  return `${localDateTime}-05:00`;
+  return null;
 }
 
 function isLeapYear(year: number): boolean {
@@ -80,10 +78,18 @@ export function exerciseNoticeDeadline(receivedAt: string): string {
     return `${year}-07-07T23:59:59-04:00`;
   }
   const days = hour < 12 ? 1 : 2;
-  return composeEasternInstant(`${dateAfterDays(receivedAt, days)}T23:59:59`);
+  const deadline = composeEasternInstant(
+    `${dateAfterDays(receivedAt, days)}T23:59:59`
+  );
+  if (!deadline) {
+    throw new Error(
+      'The Exercise Notice deadline is not a valid Eastern instant.'
+    );
+  }
+  return deadline;
 }
 
-export function oneYearAfter(value: string): string {
+export function oneYearAfter(value: string): string | null {
   const { year, month, day } = localParts(value);
   const nextYear = year + 1;
   const normalizedDay =

--- a/src/features/architect/utils/offerSheets/index.ts
+++ b/src/features/architect/utils/offerSheets/index.ts
@@ -1,0 +1,5 @@
+export {
+  createGovernedOfferSheetLifecycle,
+  resolveGovernedOfferSheetLifecycle,
+} from './governedOfferSheetLifecycle';
+export { validateGovernedOfferSheetTerms } from './governedOfferSheetTerms';

--- a/src/features/architect/utils/offerSheets/index.ts
+++ b/src/features/architect/utils/offerSheets/index.ts
@@ -2,4 +2,11 @@ export {
   createGovernedOfferSheetLifecycle,
   resolveGovernedOfferSheetLifecycle,
 } from './governedOfferSheetLifecycle';
-export { validateGovernedOfferSheetTerms } from './governedOfferSheetTerms';
+export {
+  inspectGovernedOfferSheetMatchRestriction,
+  type GovernedOfferSheetRestrictionState,
+} from './governedOfferSheetRestrictions';
+export {
+  governedOfferSheetBonusTotal,
+  validateGovernedOfferSheetTerms,
+} from './governedOfferSheetTerms';

--- a/src/features/architect/utils/offerSheets/index.ts
+++ b/src/features/architect/utils/offerSheets/index.ts
@@ -1,5 +1,6 @@
 export {
   createGovernedOfferSheetLifecycle,
+  buildGovernedOfferSheetAuthorization,
   resolveGovernedOfferSheetLifecycle,
 } from './governedOfferSheetLifecycle';
 export {

--- a/src/features/architect/utils/persistenceContracts/contracts.ts
+++ b/src/features/architect/utils/persistenceContracts/contracts.ts
@@ -346,6 +346,7 @@ export const EVENT_METADATA_TOP_LEVEL_ALLOWLIST: PersistenceAllowlist = Object.f
   'offeringTeamCode',
   'homeTeamCode',
   'offerSheetId',
+  'governedOfferSheetLifecycle',
   'offeringTeam',
   'homeTeam',
 

--- a/src/features/architect/utils/persistenceContracts/contracts.ts
+++ b/src/features/architect/utils/persistenceContracts/contracts.ts
@@ -348,6 +348,7 @@ export const EVENT_METADATA_TOP_LEVEL_ALLOWLIST: PersistenceAllowlist = Object.f
   'offerSheetId',
   'governedOfferSheetLifecycle',
   'expectedGovernedOfferSheetLifecycle',
+  'expectedOfferSheetCreationSnapshots',
   'expectedOfferSheetResolutionSnapshots',
   'offeringTeam',
   'homeTeam',

--- a/src/features/architect/utils/persistenceContracts/contracts.ts
+++ b/src/features/architect/utils/persistenceContracts/contracts.ts
@@ -347,6 +347,7 @@ export const EVENT_METADATA_TOP_LEVEL_ALLOWLIST: PersistenceAllowlist = Object.f
   'homeTeamCode',
   'offerSheetId',
   'governedOfferSheetLifecycle',
+  'expectedGovernedOfferSheetLifecycle',
   'offeringTeam',
   'homeTeam',
 

--- a/src/features/architect/utils/persistenceContracts/contracts.ts
+++ b/src/features/architect/utils/persistenceContracts/contracts.ts
@@ -348,6 +348,7 @@ export const EVENT_METADATA_TOP_LEVEL_ALLOWLIST: PersistenceAllowlist = Object.f
   'offerSheetId',
   'governedOfferSheetLifecycle',
   'expectedGovernedOfferSheetLifecycle',
+  'expectedOfferSheetResolutionSnapshots',
   'offeringTeam',
   'homeTeam',
 

--- a/src/features/architect/utils/tradeHelpers.ts
+++ b/src/features/architect/utils/tradeHelpers.ts
@@ -146,6 +146,7 @@ export const getSalaryForYear = (input: unknown, year: unknown): number => {
   return players.reduce((sum: number, player: TradeHelperPlayer) => {
     let base = 0;
     let yData: SalariesByYearEntry = {};
+    let hasExplicitCapHit = false;
 
     if (player?.contract?.salariesByYear?.length) {
       const slice =
@@ -153,12 +154,18 @@ export const getSalaryForYear = (input: unknown, year: unknown): number => {
           (entry: SalariesByYearEntry) => toEndYear(entry.season) === year
         ) ||
         player.contract.salariesByYear.find(
-          (entry: SalariesByYearEntry) =>
-            String(entry.season) === String(year)
+          (entry: SalariesByYearEntry) => String(entry.season) === String(year)
         );
       if (slice) {
         yData = slice;
-        base = Number(slice.capHit ?? slice.salary ?? 0) || 0;
+        const explicitCapHit = Number(slice.capHit);
+        hasExplicitCapHit =
+          slice.capHit !== null &&
+          slice.capHit !== undefined &&
+          Number.isFinite(explicitCapHit);
+        base = hasExplicitCapHit
+          ? explicitCapHit
+          : Number(slice.salary ?? 0) || 0;
       }
     }
 
@@ -166,12 +173,13 @@ export const getSalaryForYear = (input: unknown, year: unknown): number => {
       base = player.salary;
     }
 
-    const likely =
-      (typeof yData.likely_bonus === 'number' ? yData.likely_bonus : 0) ||
-      Number(yData.bonuses?.likely ?? 0) ||
-      Number(yData.incentives?.likely ?? 0) ||
-      Number(yData.likelyIncentives ?? 0) ||
-      Number(player?.bonusesByYear?.[String(year)]?.likely ?? 0);
+    const likely = hasExplicitCapHit
+      ? 0
+      : (typeof yData.likely_bonus === 'number' ? yData.likely_bonus : 0) ||
+        Number(yData.bonuses?.likely ?? 0) ||
+        Number(yData.incentives?.likely ?? 0) ||
+        Number(yData.likelyIncentives ?? 0) ||
+        Number(player?.bonusesByYear?.[String(year)]?.likely ?? 0);
 
     return sum + base + likely;
   }, 0);
@@ -237,7 +245,10 @@ export const getIncomingCeiling = (
           Date.parse(tradeException.expirationDate) > Date.now()) &&
         !(
           totalSalaryNum > secondApronNum &&
-          isPriorYearTPE(tradeException as TradeExceptionRecord, Number(yearKey))
+          isPriorYearTPE(
+            tradeException as TradeExceptionRecord,
+            Number(yearKey)
+          )
         )
     )
     .reduce(
@@ -313,7 +324,9 @@ export function calculateAllowableIncoming(
   ...args: unknown[]
 ): AllowableIncomingResult | number {
   if (typeof args[0] === 'object' && args[0] !== null && args.length === 1) {
-    return _calculateAllowableIncomingObj(args[0] as AllowableIncomingObjectParams);
+    return _calculateAllowableIncomingObj(
+      args[0] as AllowableIncomingObjectParams
+    );
   }
 
   const currentTeamSalary = args[0] as NumericLike;
@@ -365,19 +378,16 @@ export const getSeasonalCashLimit = (yearKey: NumericLike): number => {
   const key = String(yearKey);
   const fallbackKey = Object.keys(CBA_BY_YEAR).pop() as string;
   return (
-    ((CBA_BY_YEAR as Record<string, { cashLimit?: number }>)[key] ??
-      (CBA_BY_YEAR as Record<string, { cashLimit?: number }>)[fallbackKey])
-      .cashLimit || 0
+    (
+      (CBA_BY_YEAR as Record<string, { cashLimit?: number }>)[key] ??
+      (CBA_BY_YEAR as Record<string, { cashLimit?: number }>)[fallbackKey]
+    ).cashLimit || 0
   );
 };
 
 export const getApronStatus = (
   salary: NumericLike,
-  {
-    firstApron,
-    secondApron,
-    salaryCap,
-  }: TradeCapSettingsLike = {}
+  { firstApron, secondApron, salaryCap }: TradeCapSettingsLike = {}
 ): '2nd Apron' | '1st Apron' | 'Below Aprons' => {
   const status = getTeamApronStatusSSoT(
     { totalSalary: salary },
@@ -531,7 +541,9 @@ export const generateTradeId = (teams: TradeTeamEntry[]): string =>
     )
     .join('|');
 
-export const getPlayerAdjustmentTypes = (player: TradeHelperPlayer): string[] => {
+export const getPlayerAdjustmentTypes = (
+  player: TradeHelperPlayer
+): string[] => {
   if (!player) return [];
 
   if (isTwoWayTradePlayer(player)) {

--- a/src/features/architect/utils/tradeMachine/rules/validateConsent.ts
+++ b/src/features/architect/utils/tradeMachine/rules/validateConsent.ts
@@ -11,6 +11,7 @@ import {
   TradeTeam,
   ValidationIssue,
 } from '../constants/types';
+import { inspectGovernedOfferSheetMatchRestriction } from '@/features/architect/utils/offerSheets';
 import { summarizeValidationIssues } from '../utils/validationIssueText';
 
 type ConsentPlayer = TradeExceptionPlayer & {
@@ -29,6 +30,7 @@ type ConsentPlayer = TradeExceptionPlayer & {
     fullNTC?: boolean;
     limitedNTCList?: Array<string | number>;
     yearsRemaining?: number;
+    offerSheetMatchRestriction?: unknown;
   };
 };
 
@@ -66,9 +68,12 @@ function resolveDestinationTeamId(
   let destTeamId: string | number | null = null;
 
   if (teams.length === 2) {
-    const otherTeam = teams.find((candidate) => candidate.teamId !== team.teamId);
+    const otherTeam = teams.find(
+      (candidate) => candidate.teamId !== team.teamId
+    );
     if (otherTeam) {
-      destTeamId = (otherTeam.teamId as string | number | null | undefined) || null;
+      destTeamId =
+        (otherTeam.teamId as string | number | null | undefined) || null;
     }
   } else if (teams.length > 2) {
     destTeamId = player.destTeamId || player.toTeamId || null;
@@ -99,6 +104,55 @@ export function validateConsent(
   outgoingPlayers.forEach((player) => {
     const playerName = getPlayerName(player);
     const destTeamId = resolveDestinationTeamId(team, player, tradeCtx);
+    const offerSheetRestriction = inspectGovernedOfferSheetMatchRestriction(
+      player.contract?.offerSheetMatchRestriction,
+      tradeCtx.asOfDate ?? tradeCtx.tradeDate
+    );
+
+    if (
+      offerSheetRestriction.status === 'incompatible' ||
+      offerSheetRestriction.status === 'needs-input'
+    ) {
+      violations.push(
+        createIssue(
+          `${playerName}'s matched Offer Sheet restriction cannot be certified for this trade`,
+          'CONSENT__OFFER_SHEET_RESTRICTION_UNRESOLVED',
+          null,
+          { playerName }
+        )
+      );
+    } else if (offerSheetRestriction.status === 'active') {
+      const offeringTeamId =
+        offerSheetRestriction.restriction.offeringTeamId.toUpperCase();
+      if (!destTeamId) {
+        violations.push(
+          createIssue(
+            `${playerName}'s trade destination is required while matched Offer Sheet restrictions are active`,
+            'CONSENT__OFFER_SHEET_DESTINATION_REQUIRED',
+            null,
+            { playerName }
+          )
+        );
+      } else if (String(destTeamId).toUpperCase() === offeringTeamId) {
+        violations.push(
+          createIssue(
+            `${playerName} cannot be traded to the Offer Sheet's offering Team before ${offerSheetRestriction.restriction.restrictedUntil}`,
+            'CONSENT__OFFER_SHEET_OFFERING_TEAM_BARRED',
+            null,
+            { playerName, destTeamId }
+          )
+        );
+      } else if (!hasConsent(player)) {
+        violations.push(
+          createIssue(
+            `${playerName} must consent to a trade before ${offerSheetRestriction.restriction.restrictedUntil} after a matched Offer Sheet`,
+            'CONSENT__OFFER_SHEET_PLAYER_CONSENT_REQUIRED',
+            null,
+            { playerName, destTeamId }
+          )
+        );
+      }
+    }
 
     if (hasFullNTC(player) && !hasConsent(player)) {
       violations.push(
@@ -126,7 +180,11 @@ export function validateConsent(
       );
     }
 
-    if (destTeamId && birdRightsVetoApplies(player, destTeamId) && !hasConsent(player)) {
+    if (
+      destTeamId &&
+      birdRightsVetoApplies(player, destTeamId) &&
+      !hasConsent(player)
+    ) {
       violations.push(
         createIssue(
           `${playerName} has Bird rights veto power and must consent`,
@@ -141,7 +199,9 @@ export function validateConsent(
   return {
     passed: violations.length === 0,
     violations,
-    message: violations.length ? 'Player consent required' : 'Player consent validated',
+    message: violations.length
+      ? 'Player consent required'
+      : 'Player consent validated',
     details: summarizeValidationIssues(violations),
   };
 }

--- a/src/features/architect/utils/tradeMachine/rules/validateSignAndTrade.ts
+++ b/src/features/architect/utils/tradeMachine/rules/validateSignAndTrade.ts
@@ -16,6 +16,7 @@ import type {
   ValidationIssue,
   ValidationResult,
 } from '../constants/types';
+import { inspectGovernedOfferSheetMatchRestriction } from '@/features/architect/utils/offerSheets';
 
 type SignAndTradeRulePlayer = SignAndTradeContractCarrier & {
   signAndTrade?: boolean;
@@ -95,7 +96,9 @@ function resolveTeamId(team: SignAndTradeRuleTeam): string | null {
     : null;
 }
 
-function resolveDestinationTeamId(player: SignAndTradeRulePlayer): string | null {
+function resolveDestinationTeamId(
+  player: SignAndTradeRulePlayer
+): string | null {
   const destination =
     player.tradeTo ||
     player.receivingTeamId ||
@@ -103,7 +106,9 @@ function resolveDestinationTeamId(player: SignAndTradeRulePlayer): string | null
     player.destTeamId ||
     null;
 
-  return typeof destination === 'string' && destination.trim() ? destination : null;
+  return typeof destination === 'string' && destination.trim()
+    ? destination
+    : null;
 }
 
 function isTradeMachinePath(tradeCtx: SignAndTradeTradeContext = {}): boolean {
@@ -116,7 +121,9 @@ function getValidationYear(
   return tradeCtx.currentYear || tradeCtx.yearKey || null;
 }
 
-function getSourceTeamCapHolds(team: SignAndTradeRuleTeam): SignAndTradeCapHold[] {
+function getSourceTeamCapHolds(
+  team: SignAndTradeRuleTeam
+): SignAndTradeCapHold[] {
   if (Array.isArray(team.team?.capHolds)) {
     return team.team.capHolds;
   }
@@ -135,7 +142,9 @@ function getContractPlayerLabel(player: SignAndTradeRulePlayer): string {
   return String(player.name || player.id || 'Player');
 }
 
-function isReceivingTeamTaxpayerMleBlocked(team: SignAndTradeRuleTeam): boolean {
+function isReceivingTeamTaxpayerMleBlocked(
+  team: SignAndTradeRuleTeam
+): boolean {
   return (
     team.team?.usedTaxpayerMLEThisSeason === true ||
     team.usedTaxpayerMLEThisSeason === true
@@ -182,11 +191,43 @@ export function validateSignAndTrade(
     (player) => player.signAndTrade === true
   );
 
+  for (const player of [
+    ...incomingSignAndTradePlayers,
+    ...outgoingSignAndTradePlayers,
+  ]) {
+    const restriction = inspectGovernedOfferSheetMatchRestriction(
+      player.contract?.offerSheetMatchRestriction,
+      tradeCtx.asOfDate ?? tradeCtx.tradeDate ?? tradeDateObj
+    );
+    if (restriction.status === 'active') {
+      violations.push(
+        createIssue(
+          `${getPlayerLabel(player)} cannot be used in a sign-and-trade before ${restriction.restriction.restrictedUntil} after a matched Offer Sheet`,
+          'SIGN_AND_TRADE__OFFER_SHEET_MATCH_RESTRICTED',
+          null,
+          { playerId: player.id || null }
+        )
+      );
+    } else if (
+      restriction.status === 'incompatible' ||
+      restriction.status === 'needs-input'
+    ) {
+      violations.push(
+        createIssue(
+          `${getPlayerLabel(player)} has an unreadable matched Offer Sheet restriction`,
+          'SIGN_AND_TRADE__OFFER_SHEET_RESTRICTION_UNRESOLVED',
+          null,
+          { playerId: player.id || null }
+        )
+      );
+    }
+  }
+
   if (
     incomingSignAndTradePlayers.length === 0 &&
     outgoingSignAndTradePlayers.length === 0
   ) {
-    return buildValidationResult([], {
+    return buildValidationResult(violations, {
       hasSignAndTrade: false,
       hardCapped: false,
     });
@@ -198,7 +239,9 @@ export function validateSignAndTrade(
   const eligibilityYear = validationYear || tradeCtx.currentYear || 0;
   const sourceTeamId = resolveTeamId(team);
   const sourceTeamCapHolds = getSourceTeamCapHolds(team);
-  const activeTeamCount = Array.isArray(tradeCtx.teams) ? tradeCtx.teams.length : 2;
+  const activeTeamCount = Array.isArray(tradeCtx.teams)
+    ? tradeCtx.teams.length
+    : 2;
   const requireExplicitDestination =
     strictContractPayload || activeTeamCount >= 3;
 
@@ -285,9 +328,13 @@ export function validateSignAndTrade(
       return;
     }
 
-    const contract = resolveSignAndTradeContractPayload(player, validationYear, {
-      allowPlayerContractFallback: !strictContractPayload,
-    });
+    const contract = resolveSignAndTradeContractPayload(
+      player,
+      validationYear,
+      {
+        allowPlayerContractFallback: !strictContractPayload,
+      }
+    );
 
     const contractValidation = validateSignAndTradeContractPayload(
       contract,

--- a/src/features/architect/utils/tradeMachine/signAndTrade/signAndTradeEligibility.ts
+++ b/src/features/architect/utils/tradeMachine/signAndTrade/signAndTradeEligibility.ts
@@ -53,6 +53,7 @@ export type SignAndTradeContractLike = {
   years?: number | null;
   firstYearGuaranteed?: boolean | null;
   signingTeam?: string | null;
+  offerSheetMatchRestriction?: unknown;
 };
 
 export type SignAndTradeNormalizedContract = SignAndTradeContractLike & {
@@ -147,28 +148,33 @@ function normalizeTeamCode(value: unknown): string | null {
   return trimmed.length === 3 ? trimmed.toUpperCase() : trimmed;
 }
 
-function resolvePlayerId(player: Record<string, unknown> | null | undefined): string | null {
+function resolvePlayerId(
+  player: Record<string, unknown> | null | undefined
+): string | null {
   if (!player) return null;
   const bio = player.bio as Record<string, unknown> | null | undefined;
   const raw =
-    player.playerId ||
-    player.player_id ||
-    player.id ||
-    bio?.playerId ||
-    null;
+    player.playerId || player.player_id || player.id || bio?.playerId || null;
   return raw ? String(raw) : null;
 }
 
-function resolvePlayerName(player: Record<string, unknown> | null | undefined): string | null {
+function resolvePlayerName(
+  player: Record<string, unknown> | null | undefined
+): string | null {
   if (!player) return null;
   const bio = player.bio as Record<string, unknown> | null | undefined;
   const raw = player.displayName || player.name || bio?.displayName || null;
   return raw ? String(raw) : null;
 }
 
-function resolvePlayerTeamId(player: Record<string, unknown> | null | undefined) {
+function resolvePlayerTeamId(
+  player: Record<string, unknown> | null | undefined
+) {
   if (!player) return null;
-  const contract = player.contract as Record<string, unknown> | null | undefined;
+  const contract = player.contract as
+    | Record<string, unknown>
+    | null
+    | undefined;
   return normalizeTeamCode(
     player.teamCode ||
       player.teamId ||
@@ -205,12 +211,16 @@ function toSeasonString(endYear: number): string {
 }
 
 function getContractRows(player: Record<string, unknown>) {
-  const contract = player?.contract as Record<string, unknown> | null | undefined;
-  const primaryContract = player?.primaryContract as Record<string, unknown> | null | undefined;
+  const contract = player?.contract as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const primaryContract = player?.primaryContract as
+    | Record<string, unknown>
+    | null
+    | undefined;
   const primaryRows =
-    contract?.salariesByYear ||
-    primaryContract?.salariesByYear ||
-    [];
+    contract?.salariesByYear || primaryContract?.salariesByYear || [];
   return Array.isArray(primaryRows) ? primaryRows : [];
 }
 
@@ -256,7 +266,9 @@ function matchPlayerCapHold(
     return true;
   }
   const holdName = hold.playerName || hold.name || null;
-  return Boolean(playerName && holdName && String(holdName) === String(playerName));
+  return Boolean(
+    playerName && holdName && String(holdName) === String(playerName)
+  );
 }
 
 function isActiveCapHoldForYear(
@@ -285,10 +297,22 @@ function isActiveCapHoldForYear(
 function resolveFreeAgencyYear(player: Record<string, unknown>): number | null {
   const bio = player?.bio as Record<string, unknown> | null | undefined;
   const bioDisplay = bio?.display as Record<string, unknown> | null | undefined;
-  const contract = player?.contract as Record<string, unknown> | null | undefined;
-  const contractFreeAgency = contract?.freeAgency as Record<string, unknown> | null | undefined;
-  const primaryContract = player?.primaryContract as Record<string, unknown> | null | undefined;
-  const primaryContractFreeAgency = primaryContract?.freeAgency as Record<string, unknown> | null | undefined;
+  const contract = player?.contract as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const contractFreeAgency = contract?.freeAgency as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const primaryContract = player?.primaryContract as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const primaryContractFreeAgency = primaryContract?.freeAgency as
+    | Record<string, unknown>
+    | null
+    | undefined;
   return toIntegerOrNull(
     player?.freeAgentYear ??
       bioDisplay?.freeAgentYear ??
@@ -324,19 +348,28 @@ export function getPlayerContractStatusForYear(
     endYear: number;
   }>;
 
-  const salaryRowForYear = rowsWithYear.find((entry) => entry.endYear === endYear);
-  const hasSalaryForYear = Boolean(salaryRowForYear && hasPositiveSalary(salaryRowForYear.row));
+  const salaryRowForYear = rowsWithYear.find(
+    (entry) => entry.endYear === endYear
+  );
+  const hasSalaryForYear = Boolean(
+    salaryRowForYear && hasPositiveSalary(salaryRowForYear.row)
+  );
   const salaryForYear = salaryRowForYear
     ? toFiniteNumber(salaryRowForYear.row.capHit ?? salaryRowForYear.row.salary)
     : 0;
   const hasFutureGuaranteedSalary = rowsWithYear.some(
-    (entry) => endYear != null && entry.endYear >= endYear && hasPositiveSalary(entry.row)
+    (entry) =>
+      endYear != null &&
+      entry.endYear >= endYear &&
+      hasPositiveSalary(entry.row)
   );
 
   const matchedHolds = capHolds.filter((hold) =>
     matchPlayerCapHold(hold, playerId, playerName)
   );
-  const hasActiveCapHold = matchedHolds.some((hold) => hold.active !== false && hold.isSigned !== true);
+  const hasActiveCapHold = matchedHolds.some(
+    (hold) => hold.active !== false && hold.isSigned !== true
+  );
   const hasSeasonMatchingCapHold = matchedHolds.some((hold) =>
     isActiveCapHoldForYear(hold, seasonKey, endYear)
   );
@@ -369,7 +402,10 @@ export function getPlayerContractStatusForYear(
     };
   }
 
-  if (hasFutureGuaranteedSalary || (freeAgencyYear != null && freeAgencyYear > endYear)) {
+  if (
+    hasFutureGuaranteedSalary ||
+    (freeAgencyYear != null && freeAgencyYear > endYear)
+  ) {
     return {
       status: PLAYER_CONTRACT_STATUS.UNDER_CONTRACT,
       reasonCode: hasFutureGuaranteedSalary
@@ -547,7 +583,8 @@ function normalizeSalaryRowsFromByYear(
 ) {
   return rows.map((row, index) => {
     const normalizedSeason = (() => {
-      if (typeof row.season === 'string' && row.season.trim()) return row.season;
+      if (typeof row.season === 'string' && row.season.trim())
+        return row.season;
       if (typeof row.year === 'number' && Number.isFinite(row.year)) {
         return toSeasonString(Math.trunc(row.year));
       }
@@ -635,7 +672,10 @@ export function resolveSignAndTradeContractPayload(
     sendOrPlayer.signAndTradeContract ||
     getNestedSignAndTradeContract(sendOrPlayer.signAndTrade) ||
     null;
-  const normalizedExplicit = normalizeSignAndTradeContractPayload(explicit, yearKey);
+  const normalizedExplicit = normalizeSignAndTradeContractPayload(
+    explicit,
+    yearKey
+  );
   if (normalizedExplicit) return normalizedExplicit;
 
   if (options.allowPlayerContractFallback) {
@@ -649,7 +689,8 @@ export function resolveSignAndTradeContractPayload(
               fallbackContractBase.salariesByYear ??
               sendOrPlayer.salariesByYear ??
               null,
-            salaries: fallbackContractBase.salaries ?? sendOrPlayer.salaries ?? null,
+            salaries:
+              fallbackContractBase.salaries ?? sendOrPlayer.salaries ?? null,
             contractYears:
               sendOrPlayer.contractYears ??
               sendOrPlayer.years ??
@@ -661,10 +702,7 @@ export function resolveSignAndTradeContractPayload(
           }
         : sendOrPlayer;
 
-    return normalizeSignAndTradeContractPayload(
-      fallbackContract,
-      yearKey
-    );
+    return normalizeSignAndTradeContractPayload(fallbackContract, yearKey);
   }
 
   return null;
@@ -734,7 +772,11 @@ export function getSignAndTradeSalaryForYear(
   yearKey: number | string,
   options: { allowPlayerContractFallback?: boolean } = {}
 ): number {
-  const contract = resolveSignAndTradeContractPayload(sendOrPlayer, yearKey, options);
+  const contract = resolveSignAndTradeContractPayload(
+    sendOrPlayer,
+    yearKey,
+    options
+  );
   if (!contract) return 0;
 
   const normalizedYear = normalizeYearInput(yearKey);

--- a/src/schemas/governedOfferSheet.ts
+++ b/src/schemas/governedOfferSheet.ts
@@ -5,11 +5,11 @@ import { z } from 'zod';
 const NonEmptyStringZ = z.string().refine((value) => value.trim().length > 0, {
   message: 'must contain at least one non-whitespace character',
 });
+export const MAX_OFFER_SHEET_SALARY_CAP_YEARS = 4;
 // Governed money records use dollars with at most cent precision, including
 // Arenas maximums and derived Average Annual Salary amounts.
 const MoneyZ = z
   .number()
-  .finite()
   .nonnegative()
   .refine((value) => Math.abs(value * 100 - Math.round(value * 100)) < 1e-6, {
     message: 'must use at most cent precision',
@@ -161,19 +161,22 @@ export const GovernedOfferSheetProposalZ = z.strictObject({
   receivedAt: ZonedInstantZ,
   principalTermsDocumentId: NonEmptyStringZ,
   noticeDocumentId: NonEmptyStringZ,
-  salariesByYear: z.array(GovernedOfferSheetSalaryZ).min(1).max(4),
+  salariesByYear: z
+    .array(GovernedOfferSheetSalaryZ)
+    .min(1)
+    .max(MAX_OFFER_SHEET_SALARY_CAP_YEARS),
 });
 
 export const GovernedOfferSheetReservationZ = z.strictObject({
   season: NonEmptyStringZ,
-  amount: z.number().finite().nonnegative(),
+  amount: z.number().nonnegative(),
 });
 
 export const GovernedOfferSheetTeamSalaryReferenceZ = z.strictObject({
   ledgerKind: z.literal('team-salary'),
   asOfDate: ZonedInstantZ,
   salaryCap: MoneyZ,
-  totalBeforeOfferSheet: z.number().finite().nonnegative(),
+  totalBeforeOfferSheet: z.number().nonnegative(),
   teamStateReference: NonEmptyStringZ,
   canonLeafIds: z.array(NonEmptyStringZ).min(1),
 });

--- a/src/schemas/governedOfferSheet.ts
+++ b/src/schemas/governedOfferSheet.ts
@@ -216,40 +216,60 @@ export const GovernedOfferSheetLifecycleEventZ = z.discriminatedUnion(
   ]
 );
 
-export const GovernedOfferSheetLifecycleZ = z.strictObject({
-  payloadVersion: z.literal(1),
-  ledgerId: NonEmptyStringZ,
-  ledgerVersion: PositiveVersionZ,
-  worldId: NonEmptyStringZ,
-  playerId: NonEmptyStringZ,
-  homeTeamId: NonEmptyStringZ,
-  offeringTeamId: NonEmptyStringZ,
-  salaryCapYear: z.number().int(),
-  status: z.enum(['pending-match', 'matched', 'declined']),
-  evidenceReference: z.strictObject({
-    evidenceId: NonEmptyStringZ,
-    evidenceRecordVersion: PositiveVersionZ,
-  }),
-  evidenceSnapshot: GovernedOfferSheetEvidenceZ,
-  rightsReference: z.strictObject({
+export const GovernedOfferSheetLifecycleZ = z
+  .strictObject({
+    payloadVersion: z.literal(1),
     ledgerId: NonEmptyStringZ,
     ledgerVersion: PositiveVersionZ,
-    stateId: NonEmptyStringZ,
-    stateVersion: PositiveVersionZ,
-  }),
-  reservations: z.strictObject({
-    offeringTeam: z.array(GovernedOfferSheetReservationZ).min(1),
-    offeringTeamSalaryReference: GovernedOfferSheetTeamSalaryReferenceZ,
-    homeTeamAuthority: z.enum(['room', 'exception']),
-    arenasApplies: z.boolean(),
-    offeringTeamAccounting: z.enum([
-      'stated-schedule',
-      'average-annual-salary',
-    ]),
-    homeTeamAccounting: z.enum(['stated-schedule', 'average-annual-salary']),
-  }),
-  events: z.array(GovernedOfferSheetLifecycleEventZ).min(1),
-});
+    worldId: NonEmptyStringZ,
+    playerId: NonEmptyStringZ,
+    homeTeamId: NonEmptyStringZ,
+    offeringTeamId: NonEmptyStringZ,
+    salaryCapYear: z.number().int(),
+    status: z.enum(['pending-match', 'matched', 'declined']),
+    evidenceReference: z.strictObject({
+      evidenceId: NonEmptyStringZ,
+      evidenceRecordVersion: PositiveVersionZ,
+    }),
+    evidenceSnapshot: GovernedOfferSheetEvidenceZ,
+    rightsReference: z.strictObject({
+      ledgerId: NonEmptyStringZ,
+      ledgerVersion: PositiveVersionZ,
+      stateId: NonEmptyStringZ,
+      stateVersion: PositiveVersionZ,
+    }),
+    reservations: z.strictObject({
+      offeringTeam: z.array(GovernedOfferSheetReservationZ).min(1),
+      offeringTeamSalaryReference: GovernedOfferSheetTeamSalaryReferenceZ,
+      homeTeamAuthority: z.enum(['room', 'exception']),
+      arenasApplies: z.boolean(),
+      offeringTeamAccounting: z.enum([
+        'stated-schedule',
+        'average-annual-salary',
+      ]),
+      homeTeamAccounting: z.enum(['stated-schedule', 'average-annual-salary']),
+    }),
+    events: z.array(GovernedOfferSheetLifecycleEventZ).min(1),
+  })
+  .superRefine((lifecycle, context) => {
+    const evidence = lifecycle.evidenceSnapshot;
+    if (
+      lifecycle.worldId !== evidence.worldId ||
+      lifecycle.playerId !== evidence.playerId ||
+      lifecycle.homeTeamId !== evidence.homeTeamId ||
+      lifecycle.salaryCapYear !== evidence.salaryCapYear ||
+      lifecycle.evidenceReference.evidenceId !== evidence.evidenceId ||
+      lifecycle.evidenceReference.evidenceRecordVersion !==
+        evidence.evidenceRecordVersion
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['evidenceSnapshot'],
+        message:
+          'Lifecycle identity and evidence reference must match the immutable evidence snapshot.',
+      });
+    }
+  });
 
 export type GovernedOfferSheetEvidence = z.infer<
   typeof GovernedOfferSheetEvidenceZ

--- a/src/schemas/governedOfferSheet.ts
+++ b/src/schemas/governedOfferSheet.ts
@@ -5,7 +5,15 @@ import { z } from 'zod';
 const NonEmptyStringZ = z.string().refine((value) => value.trim().length > 0, {
   message: 'must contain at least one non-whitespace character',
 });
-const MoneyZ = z.number().int().nonnegative();
+// Governed money records use dollars with at most cent precision, including
+// Arenas maximums and derived Average Annual Salary amounts.
+const MoneyZ = z
+  .number()
+  .finite()
+  .nonnegative()
+  .refine((value) => Math.abs(value * 100 - Math.round(value * 100)) < 1e-6, {
+    message: 'must use at most cent precision',
+  });
 const PositiveVersionZ = z.number().int().min(1);
 const ZonedInstantZ = z.string().datetime({ offset: true });
 const Sha256Z = z.string().regex(/^sha256:[0-9a-f]{64}$/);

--- a/src/schemas/governedOfferSheet.ts
+++ b/src/schemas/governedOfferSheet.ts
@@ -17,6 +17,7 @@ const MoneyZ = z
 const PositiveVersionZ = z.number().int().min(1);
 const ZonedInstantZ = z.string().datetime({ offset: true });
 const Sha256Z = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+const StateDigestZ = z.string().regex(/^fnv1a64:[0-9a-f]{16}$/);
 
 export const GovernedOfferSheetSourceZ = z.strictObject({
   provider: NonEmptyStringZ,
@@ -274,6 +275,24 @@ export const GovernedOfferSheetLifecycleZ = z
     }
   });
 
+/**
+ * Client-created once, then immutable under Firestore rules. This anchor binds
+ * the complete pending lifecycle (including evidence, proposal, reservations,
+ * and root event) so writable Team mirrors cannot rewrite it before resolution.
+ */
+export const GovernedOfferSheetAuthorizationZ = z.strictObject({
+  authorizationVersion: z.literal(1),
+  worldId: NonEmptyStringZ,
+  offerSheetId: NonEmptyStringZ,
+  dedupKey: NonEmptyStringZ,
+  playerId: NonEmptyStringZ,
+  homeTeamId: NonEmptyStringZ,
+  offeringTeamId: NonEmptyStringZ,
+  salaryCapYear: z.number().int(),
+  pendingLifecycleDigest: StateDigestZ,
+  immutableEvidenceDigest: StateDigestZ,
+});
+
 export type GovernedOfferSheetEvidence = z.infer<
   typeof GovernedOfferSheetEvidenceZ
 >;
@@ -291,4 +310,7 @@ export type GovernedOfferSheetTeamSalaryReference = z.infer<
 >;
 export type GovernedOfferSheetLifecycle = z.infer<
   typeof GovernedOfferSheetLifecycleZ
+>;
+export type GovernedOfferSheetAuthorization = z.infer<
+  typeof GovernedOfferSheetAuthorizationZ
 >;

--- a/src/schemas/governedOfferSheet.ts
+++ b/src/schemas/governedOfferSheet.ts
@@ -27,19 +27,34 @@ export const GovernedQualifyingOfferZ = z.strictObject({
   amount: MoneyZ,
   deliveredAt: ZonedInstantZ,
   openThrough: ZonedInstantZ,
+  extensionDocumentId: NonEmptyStringZ.nullable(),
   withdrawnAt: ZonedInstantZ.nullable(),
   withdrawalConsentAt: ZonedInstantZ.nullable(),
+  withdrawalConsentDocumentId: NonEmptyStringZ.nullable(),
   contractYears: z.number().int().positive(),
   annualRaiseBasisPoints: z.number().int().nonnegative(),
+  annualBaseSchedule: z.array(MoneyZ).min(1).max(5),
   fullyProtected: z.boolean(),
   requiredTermsPresent: z.boolean(),
   hasOptionOrEto: z.boolean(),
+  requiredOfferSheetGuaranteedSeasons: z.number().int().positive(),
   calculation: z.strictObject({
-    basis: z.enum(['draft-slot', 'prior-salary', 'starter-criteria', 'two-way']),
+    basis: z.enum([
+      'draft-slot',
+      'prior-salary',
+      'starter-criteria',
+      'two-way',
+    ]),
     certifiedAmount: MoneyZ,
     inputSourceIds: z.array(NonEmptyStringZ).min(1),
+    calculationYear: z.number().int(),
+    draftSlot: z.number().int().positive().nullable(),
     draftSlotAmount: MoneyZ.nullable(),
     priorSalary: MoneyZ.nullable(),
+    officialStarts: z.number().int().nonnegative().nullable(),
+    officialMinutes: z.number().int().nonnegative().nullable(),
+    starterStartsThreshold: z.number().int().nonnegative().nullable(),
+    starterMinutesThreshold: z.number().int().nonnegative().nullable(),
     starterCriteriaAmount: MoneyZ.nullable(),
     twoWayQualifyingAmount: MoneyZ.nullable(),
   }),
@@ -69,10 +84,30 @@ export const GovernedOfferSheetEvidenceZ = z.strictObject({
     otherPlayerEligible: z.boolean(),
   }),
   qualifyingOffer: GovernedQualifyingOfferZ,
+  homeTeamMatchingAuthority: z.strictObject({
+    authorityId: NonEmptyStringZ,
+    authorityVersion: PositiveVersionZ,
+    kind: z.enum(['room', 'exception']),
+    amount: MoneyZ,
+    effectiveFrom: ZonedInstantZ,
+    effectiveThrough: ZonedInstantZ,
+    recordStatus: z.enum(['current', 'superseded']),
+    source: GovernedOfferSheetSourceZ,
+  }),
   league: z.strictObject({
     salaryCap: MoneyZ,
     nonTaxpayerMle: MoneyZ,
     maximumSalary: MoneyZ,
+    maximumSalaryBySeason: z
+      .array(
+        z.strictObject({
+          season: NonEmptyStringZ,
+          amount: MoneyZ,
+        })
+      )
+      .min(1),
+    arenasYearOneMaximum: MoneyZ,
+    arenasYearTwoMaximum: MoneyZ,
     source: GovernedOfferSheetSourceZ,
   }),
 });
@@ -98,6 +133,18 @@ export const GovernedOfferSheetAveragingElectionZ = z.strictObject({
   statementId: NonEmptyStringZ,
   deliveredToNbaAt: ZonedInstantZ,
   relayedToPlayersAssociationAt: ZonedInstantZ,
+});
+
+export const GovernedOfferSheetMatchRestrictionZ = z.strictObject({
+  restrictionVersion: z.literal(1),
+  lifecycleId: NonEmptyStringZ,
+  eventId: NonEmptyStringZ,
+  matchedAt: ZonedInstantZ,
+  restrictedUntil: ZonedInstantZ,
+  offeringTeamId: NonEmptyStringZ,
+  playerTradeConsentRequired: z.literal(true),
+  offeringTeamTradeBarred: z.literal(true),
+  signAndTradeBarred: z.literal(true),
 });
 
 export const GovernedOfferSheetProposalZ = z.strictObject({
@@ -148,6 +195,8 @@ export const GovernedOfferSheetLifecycleEventZ = z.discriminatedUnion(
       offeringTeamTradeBarred: z.literal(true),
       signAndTradeBarred: z.literal(true),
       averagingElection: GovernedOfferSheetAveragingElectionZ.nullable(),
+      matchingTeamSalaryReference:
+        GovernedOfferSheetTeamSalaryReferenceZ.nullable(),
     }),
     z.strictObject({
       eventKind: z.literal('offer-sheet-declined'),
@@ -183,9 +232,12 @@ export const GovernedOfferSheetLifecycleZ = z.strictObject({
   reservations: z.strictObject({
     offeringTeam: z.array(GovernedOfferSheetReservationZ).min(1),
     offeringTeamSalaryReference: GovernedOfferSheetTeamSalaryReferenceZ,
-    homeTeamAuthority: z.enum(['room', 'right-of-first-refusal']),
+    homeTeamAuthority: z.enum(['room', 'exception']),
     arenasApplies: z.boolean(),
-    offeringTeamAccounting: z.enum(['stated-schedule', 'average-annual-salary']),
+    offeringTeamAccounting: z.enum([
+      'stated-schedule',
+      'average-annual-salary',
+    ]),
     homeTeamAccounting: z.enum(['stated-schedule', 'average-annual-salary']),
   }),
   events: z.array(GovernedOfferSheetLifecycleEventZ).min(1),
@@ -199,6 +251,12 @@ export type GovernedOfferSheetProposal = z.infer<
 >;
 export type GovernedOfferSheetAveragingElection = z.infer<
   typeof GovernedOfferSheetAveragingElectionZ
+>;
+export type GovernedOfferSheetMatchRestriction = z.infer<
+  typeof GovernedOfferSheetMatchRestrictionZ
+>;
+export type GovernedOfferSheetTeamSalaryReference = z.infer<
+  typeof GovernedOfferSheetTeamSalaryReferenceZ
 >;
 export type GovernedOfferSheetLifecycle = z.infer<
   typeof GovernedOfferSheetLifecycleZ

--- a/src/schemas/governedOfferSheet.ts
+++ b/src/schemas/governedOfferSheet.ts
@@ -1,0 +1,205 @@
+/** Strict authority, proposal, and lifecycle contracts for RFA Offer Sheets. */
+
+import { z } from 'zod';
+
+const NonEmptyStringZ = z.string().refine((value) => value.trim().length > 0, {
+  message: 'must contain at least one non-whitespace character',
+});
+const MoneyZ = z.number().int().nonnegative();
+const PositiveVersionZ = z.number().int().min(1);
+const ZonedInstantZ = z.string().datetime({ offset: true });
+const Sha256Z = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+
+export const GovernedOfferSheetSourceZ = z.strictObject({
+  provider: NonEmptyStringZ,
+  retainedArtifactPath: NonEmptyStringZ,
+  artifactSha256: Sha256Z,
+  artifactBytes: z.number().int().positive(),
+  retrievedAt: ZonedInstantZ,
+  recordVersion: PositiveVersionZ,
+  recordStatus: z.enum(['current', 'superseded']),
+});
+
+export const GovernedQualifyingOfferZ = z.strictObject({
+  offerId: NonEmptyStringZ,
+  offerVersion: PositiveVersionZ,
+  branch: z.enum(['standard', 'maximum', 'two-way']),
+  amount: MoneyZ,
+  deliveredAt: ZonedInstantZ,
+  openThrough: ZonedInstantZ,
+  withdrawnAt: ZonedInstantZ.nullable(),
+  withdrawalConsentAt: ZonedInstantZ.nullable(),
+  contractYears: z.number().int().positive(),
+  annualRaiseBasisPoints: z.number().int().nonnegative(),
+  fullyProtected: z.boolean(),
+  requiredTermsPresent: z.boolean(),
+  hasOptionOrEto: z.boolean(),
+  calculation: z.strictObject({
+    basis: z.enum(['draft-slot', 'prior-salary', 'starter-criteria', 'two-way']),
+    certifiedAmount: MoneyZ,
+    inputSourceIds: z.array(NonEmptyStringZ).min(1),
+    draftSlotAmount: MoneyZ.nullable(),
+    priorSalary: MoneyZ.nullable(),
+    starterCriteriaAmount: MoneyZ.nullable(),
+    twoWayQualifyingAmount: MoneyZ.nullable(),
+  }),
+  recordStatus: z.enum(['current', 'superseded']),
+  source: GovernedOfferSheetSourceZ,
+});
+
+export const GovernedOfferSheetEvidenceZ = z.strictObject({
+  evidenceVersion: z.literal(1),
+  evidenceId: NonEmptyStringZ,
+  evidenceRecordVersion: PositiveVersionZ,
+  status: z.enum(['known', 'unknown', 'conflicting']),
+  worldId: NonEmptyStringZ,
+  homeTeamId: NonEmptyStringZ,
+  playerId: NonEmptyStringZ,
+  salaryCapYear: z.number().int(),
+  observedAt: ZonedInstantZ,
+  eligibility: z.strictObject({
+    category: z.enum([
+      'first-round-year-four',
+      'qualifying-two-way',
+      'three-or-fewer-yos',
+    ]),
+    yearsOfService: z.number().int().nonnegative(),
+    firstRoundRookieScaleYearFourCompleted: z.boolean(),
+    qualifyingTwoWayService: z.boolean(),
+    otherPlayerEligible: z.boolean(),
+  }),
+  qualifyingOffer: GovernedQualifyingOfferZ,
+  league: z.strictObject({
+    salaryCap: MoneyZ,
+    nonTaxpayerMle: MoneyZ,
+    maximumSalary: MoneyZ,
+    source: GovernedOfferSheetSourceZ,
+  }),
+});
+
+export const GovernedOfferSheetBonusZ = z.strictObject({
+  bonusId: NonEmptyStringZ,
+  classification: z.enum(['likely', 'unlikely']),
+  amount: MoneyZ,
+});
+
+export const GovernedOfferSheetSalaryZ = z.strictObject({
+  season: NonEmptyStringZ,
+  salaryExcludingIncentive: MoneyZ,
+  regularSalary: MoneyZ,
+  bonuses: z.array(GovernedOfferSheetBonusZ),
+  guaranteedForLackOfSkill: z.boolean(),
+  guaranteedForInjuryOrIllness: z.boolean(),
+  individuallyNegotiatedProtectionConditions: z.boolean(),
+  option: z.enum(['PO', 'TO', 'ETO']).nullable(),
+});
+
+export const GovernedOfferSheetAveragingElectionZ = z.strictObject({
+  statementId: NonEmptyStringZ,
+  deliveredToNbaAt: ZonedInstantZ,
+  relayedToPlayersAssociationAt: ZonedInstantZ,
+});
+
+export const GovernedOfferSheetProposalZ = z.strictObject({
+  proposalVersion: z.literal(1),
+  signedAt: ZonedInstantZ,
+  receivedAt: ZonedInstantZ,
+  principalTermsDocumentId: NonEmptyStringZ,
+  noticeDocumentId: NonEmptyStringZ,
+  salariesByYear: z.array(GovernedOfferSheetSalaryZ).min(1).max(4),
+});
+
+export const GovernedOfferSheetReservationZ = z.strictObject({
+  season: NonEmptyStringZ,
+  amount: z.number().finite().nonnegative(),
+});
+
+export const GovernedOfferSheetTeamSalaryReferenceZ = z.strictObject({
+  ledgerKind: z.literal('team-salary'),
+  asOfDate: ZonedInstantZ,
+  salaryCap: MoneyZ,
+  totalBeforeOfferSheet: z.number().finite().nonnegative(),
+  teamStateReference: NonEmptyStringZ,
+  canonLeafIds: z.array(NonEmptyStringZ).min(1),
+});
+
+export const GovernedOfferSheetLifecycleEventZ = z.discriminatedUnion(
+  'eventKind',
+  [
+    z.strictObject({
+      eventKind: z.literal('offer-sheet-signed'),
+      eventId: NonEmptyStringZ,
+      eventVersion: PositiveVersionZ,
+      executedAt: ZonedInstantZ,
+      recordedAt: ZonedInstantZ,
+      qualifyingOfferId: NonEmptyStringZ,
+      qualifyingOfferVersion: PositiveVersionZ,
+      exerciseNoticeDeadline: ZonedInstantZ,
+      proposal: GovernedOfferSheetProposalZ,
+    }),
+    z.strictObject({
+      eventKind: z.literal('offer-sheet-matched'),
+      eventId: NonEmptyStringZ,
+      eventVersion: PositiveVersionZ,
+      executedAt: ZonedInstantZ,
+      recordedAt: ZonedInstantZ,
+      restrictionsUntil: ZonedInstantZ,
+      playerTradeConsentRequired: z.literal(true),
+      offeringTeamTradeBarred: z.literal(true),
+      signAndTradeBarred: z.literal(true),
+      averagingElection: GovernedOfferSheetAveragingElectionZ.nullable(),
+    }),
+    z.strictObject({
+      eventKind: z.literal('offer-sheet-declined'),
+      eventId: NonEmptyStringZ,
+      eventVersion: PositiveVersionZ,
+      executedAt: ZonedInstantZ,
+      recordedAt: ZonedInstantZ,
+    }),
+  ]
+);
+
+export const GovernedOfferSheetLifecycleZ = z.strictObject({
+  payloadVersion: z.literal(1),
+  ledgerId: NonEmptyStringZ,
+  ledgerVersion: PositiveVersionZ,
+  worldId: NonEmptyStringZ,
+  playerId: NonEmptyStringZ,
+  homeTeamId: NonEmptyStringZ,
+  offeringTeamId: NonEmptyStringZ,
+  salaryCapYear: z.number().int(),
+  status: z.enum(['pending-match', 'matched', 'declined']),
+  evidenceReference: z.strictObject({
+    evidenceId: NonEmptyStringZ,
+    evidenceRecordVersion: PositiveVersionZ,
+  }),
+  evidenceSnapshot: GovernedOfferSheetEvidenceZ,
+  rightsReference: z.strictObject({
+    ledgerId: NonEmptyStringZ,
+    ledgerVersion: PositiveVersionZ,
+    stateId: NonEmptyStringZ,
+    stateVersion: PositiveVersionZ,
+  }),
+  reservations: z.strictObject({
+    offeringTeam: z.array(GovernedOfferSheetReservationZ).min(1),
+    offeringTeamSalaryReference: GovernedOfferSheetTeamSalaryReferenceZ,
+    homeTeamAuthority: z.enum(['room', 'right-of-first-refusal']),
+    arenasApplies: z.boolean(),
+    offeringTeamAccounting: z.enum(['stated-schedule', 'average-annual-salary']),
+    homeTeamAccounting: z.enum(['stated-schedule', 'average-annual-salary']),
+  }),
+  events: z.array(GovernedOfferSheetLifecycleEventZ).min(1),
+});
+
+export type GovernedOfferSheetEvidence = z.infer<
+  typeof GovernedOfferSheetEvidenceZ
+>;
+export type GovernedOfferSheetProposal = z.infer<
+  typeof GovernedOfferSheetProposalZ
+>;
+export type GovernedOfferSheetAveragingElection = z.infer<
+  typeof GovernedOfferSheetAveragingElectionZ
+>;
+export type GovernedOfferSheetLifecycle = z.infer<
+  typeof GovernedOfferSheetLifecycleZ
+>;

--- a/src/shared/components/EditContractModal.DetailsForm.tsx
+++ b/src/shared/components/EditContractModal.DetailsForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { formatCurrencyFull } from '@/shared/utils/formatting';
 import { TeamSelectDropdown } from '@/shared/components/TeamSelectDropdown';
-import { GovernedOfferSheetNoticeForm } from './EditContractModal.OfferSheetNoticeForm';
+import { GovernedOfferSheetNoticeForm } from '@/shared/components/EditContractModal.OfferSheetNoticeForm';
 import type { GovernedExtensionAvailability } from '@/features/architect/utils/extensions';
 import type {
   SelectedContractAction,
@@ -32,7 +32,9 @@ type ContractDetailsFormProps = {
   isOfferSheet: boolean;
   setIsOfferSheet: (v: boolean) => void;
   offerSheetTiming: OfferSheetTimingLike;
-  setOfferSheetTiming: React.Dispatch<React.SetStateAction<OfferSheetTimingLike>>;
+  setOfferSheetTiming: React.Dispatch<
+    React.SetStateAction<OfferSheetTimingLike>
+  >;
   destinationTeamId: string | null;
   setDestinationTeamId: (id: string | null) => void;
   buyoutAmountInput: string;
@@ -96,7 +98,9 @@ export const ContractDetailsForm = ({
   onTermsChange,
 }: ContractDetailsFormProps) => (
   <>
-    {['signNew', 'resign', 'extend', 'signAndTrade'].includes(selectedAction) && (
+    {['signNew', 'resign', 'extend', 'signAndTrade'].includes(
+      selectedAction
+    ) && (
       <div className="bg-white/5 rounded-lg border border-white/20 p-4">
         <div className="flex items-center justify-between mb-4">
           <h4 className="font-semibold text-sm text-white flex items-center gap-2">
@@ -107,7 +111,11 @@ export const ContractDetailsForm = ({
             {selectedAction === 'extend' ? (
               <select
                 data-testid="governed-extension-route"
-                value={extension.route || extensionAvailability?.suggestedRoute || 'veteran'}
+                value={
+                  extension.route ||
+                  extensionAvailability?.suggestedRoute ||
+                  'veteran'
+                }
                 onChange={(e) => {
                   const route = e.target.value as ExtensionStateLike['route'];
                   setExtension({
@@ -115,11 +123,11 @@ export const ContractDetailsForm = ({
                     route,
                     conditionalHigherMaxPercentage:
                       route === 'rookie-scale'
-                        ? extension.conditionalHigherMaxPercentage ?? null
+                        ? (extension.conditionalHigherMaxPercentage ?? null)
                         : null,
                     agreedDesignatedVeteranPercentage:
                       route === 'designated-veteran'
-                        ? extension.agreedDesignatedVeteranPercentage ?? 30
+                        ? (extension.agreedDesignatedVeteranPercentage ?? 30)
                         : null,
                   });
                 }}
@@ -182,12 +190,13 @@ export const ContractDetailsForm = ({
                   isSigningAction && signingGuardrails?.maxYears
                     ? Math.min(signingGuardrails.maxYears, 5)
                     : null;
-                const maxYearsOption =
-                  selectedAction === 'extend' && extensionAvailability
+                const maxYearsOption = isOfferSheet
+                  ? 4
+                  : selectedAction === 'extend' && extensionAvailability
                     ? 5
                     : selectedAction === 'extend' && extMax?.maxYears
                       ? extMax.maxYears
-                    : guardrailYears || 5;
+                      : guardrailYears || 5;
                 const yrs = Math.min(Number(e.target.value), maxYearsOption);
                 const raisePct =
                   signingGuardrails?.raisePct ?? extension.raisePct ?? 0.05;
@@ -210,14 +219,15 @@ export const ContractDetailsForm = ({
               className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
             >
               {[1, 2, 3, 4, 5].map((yr) => {
-                const maxYearsOption =
-                  selectedAction === 'extend' && extensionAvailability
+                const maxYearsOption = isOfferSheet
+                  ? 4
+                  : selectedAction === 'extend' && extensionAvailability
                     ? 5
                     : selectedAction === 'extend' && extMax?.maxYears
                       ? extMax.maxYears
-                    : isSigningAction && signingGuardrails?.maxYears
-                      ? Math.min(signingGuardrails.maxYears, 5)
-                      : 5;
+                      : isSigningAction && signingGuardrails?.maxYears
+                        ? Math.min(signingGuardrails.maxYears, 5)
+                        : 5;
                 return (
                   <option key={yr} value={yr} disabled={yr > maxYearsOption}>
                     {yr}yr
@@ -331,8 +341,8 @@ export const ContractDetailsForm = ({
                 : 'Max'}
             </span>
             <span className="px-2 py-1 rounded bg-white/5 border border-white/10">
-              Raises up to {Math.round((signingGuardrails.raisePct || 0) * 100)}% •
-              Max {signingGuardrails.maxYears || '—'} yrs
+              Raises up to {Math.round((signingGuardrails.raisePct || 0) * 100)}
+              % • Max {signingGuardrails.maxYears || '—'} yrs
             </span>
             {playerRulesProfile?.restrictedFreeAgency?.qualifyingOfferAmount ? (
               <span className="px-2 py-1 rounded bg-red-500/10 border border-red-500/20 text-red-100">
@@ -366,8 +376,9 @@ export const ContractDetailsForm = ({
           {Array.from({ length: 5 }, (_, idx) => {
             const isActive = idx < extension.years;
             const year =
-              (selectedAction === 'extend' ? extensionStartYear : CURRENT_YEAR) +
-              idx;
+              (selectedAction === 'extend'
+                ? extensionStartYear
+                : CURRENT_YEAR) + idx;
             return (
               <div
                 key={idx}
@@ -413,7 +424,9 @@ export const ContractDetailsForm = ({
                         ...prev,
                         salaries: nextSalaries,
                       }));
-                      setSalaryInputs(toSalaryInputs(nextSalaries, activeYears));
+                      setSalaryInputs(
+                        toSalaryInputs(nextSalaries, activeYears)
+                      );
                     }}
                     className="w-full pl-5 pr-2 py-2 rounded bg-black/50 border border-white/10 text-xs text-white font-medium text-center focus:border-cyan-500 focus:bg-cyan-500/10 outline-none disabled:opacity-50 disabled:cursor-not-allowed"
                   />
@@ -490,7 +503,10 @@ export const ContractDetailsForm = ({
           Resulting dead cap:{' '}
           <span className="text-white">
             {formatCurrencyFull(
-              Math.max(0, remainingGuaranteedForBuyout - (parsedBuyoutAmount || 0))
+              Math.max(
+                0,
+                remainingGuaranteedForBuyout - (parsedBuyoutAmount || 0)
+              )
             )}
           </span>
         </div>

--- a/src/shared/components/EditContractModal.DetailsForm.tsx
+++ b/src/shared/components/EditContractModal.DetailsForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { formatCurrencyFull } from '@/shared/utils/formatting';
 import { TeamSelectDropdown } from '@/shared/components/TeamSelectDropdown';
+import { GovernedOfferSheetNoticeForm } from './EditContractModal.OfferSheetNoticeForm';
 import type { GovernedExtensionAvailability } from '@/features/architect/utils/extensions';
 import type {
   SelectedContractAction,
@@ -8,6 +9,7 @@ import type {
   ExtMaxState,
   PlayerRulesProfileLike,
   SigningExceptionOption,
+  OfferSheetTimingLike,
 } from './EditContractModal.types';
 
 type SigningGuardrailsLike = {
@@ -29,6 +31,8 @@ type ContractDetailsFormProps = {
   setSelectedException: (e: string) => void;
   isOfferSheet: boolean;
   setIsOfferSheet: (v: boolean) => void;
+  offerSheetTiming: OfferSheetTimingLike;
+  setOfferSheetTiming: React.Dispatch<React.SetStateAction<OfferSheetTimingLike>>;
   destinationTeamId: string | null;
   setDestinationTeamId: (id: string | null) => void;
   buyoutAmountInput: string;
@@ -67,6 +71,8 @@ export const ContractDetailsForm = ({
   setSelectedException,
   isOfferSheet,
   setIsOfferSheet,
+  offerSheetTiming,
+  setOfferSheetTiming,
   destinationTeamId,
   setDestinationTeamId,
   buyoutAmountInput,
@@ -299,6 +305,14 @@ export const ContractDetailsForm = ({
               </label>
             )}
           </div>
+        )}
+
+        {isOfferSheet && (
+          <GovernedOfferSheetNoticeForm
+            value={offerSheetTiming}
+            onChange={setOfferSheetTiming}
+            onTermsChange={onTermsChange}
+          />
         )}
 
         {isSigningAction && signingGuardrails && (

--- a/src/shared/components/EditContractModal.DetailsForm.tsx
+++ b/src/shared/components/EditContractModal.DetailsForm.tsx
@@ -3,6 +3,7 @@ import { formatCurrencyFull } from '@/shared/utils/formatting';
 import { TeamSelectDropdown } from '@/shared/components/TeamSelectDropdown';
 import { GovernedOfferSheetNoticeForm } from '@/shared/components/EditContractModal.OfferSheetNoticeForm';
 import type { GovernedExtensionAvailability } from '@/features/architect/utils/extensions';
+import { MAX_OFFER_SHEET_SALARY_CAP_YEARS } from '@/schemas/governedOfferSheet';
 import type {
   SelectedContractAction,
   ExtensionStateLike,
@@ -96,427 +97,428 @@ export const ContractDetailsForm = ({
   buildSalarySeries,
   toSalaryInputs,
   onTermsChange,
-}: ContractDetailsFormProps) => (
-  <>
-    {['signNew', 'resign', 'extend', 'signAndTrade'].includes(
-      selectedAction
-    ) && (
-      <div className="bg-white/5 rounded-lg border border-white/20 p-4">
-        <div className="flex items-center justify-between mb-4">
-          <h4 className="font-semibold text-sm text-white flex items-center gap-2">
-            <span className="w-1 h-4 bg-orange-500 rounded-full"></span>
-            New Contract Preview
-          </h4>
-          <div className="flex items-center gap-2">
-            {selectedAction === 'extend' ? (
+}: ContractDetailsFormProps) => {
+  const maxYearsOption = isOfferSheet
+    ? MAX_OFFER_SHEET_SALARY_CAP_YEARS
+    : selectedAction === 'extend' && extensionAvailability
+      ? 5
+      : selectedAction === 'extend' && extMax?.maxYears
+        ? extMax.maxYears
+        : isSigningAction && signingGuardrails?.maxYears
+          ? Math.min(signingGuardrails.maxYears, 5)
+          : 5;
+
+  return (
+    <>
+      {['signNew', 'resign', 'extend', 'signAndTrade'].includes(
+        selectedAction
+      ) && (
+        <div className="bg-white/5 rounded-lg border border-white/20 p-4">
+          <div className="flex items-center justify-between mb-4">
+            <h4 className="font-semibold text-sm text-white flex items-center gap-2">
+              <span className="w-1 h-4 bg-orange-500 rounded-full"></span>
+              New Contract Preview
+            </h4>
+            <div className="flex items-center gap-2">
+              {selectedAction === 'extend' ? (
+                <select
+                  data-testid="governed-extension-route"
+                  value={
+                    extension.route ||
+                    extensionAvailability?.suggestedRoute ||
+                    'veteran'
+                  }
+                  onChange={(e) => {
+                    const route = e.target.value as ExtensionStateLike['route'];
+                    setExtension({
+                      ...extension,
+                      route,
+                      conditionalHigherMaxPercentage:
+                        route === 'rookie-scale'
+                          ? (extension.conditionalHigherMaxPercentage ?? null)
+                          : null,
+                      agreedDesignatedVeteranPercentage:
+                        route === 'designated-veteran'
+                          ? (extension.agreedDesignatedVeteranPercentage ?? 30)
+                          : null,
+                    });
+                  }}
+                  disabled={!extensionAvailability}
+                  className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
+                >
+                  <option value="rookie-scale">Rookie Scale</option>
+                  <option value="veteran">Veteran</option>
+                  <option value="designated-veteran">Designated Veteran</option>
+                </select>
+              ) : (
+                <select
+                  value={extension.contractType}
+                  onChange={(e) =>
+                    setExtension({ ...extension, contractType: e.target.value })
+                  }
+                  className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
+                >
+                  <option value="Standard">Standard</option>
+                  <option value="Rookie Scale">Rookie Scale</option>
+                  <option value="Designated veteran">Designated Veteran</option>
+                </select>
+              )}
+
+              {['signNew', 'resign'].includes(selectedAction) && (
+                <select
+                  value={selectedException}
+                  onChange={(e) => setSelectedException(e.target.value)}
+                  className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
+                >
+                  {availableSigningExceptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+
+              {selectedAction === 'signNew' && resolvedShowOfferSheetToggle && (
+                <label className="flex items-center gap-1.5 cursor-pointer ml-2 bg-black px-2 py-1 rounded border border-white/20 select-none">
+                  <input
+                    type="checkbox"
+                    checked={isOfferSheet}
+                    onChange={(e) => setIsOfferSheet(e.target.checked)}
+                    className="accent-cyan-500"
+                  />
+                  <span
+                    className={`text-xs font-bold ${isOfferSheet ? 'text-cyan-400' : 'text-white/50'}`}
+                  >
+                    Offer Sheet
+                  </span>
+                </label>
+              )}
+
               <select
-                data-testid="governed-extension-route"
-                value={
-                  extension.route ||
-                  extensionAvailability?.suggestedRoute ||
-                  'veteran'
-                }
+                data-testid="contract-years"
+                value={extension.years}
                 onChange={(e) => {
-                  const route = e.target.value as ExtensionStateLike['route'];
+                  const yrs = Math.min(Number(e.target.value), maxYearsOption);
+                  const raisePct =
+                    signingGuardrails?.raisePct ?? extension.raisePct ?? 0.05;
+                  const firstYear = isSigningAction
+                    ? clampFirstYearToGuardrails(
+                        extension.salaries?.[0] ??
+                          signingGuardrails?.minFirstYear ??
+                          0
+                      )
+                    : extension.salaries?.[0] || 0;
+                  const salaries = isSigningAction
+                    ? buildSalarySeries(firstYear, yrs, raisePct)
+                    : Array.from(
+                        { length: yrs },
+                        (_, i) => extension.salaries[i] || 0
+                      );
                   setExtension({
                     ...extension,
-                    route,
-                    conditionalHigherMaxPercentage:
-                      route === 'rookie-scale'
-                        ? (extension.conditionalHigherMaxPercentage ?? null)
-                        : null,
-                    agreedDesignatedVeteranPercentage:
-                      route === 'designated-veteran'
-                        ? (extension.agreedDesignatedVeteranPercentage ?? 30)
-                        : null,
+                    years: yrs,
+                    salaries,
+                    raisePct,
                   });
+                  setSalaryInputs(toSalaryInputs(salaries, yrs));
                 }}
-                disabled={!extensionAvailability}
                 className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
               >
-                <option value="rookie-scale">Rookie Scale</option>
-                <option value="veteran">Veteran</option>
-                <option value="designated-veteran">Designated Veteran</option>
-              </select>
-            ) : (
-              <select
-                value={extension.contractType}
-                onChange={(e) =>
-                  setExtension({ ...extension, contractType: e.target.value })
-                }
-                className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
-              >
-                <option value="Standard">Standard</option>
-                <option value="Rookie Scale">Rookie Scale</option>
-                <option value="Designated veteran">Designated Veteran</option>
-              </select>
-            )}
-
-            {['signNew', 'resign'].includes(selectedAction) && (
-              <select
-                value={selectedException}
-                onChange={(e) => setSelectedException(e.target.value)}
-                className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
-              >
-                {availableSigningExceptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            )}
-
-            {selectedAction === 'signNew' && resolvedShowOfferSheetToggle && (
-              <label className="flex items-center gap-1.5 cursor-pointer ml-2 bg-black px-2 py-1 rounded border border-white/20 select-none">
-                <input
-                  type="checkbox"
-                  checked={isOfferSheet}
-                  onChange={(e) => setIsOfferSheet(e.target.checked)}
-                  className="accent-cyan-500"
-                />
-                <span
-                  className={`text-xs font-bold ${isOfferSheet ? 'text-cyan-400' : 'text-white/50'}`}
-                >
-                  Offer Sheet
-                </span>
-              </label>
-            )}
-
-            <select
-              data-testid="contract-years"
-              value={extension.years}
-              onChange={(e) => {
-                const guardrailYears =
-                  isSigningAction && signingGuardrails?.maxYears
-                    ? Math.min(signingGuardrails.maxYears, 5)
-                    : null;
-                const maxYearsOption = isOfferSheet
-                  ? 4
-                  : selectedAction === 'extend' && extensionAvailability
-                    ? 5
-                    : selectedAction === 'extend' && extMax?.maxYears
-                      ? extMax.maxYears
-                      : guardrailYears || 5;
-                const yrs = Math.min(Number(e.target.value), maxYearsOption);
-                const raisePct =
-                  signingGuardrails?.raisePct ?? extension.raisePct ?? 0.05;
-                const firstYear = isSigningAction
-                  ? clampFirstYearToGuardrails(
-                      extension.salaries?.[0] ??
-                        signingGuardrails?.minFirstYear ??
-                        0
-                    )
-                  : extension.salaries?.[0] || 0;
-                const salaries = isSigningAction
-                  ? buildSalarySeries(firstYear, yrs, raisePct)
-                  : Array.from(
-                      { length: yrs },
-                      (_, i) => extension.salaries[i] || 0
-                    );
-                setExtension({ ...extension, years: yrs, salaries, raisePct });
-                setSalaryInputs(toSalaryInputs(salaries, yrs));
-              }}
-              className="px-2 py-1 rounded bg-black border border-white/20 text-xs text-white focus:border-orange-500 outline-none"
-            >
-              {[1, 2, 3, 4, 5].map((yr) => {
-                const maxYearsOption = isOfferSheet
-                  ? 4
-                  : selectedAction === 'extend' && extensionAvailability
-                    ? 5
-                    : selectedAction === 'extend' && extMax?.maxYears
-                      ? extMax.maxYears
-                      : isSigningAction && signingGuardrails?.maxYears
-                        ? Math.min(signingGuardrails.maxYears, 5)
-                        : 5;
-                return (
+                {[1, 2, 3, 4, 5].map((yr) => (
                   <option key={yr} value={yr} disabled={yr > maxYearsOption}>
                     {yr}yr
                   </option>
-                );
-              })}
-            </select>
+                ))}
+              </select>
+            </div>
           </div>
-        </div>
 
-        {selectedAction === 'extend' && extensionAvailability && (
-          <div className="mb-4 grid gap-3 md:grid-cols-2">
-            <label className="text-xs text-white/70">
-              Exact signature time
-              <input
-                data-testid="governed-extension-signed-at"
-                value={extension.signedAt || ''}
-                onChange={(event) => {
-                  onTermsChange();
-                  setExtension({ ...extension, signedAt: event.target.value });
-                }}
-                placeholder="2026-10-19T18:00:00-04:00"
-                className="mt-1 w-full rounded border border-white/15 bg-black/35 px-3 py-2 text-xs text-white outline-none focus:border-orange-400/50"
-              />
-              <span className="mt-1 block text-[10px] text-white/45">
-                Include the UTC offset. No signing time is inferred.
-              </span>
-            </label>
-            {(extension.route || extensionAvailability.suggestedRoute) ===
-              'rookie-scale' && (
+          {selectedAction === 'extend' && extensionAvailability && (
+            <div className="mb-4 grid gap-3 md:grid-cols-2">
               <label className="text-xs text-white/70">
-                Conditional Higher Max percentage
+                Exact signature time
                 <input
-                  data-testid="governed-extension-higher-max-percentage"
-                  type="number"
-                  min="25"
-                  max="30"
-                  step="0.0001"
-                  value={extension.conditionalHigherMaxPercentage ?? ''}
+                  data-testid="governed-extension-signed-at"
+                  value={extension.signedAt || ''}
                   onChange={(event) => {
                     onTermsChange();
                     setExtension({
                       ...extension,
-                      conditionalHigherMaxPercentage:
-                        event.target.value === ''
-                          ? null
-                          : Number(event.target.value),
+                      signedAt: event.target.value,
                     });
                   }}
-                  placeholder="Optional"
+                  placeholder="2026-10-19T18:00:00-04:00"
                   className="mt-1 w-full rounded border border-white/15 bg-black/35 px-3 py-2 text-xs text-white outline-none focus:border-orange-400/50"
                 />
                 <span className="mt-1 block text-[10px] text-white/45">
-                  Optional 25% through 30% clause; qualification remains pending
-                  until the required award information resolves it.
+                  Include the UTC offset. No signing time is inferred.
                 </span>
               </label>
-            )}
-            {(extension.route || extensionAvailability.suggestedRoute) ===
-              'designated-veteran' && (
-              <label className="text-xs text-white/70">
-                Agreed cap percentage
-                <input
-                  data-testid="governed-extension-dv-percentage"
-                  type="number"
-                  min="30"
-                  max="35"
-                  step="0.0001"
-                  value={extension.agreedDesignatedVeteranPercentage ?? ''}
-                  onChange={(event) => {
-                    onTermsChange();
-                    setExtension({
-                      ...extension,
-                      agreedDesignatedVeteranPercentage:
-                        event.target.value === ''
-                          ? null
-                          : Number(event.target.value),
-                    });
-                  }}
-                  className="mt-1 w-full rounded border border-white/15 bg-black/35 px-3 py-2 text-xs text-white outline-none focus:border-orange-400/50"
-                />
-                <span className="mt-1 block text-[10px] text-white/45">
-                  Must be 30% through 35% of the first extended Season cap.
-                </span>
-              </label>
-            )}
-          </div>
-        )}
-
-        {isOfferSheet && (
-          <GovernedOfferSheetNoticeForm
-            value={offerSheetTiming}
-            onChange={setOfferSheetTiming}
-            onTermsChange={onTermsChange}
-          />
-        )}
-
-        {isSigningAction && signingGuardrails && (
-          <div className="mb-3 flex flex-wrap gap-2 text-[11px] text-white/70">
-            <span className="px-2 py-1 rounded bg-white/5 border border-white/10">
-              Rights/Exception: {signingGuardrails.source}
-              {playerRulesProfile?.birdRights?.type
-                ? ` (${playerRulesProfile.birdRights.type})`
-                : ''}
-            </span>
-            <span className="px-2 py-1 rounded bg-white/5 border border-white/10">
-              First-year range:{' '}
-              {formatCurrencyFull(signingGuardrails.minFirstYear || 0)} -{' '}
-              {signingGuardrails.maxFirstYear != null
-                ? formatCurrencyFull(signingGuardrails.maxFirstYear)
-                : 'Max'}
-            </span>
-            <span className="px-2 py-1 rounded bg-white/5 border border-white/10">
-              Raises up to {Math.round((signingGuardrails.raisePct || 0) * 100)}
-              % • Max {signingGuardrails.maxYears || '—'} yrs
-            </span>
-            {playerRulesProfile?.restrictedFreeAgency?.qualifyingOfferAmount ? (
-              <span className="px-2 py-1 rounded bg-red-500/10 border border-red-500/20 text-red-100">
-                QO:{' '}
-                {formatCurrencyFull(
-                  playerRulesProfile.restrictedFreeAgency.qualifyingOfferAmount
-                )}
-              </span>
-            ) : null}
-          </div>
-        )}
-
-        {selectedAction === 'signAndTrade' && (
-          <div className="mb-4 p-4 bg-blue-500/10 border border-blue-500/30 rounded-lg">
-            <label className="block text-xs font-bold text-blue-200 uppercase tracking-wider mb-2">
-              Destination Team
-            </label>
-            <TeamSelectDropdown
-              selectedTeamId={destinationTeamId}
-              onChange={setDestinationTeamId}
-              valueFormat="teamCode"
-            />
-            <p className="mt-2 text-[11px] text-white/60">
-              The player will be signed to your team, then immediately traded to
-              this destination.
-            </p>
-          </div>
-        )}
-
-        <div className="grid grid-cols-5 gap-2 bg-white/5 rounded-lg p-3">
-          {Array.from({ length: 5 }, (_, idx) => {
-            const isActive = idx < extension.years;
-            const year =
-              (selectedAction === 'extend'
-                ? extensionStartYear
-                : CURRENT_YEAR) + idx;
-            return (
-              <div
-                key={idx}
-                className={`${isActive ? 'opacity-100' : 'opacity-30'}`}
-              >
-                <div className="text-[10px] text-white/50 text-center mb-1 font-medium">
-                  {year - 1}-{String(year % 100).padStart(2, '00')}
-                </div>
-                <div className="relative">
-                  <span className="absolute left-2 top-1/2 -translate-y-1/2 text-white/40 text-xs">
-                    $
-                  </span>
+              {(extension.route || extensionAvailability.suggestedRoute) ===
+                'rookie-scale' && (
+                <label className="text-xs text-white/70">
+                  Conditional Higher Max percentage
                   <input
-                    type="text"
-                    inputMode="decimal"
-                    placeholder="0"
-                    disabled={!isActive}
-                    value={salaryInputs[idx] || ''}
-                    onChange={(e) => {
+                    data-testid="governed-extension-higher-max-percentage"
+                    type="number"
+                    min="25"
+                    max="30"
+                    step="0.0001"
+                    value={extension.conditionalHigherMaxPercentage ?? ''}
+                    onChange={(event) => {
                       onTermsChange();
-                      const raw = e.target.value.replace(/[^0-9]/g, '');
-                      const parsed = Number(raw);
-                      const nextSalaries = (() => {
-                        const arr = [...extension.salaries];
-                        let nextVal = parsed;
-                        if (isSigningAction && signingGuardrails) {
-                          if (idx === 0) {
-                            nextVal = clampFirstYearToGuardrails(parsed);
-                          } else if (signingGuardrails.raisePct != null) {
-                            const prevSalary = arr[idx - 1] || 0;
-                            const allowed = Math.round(
-                              prevSalary * (1 + signingGuardrails.raisePct)
-                            );
-                            nextVal = Math.min(parsed || 0, allowed);
-                          }
-                        }
-                        arr[idx] = nextVal;
-                        return arr;
-                      })();
-                      const activeYears =
-                        extension.years || nextSalaries.length || 0;
-                      setExtension((prev) => ({
-                        ...prev,
-                        salaries: nextSalaries,
-                      }));
-                      setSalaryInputs(
-                        toSalaryInputs(nextSalaries, activeYears)
-                      );
+                      setExtension({
+                        ...extension,
+                        conditionalHigherMaxPercentage:
+                          event.target.value === ''
+                            ? null
+                            : Number(event.target.value),
+                      });
                     }}
-                    className="w-full pl-5 pr-2 py-2 rounded bg-black/50 border border-white/10 text-xs text-white font-medium text-center focus:border-cyan-500 focus:bg-cyan-500/10 outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                    placeholder="Optional"
+                    className="mt-1 w-full rounded border border-white/15 bg-black/35 px-3 py-2 text-xs text-white outline-none focus:border-orange-400/50"
                   />
-                </div>
-              </div>
-            );
-          })}
-        </div>
+                  <span className="mt-1 block text-[10px] text-white/45">
+                    Optional 25% through 30% clause; qualification remains
+                    pending until the required award information resolves it.
+                  </span>
+                </label>
+              )}
+              {(extension.route || extensionAvailability.suggestedRoute) ===
+                'designated-veteran' && (
+                <label className="text-xs text-white/70">
+                  Agreed cap percentage
+                  <input
+                    data-testid="governed-extension-dv-percentage"
+                    type="number"
+                    min="30"
+                    max="35"
+                    step="0.0001"
+                    value={extension.agreedDesignatedVeteranPercentage ?? ''}
+                    onChange={(event) => {
+                      onTermsChange();
+                      setExtension({
+                        ...extension,
+                        agreedDesignatedVeteranPercentage:
+                          event.target.value === ''
+                            ? null
+                            : Number(event.target.value),
+                      });
+                    }}
+                    className="mt-1 w-full rounded border border-white/15 bg-black/35 px-3 py-2 text-xs text-white outline-none focus:border-orange-400/50"
+                  />
+                  <span className="mt-1 block text-[10px] text-white/45">
+                    Must be 30% through 35% of the first extended Season cap.
+                  </span>
+                </label>
+              )}
+            </div>
+          )}
 
-        {selectedAction === 'extend' && (
-          <div className="mt-3 px-3 py-2 bg-orange-500/10 border border-orange-500/20 rounded text-xs text-orange-200 space-y-1">
-            {extensionAvailability ? (
-              <>
-                <div className="font-medium">
-                  {extensionAvailability.status === 'ready'
-                    ? 'Extension information ready'
-                    : extensionAvailability.status === 'incompatible'
-                      ? 'Extension unavailable'
-                      : 'Required contract information is missing'}
+          {isOfferSheet && (
+            <GovernedOfferSheetNoticeForm
+              value={offerSheetTiming}
+              onChange={setOfferSheetTiming}
+              onTermsChange={onTermsChange}
+            />
+          )}
+
+          {isSigningAction && signingGuardrails && (
+            <div className="mb-3 flex flex-wrap gap-2 text-[11px] text-white/70">
+              <span className="px-2 py-1 rounded bg-white/5 border border-white/10">
+                Rights/Exception: {signingGuardrails.source}
+                {playerRulesProfile?.birdRights?.type
+                  ? ` (${playerRulesProfile.birdRights.type})`
+                  : ''}
+              </span>
+              <span className="px-2 py-1 rounded bg-white/5 border border-white/10">
+                First-year range:{' '}
+                {formatCurrencyFull(signingGuardrails.minFirstYear || 0)} -{' '}
+                {signingGuardrails.maxFirstYear != null
+                  ? formatCurrencyFull(signingGuardrails.maxFirstYear)
+                  : 'Max'}
+              </span>
+              <span className="px-2 py-1 rounded bg-white/5 border border-white/10">
+                Raises up to{' '}
+                {Math.round((signingGuardrails.raisePct || 0) * 100)}% • Max{' '}
+                {signingGuardrails.maxYears || '—'} yrs
+              </span>
+              {playerRulesProfile?.restrictedFreeAgency
+                ?.qualifyingOfferAmount ? (
+                <span className="px-2 py-1 rounded bg-red-500/10 border border-red-500/20 text-red-100">
+                  QO:{' '}
+                  {formatCurrencyFull(
+                    playerRulesProfile.restrictedFreeAgency
+                      .qualifyingOfferAmount
+                  )}
+                </span>
+              ) : null}
+            </div>
+          )}
+
+          {selectedAction === 'signAndTrade' && (
+            <div className="mb-4 p-4 bg-blue-500/10 border border-blue-500/30 rounded-lg">
+              <label className="block text-xs font-bold text-blue-200 uppercase tracking-wider mb-2">
+                Destination Team
+              </label>
+              <TeamSelectDropdown
+                selectedTeamId={destinationTeamId}
+                onChange={setDestinationTeamId}
+                valueFormat="teamCode"
+              />
+              <p className="mt-2 text-[11px] text-white/60">
+                The player will be signed to your team, then immediately traded
+                to this destination.
+              </p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-5 gap-2 bg-white/5 rounded-lg p-3">
+            {Array.from({ length: 5 }, (_, idx) => {
+              const isActive = idx < extension.years;
+              const year =
+                (selectedAction === 'extend'
+                  ? extensionStartYear
+                  : CURRENT_YEAR) + idx;
+              return (
+                <div
+                  key={idx}
+                  className={`${isActive ? 'opacity-100' : 'opacity-30'}`}
+                >
+                  <div className="text-[10px] text-white/50 text-center mb-1 font-medium">
+                    {year - 1}-{String(year % 100).padStart(2, '00')}
+                  </div>
+                  <div className="relative">
+                    <span className="absolute left-2 top-1/2 -translate-y-1/2 text-white/40 text-xs">
+                      $
+                    </span>
+                    <input
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="0"
+                      disabled={!isActive}
+                      value={salaryInputs[idx] || ''}
+                      onChange={(e) => {
+                        onTermsChange();
+                        const raw = e.target.value.replace(/[^0-9]/g, '');
+                        const parsed = Number(raw);
+                        const nextSalaries = (() => {
+                          const arr = [...extension.salaries];
+                          let nextVal = parsed;
+                          if (isSigningAction && signingGuardrails) {
+                            if (idx === 0) {
+                              nextVal = clampFirstYearToGuardrails(parsed);
+                            } else if (signingGuardrails.raisePct != null) {
+                              const prevSalary = arr[idx - 1] || 0;
+                              const allowed = Math.round(
+                                prevSalary * (1 + signingGuardrails.raisePct)
+                              );
+                              nextVal = Math.min(parsed || 0, allowed);
+                            }
+                          }
+                          arr[idx] = nextVal;
+                          return arr;
+                        })();
+                        const activeYears =
+                          extension.years || nextSalaries.length || 0;
+                        setExtension((prev) => ({
+                          ...prev,
+                          salaries: nextSalaries,
+                        }));
+                        setSalaryInputs(
+                          toSalaryInputs(nextSalaries, activeYears)
+                        );
+                      }}
+                      className="w-full pl-5 pr-2 py-2 rounded bg-black/50 border border-white/10 text-xs text-white font-medium text-center focus:border-cyan-500 focus:bg-cyan-500/10 outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
+                  </div>
                 </div>
-                <div className="text-[11px] text-orange-100/75">
-                  {extensionAvailability.status === 'ready'
-                    ? `${extensionAvailability.firstExtendedSeason || 'The next Contract Season'} begins the extension. Exact route, timing, term, salary, bonus, and annual-change rules are checked again when saved.`
-                    : extensionAvailability.reasons[0] ||
-                      'Required Contract or league evidence is unavailable.'}
-                </div>
-              </>
-            ) : (
-              <>
-                <div className="font-medium">Extension unavailable</div>
-                <div className="text-[11px] text-orange-100/80">
-                  Required contract and league information is needed before an
-                  extension can be saved.
-                </div>
-              </>
-            )}
+              );
+            })}
           </div>
-        )}
-      </div>
-    )}
 
-    {selectedAction === 'buyout' && (
-      <div className="bg-white/5 rounded-lg border border-white/20 p-4 space-y-3">
-        <h4 className="font-semibold text-sm text-white flex items-center gap-2">
-          <span className="w-1 h-4 bg-orange-500 rounded-full"></span>
-          Buyout Terms
-        </h4>
-        <div className="text-xs text-white/70">
-          Remaining guaranteed salary:{' '}
-          <span className="text-white font-semibold">
-            {formatCurrencyFull(remainingGuaranteedForBuyout)}
-          </span>
+          {selectedAction === 'extend' && (
+            <div className="mt-3 px-3 py-2 bg-orange-500/10 border border-orange-500/20 rounded text-xs text-orange-200 space-y-1">
+              {extensionAvailability ? (
+                <>
+                  <div className="font-medium">
+                    {extensionAvailability.status === 'ready'
+                      ? 'Extension information ready'
+                      : extensionAvailability.status === 'incompatible'
+                        ? 'Extension unavailable'
+                        : 'Required contract information is missing'}
+                  </div>
+                  <div className="text-[11px] text-orange-100/75">
+                    {extensionAvailability.status === 'ready'
+                      ? `${extensionAvailability.firstExtendedSeason || 'The next Contract Season'} begins the extension. Exact route, timing, term, salary, bonus, and annual-change rules are checked again when saved.`
+                      : extensionAvailability.reasons[0] ||
+                        'Required Contract or league evidence is unavailable.'}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="font-medium">Extension unavailable</div>
+                  <div className="text-[11px] text-orange-100/80">
+                    Required contract and league information is needed before an
+                    extension can be saved.
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
-        <div>
-          <label
-            htmlFor="buyout-amount-input"
-            className="block text-xs font-medium text-white/80 mb-1"
-          >
-            Buyout Amount
-          </label>
-          <input
-            id="buyout-amount-input"
-            type="number"
-            min={0}
-            max={remainingGuaranteedForBuyout || undefined}
-            step="1000"
-            value={buyoutAmountInput}
-            onChange={(event) => setBuyoutAmountInput(event.target.value)}
-            placeholder="0"
-            className="w-full px-3 py-2 rounded bg-black/50 border border-white/20 text-sm text-white outline-none focus:border-orange-500"
-          />
+      )}
+
+      {selectedAction === 'buyout' && (
+        <div className="bg-white/5 rounded-lg border border-white/20 p-4 space-y-3">
+          <h4 className="font-semibold text-sm text-white flex items-center gap-2">
+            <span className="w-1 h-4 bg-orange-500 rounded-full"></span>
+            Buyout Terms
+          </h4>
+          <div className="text-xs text-white/70">
+            Remaining guaranteed salary:{' '}
+            <span className="text-white font-semibold">
+              {formatCurrencyFull(remainingGuaranteedForBuyout)}
+            </span>
+          </div>
+          <div>
+            <label
+              htmlFor="buyout-amount-input"
+              className="block text-xs font-medium text-white/80 mb-1"
+            >
+              Buyout Amount
+            </label>
+            <input
+              id="buyout-amount-input"
+              type="number"
+              min={0}
+              max={remainingGuaranteedForBuyout || undefined}
+              step="1000"
+              value={buyoutAmountInput}
+              onChange={(event) => setBuyoutAmountInput(event.target.value)}
+              placeholder="0"
+              className="w-full px-3 py-2 rounded bg-black/50 border border-white/20 text-sm text-white outline-none focus:border-orange-500"
+            />
+          </div>
+          <div className="text-[11px] text-white/60">
+            Resulting dead cap:{' '}
+            <span className="text-white">
+              {formatCurrencyFull(
+                Math.max(
+                  0,
+                  remainingGuaranteedForBuyout - (parsedBuyoutAmount || 0)
+                )
+              )}
+            </span>
+          </div>
+          {!buyoutAmountIsValid && (
+            <p className="text-[11px] text-red-300">
+              Enter a value between 0 and{' '}
+              {formatCurrencyFull(remainingGuaranteedForBuyout)}.
+            </p>
+          )}
         </div>
-        <div className="text-[11px] text-white/60">
-          Resulting dead cap:{' '}
-          <span className="text-white">
-            {formatCurrencyFull(
-              Math.max(
-                0,
-                remainingGuaranteedForBuyout - (parsedBuyoutAmount || 0)
-              )
-            )}
-          </span>
-        </div>
-        {!buyoutAmountIsValid && (
-          <p className="text-[11px] text-red-300">
-            Enter a value between 0 and{' '}
-            {formatCurrencyFull(remainingGuaranteedForBuyout)}.
-          </p>
-        )}
-      </div>
-    )}
-  </>
-);
+      )}
+    </>
+  );
+};

--- a/src/shared/components/EditContractModal.OfferSheetNoticeForm.tsx
+++ b/src/shared/components/EditContractModal.OfferSheetNoticeForm.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import type { OfferSheetTimingLike } from './EditContractModal.types';
+
+type GovernedOfferSheetNoticeFormProps = {
+  value: OfferSheetTimingLike;
+  onChange: React.Dispatch<React.SetStateAction<OfferSheetTimingLike>>;
+  onTermsChange: () => void;
+};
+
+export const GovernedOfferSheetNoticeForm = ({
+  value,
+  onChange,
+  onTermsChange,
+}: GovernedOfferSheetNoticeFormProps) => (
+  <div className="mb-4 grid gap-3 rounded-lg border border-cyan-400/25 bg-cyan-500/10 p-4 md:grid-cols-2">
+    <div className="md:col-span-2">
+      <div className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">
+        Offer Sheet notice
+      </div>
+      <p className="mt-1 text-[11px] text-cyan-50/70">
+        Record the exact Eastern signing and receipt times. The matching window
+        is calculated from receipt; neither time is inferred.
+      </p>
+    </div>
+    <label className="text-xs text-white/70">
+      Exact signature time
+      <input
+        data-testid="governed-offer-sheet-signed-at"
+        value={value.signedAt}
+        onChange={(event) => {
+          onTermsChange();
+          onChange((current) => ({
+            ...current,
+            signedAt: event.target.value,
+          }));
+        }}
+        placeholder="2026-07-08T09:55:00-04:00"
+        className="mt-1 w-full rounded border border-white/15 bg-black/35 px-3 py-2 text-xs text-white outline-none focus:border-cyan-400/50"
+      />
+      <span className="mt-1 block text-[10px] text-white/45">
+        Include the Eastern UTC offset.
+      </span>
+    </label>
+    <label className="text-xs text-white/70">
+      Exact Team receipt time
+      <input
+        data-testid="governed-offer-sheet-received-at"
+        value={value.receivedAt}
+        onChange={(event) => {
+          onTermsChange();
+          onChange((current) => ({
+            ...current,
+            receivedAt: event.target.value,
+          }));
+        }}
+        placeholder="2026-07-08T10:00:00-04:00"
+        className="mt-1 w-full rounded border border-white/15 bg-black/35 px-3 py-2 text-xs text-white outline-none focus:border-cyan-400/50"
+      />
+      <span className="mt-1 block text-[10px] text-white/45">
+        This instant starts the Exercise Notice deadline.
+      </span>
+    </label>
+  </div>
+);

--- a/src/shared/components/EditContractModal.form.hook.ts
+++ b/src/shared/components/EditContractModal.form.hook.ts
@@ -69,7 +69,9 @@ const getContractSalaryForEndYear = (
   const rows = Array.isArray(player?.contract?.salariesByYear)
     ? player.contract.salariesByYear
     : [];
-  const row = rows.find((salaryRow) => getSalaryRowEndYear(salaryRow) === endYear);
+  const row = rows.find(
+    (salaryRow) => getSalaryRowEndYear(salaryRow) === endYear
+  );
   const salary = Number(row?.salary ?? row?.capHit ?? 0);
   return Number.isFinite(salary) && salary > 0 ? salary : null;
 };
@@ -96,10 +98,11 @@ export const useEditContractModalForm = ({
   const [salaryInputs, setSalaryInputs] = useState<string[]>(['']);
   const [selectedException, setSelectedException] = useState('None');
   const [isOfferSheet, setIsOfferSheet] = useState(false);
-  const [offerSheetTiming, setOfferSheetTiming] = useState<OfferSheetTimingLike>({
-    signedAt: '',
-    receivedAt: '',
-  });
+  const [offerSheetTiming, setOfferSheetTiming] =
+    useState<OfferSheetTimingLike>({
+      signedAt: '',
+      receivedAt: '',
+    });
   const [extReason, setExtReason] = useState('');
   const [extMax, setExtMax] = useState<ExtMaxState | null>(null);
 
@@ -124,12 +127,24 @@ export const useEditContractModalForm = ({
     return SIGNING_EXCEPTION_OPTIONS.filter((option) => {
       if (option.value === 'None' || option.value === 'Minimum') return true;
       if (!teamCapSheet) return false;
-      const exceptionKey = getCanonicalExceptionKeyForSigningMechanism(option.value);
+      const exceptionKey = getCanonicalExceptionKeyForSigningMechanism(
+        option.value
+      );
       if (!exceptionKey) return false;
-      const availability = getCanonicalExceptionAvailability(teamCapSheet, exceptionKey);
-      if (!availability.present || !availability.enabled || !availability.usable) return false;
+      const availability = getCanonicalExceptionAvailability(
+        teamCapSheet,
+        exceptionKey
+      );
+      if (
+        !availability.present ||
+        !availability.enabled ||
+        !availability.usable
+      )
+        return false;
       return !validateExceptionEligibility({
-        team: teamCapSheet as Parameters<typeof validateExceptionEligibility>[0]['team'],
+        team: teamCapSheet as Parameters<
+          typeof validateExceptionEligibility
+        >[0]['team'],
         signedUsing: option.value,
         year: ACTION_YEAR,
       }).blocked;
@@ -151,7 +166,12 @@ export const useEditContractModalForm = ({
 
   useEffect(() => {
     if (!isSigningAction) return;
-    if (availableSigningExceptions.some((option) => option.value === selectedException)) return;
+    if (
+      availableSigningExceptions.some(
+        (option) => option.value === selectedException
+      )
+    )
+      return;
     setSelectedException('None');
   }, [availableSigningExceptions, isSigningAction, selectedException]);
 
@@ -174,11 +194,19 @@ export const useEditContractModalForm = ({
   );
 
   const buildSalarySeries = useCallback(
-    (firstYear: number, years: number, raisePct: number | null | undefined): number[] => {
+    (
+      firstYear: number,
+      years: number,
+      raisePct: number | null | undefined
+    ): number[] => {
       const totalYears = Math.min(Math.max(years, 1), 5);
       const series: number[] = [];
       for (let i = 0; i < totalYears; i += 1) {
-        series.push(i === 0 ? Math.round(firstYear) : Math.round(series[i - 1] * (1 + (raisePct || 0))));
+        series.push(
+          i === 0
+            ? Math.round(firstYear)
+            : Math.round(series[i - 1] * (1 + (raisePct || 0)))
+        );
       }
       return series;
     },
@@ -194,11 +222,15 @@ export const useEditContractModalForm = ({
   );
 
   const buildSigningDispatchPayload = useCallback(
-    (overrides: Partial<StagedSigningPayloadLike> = {}): StagedSigningPayloadLike => {
+    (
+      overrides: Partial<StagedSigningPayloadLike> = {}
+    ): StagedSigningPayloadLike => {
       const years = extension.years || extension.salaries?.length || 0;
       const salaries = (extension.salaries || []).slice(0, years);
       const signedUsing =
-        selectedException && selectedException !== 'None' ? selectedException : null;
+        selectedException && selectedException !== 'None'
+          ? selectedException
+          : null;
       return {
         ...extension,
         years,
@@ -215,7 +247,9 @@ export const useEditContractModalForm = ({
   );
 
   const buildCanonicalSigningDispatchPayload = useCallback(
-    (overrides: Partial<StagedSigningPayloadLike> = {}): StagedSigningPayloadLike => {
+    (
+      overrides: Partial<StagedSigningPayloadLike> = {}
+    ): StagedSigningPayloadLike => {
       const stagedPayload = buildSigningDispatchPayload(overrides);
       const salaries = (stagedPayload.salaries || []).map((value) =>
         Math.round(Number(value) || 0)
@@ -237,7 +271,9 @@ export const useEditContractModalForm = ({
         base: salaries[0] || 0,
         totalValue,
         averageAnnualValue:
-          stagedPayload.years > 0 ? Math.round(totalValue / stagedPayload.years) : 0,
+          stagedPayload.years > 0
+            ? Math.round(totalValue / stagedPayload.years)
+            : 0,
         firstYearGuaranteed: salariesByYear[0]?.guaranteed !== false,
       };
     },
@@ -245,7 +281,9 @@ export const useEditContractModalForm = ({
   );
 
   const buildOfferSheetDispatchPayload = useCallback(
-    (overrides: Partial<StagedSigningPayloadLike> = {}): StagedSigningPayloadLike => {
+    (
+      overrides: Partial<StagedSigningPayloadLike> = {}
+    ): StagedSigningPayloadLike => {
       const staged = buildCanonicalSigningDispatchPayload({
         rfaOfferSheet: true,
         rfaOfferSheetOnly: true,
@@ -254,34 +292,42 @@ export const useEditContractModalForm = ({
         ...overrides,
       });
       const playerId = String(
-        player?.id || player?.player_id || player?.playerId || 'unknown-player'
-      );
+        player?.id || player?.player_id || player?.playerId || ''
+      ).trim();
       return {
         ...staged,
-        offerSheetProposal: {
-          proposalVersion: 1,
-          signedAt: offerSheetTiming.signedAt,
-          receivedAt: offerSheetTiming.receivedAt,
-          principalTermsDocumentId: `architect-principal-terms:${playerId}:v1`,
-          noticeDocumentId: `architect-offer-sheet-notice:${playerId}:v1`,
-          salariesByYear: (staged.salariesByYear || []).map((row) => ({
-            season: row.season,
-            salaryExcludingIncentive: row.salary,
-            regularSalary: row.salary,
-            bonuses: [],
-            guaranteedForLackOfSkill: row.guaranteed,
-            guaranteedForInjuryOrIllness: row.guaranteed,
-            individuallyNegotiatedProtectionConditions: false,
-            option: null,
-          })),
-        },
+        ...(playerId
+          ? {
+              offerSheetProposal: {
+                proposalVersion: 1 as const,
+                signedAt: offerSheetTiming.signedAt,
+                receivedAt: offerSheetTiming.receivedAt,
+                principalTermsDocumentId: `architect-principal-terms:${playerId}:v1`,
+                noticeDocumentId: `architect-offer-sheet-notice:${playerId}:v1`,
+                salariesByYear: (staged.salariesByYear || []).map((row) => ({
+                  season: row.season,
+                  salaryExcludingIncentive: row.salary,
+                  regularSalary: row.salary,
+                  bonuses: [],
+                  guaranteedForLackOfSkill: row.guaranteed,
+                  guaranteedForInjuryOrIllness: row.guaranteed,
+                  individuallyNegotiatedProtectionConditions: false,
+                  option: null,
+                })),
+              },
+            }
+          : {}),
       };
     },
     [buildCanonicalSigningDispatchPayload, offerSheetTiming, player]
   );
 
   const signAndTradeDispatchPayload = useMemo(
-    () => buildSigningDispatchPayload({ signAndTrade: true, contractType: 'Sign & Trade' }),
+    () =>
+      buildSigningDispatchPayload({
+        signAndTrade: true,
+        contractType: 'Sign & Trade',
+      }),
     [buildSigningDispatchPayload]
   );
 
@@ -311,7 +357,11 @@ export const useEditContractModalForm = ({
     const eligibility = playerRulesProfile?.extensionEligibility;
     const terms = playerRulesProfile?.extensionTerms;
     if (eligibility) {
-      setExtReason(eligibility.isEligible ? 'Eligible' : eligibility.reason || 'Not eligible');
+      setExtReason(
+        eligibility.isEligible
+          ? 'Eligible'
+          : eligibility.reason || 'Not eligible'
+      );
       setExtMax(
         terms
           ? {
@@ -337,8 +387,9 @@ export const useEditContractModalForm = ({
           ...ruleCtx.player,
           playerId: String(player.id || player.player_id || 'unknown'),
           displayName: player.displayName || player.name || 'Unknown',
-          yearsOfServiceAtOperation:
-            Number(player.yearsOfService || player.bio?.experience || 0),
+          yearsOfServiceAtOperation: Number(
+            player.yearsOfService || player.bio?.experience || 0
+          ),
           priorSeasonSalary: lastSalaryForPrefill || null,
           currentSeasonSalary: lastSalaryForPrefill || null,
           isRookieScale:
@@ -380,7 +431,13 @@ export const useEditContractModalForm = ({
       setExtReason('Unable to determine eligibility');
       setExtMax(null);
     }
-  }, [CURRENT_YEAR, initialAction, lastSalaryForPrefill, player, playerRulesProfile]);
+  }, [
+    CURRENT_YEAR,
+    initialAction,
+    lastSalaryForPrefill,
+    player,
+    playerRulesProfile,
+  ]);
 
   useEffect(() => {
     if (selectedAction !== 'extend') return;
@@ -407,11 +464,7 @@ export const useEditContractModalForm = ({
     setExtension((prev) => {
       const years = extMax.maxYears || prev.years || 1;
       const safeRaisePct = Math.max(0, (extMax.baseRaisePct ?? 0.08) - 0.0001);
-      const salaries = buildSalarySeries(
-        firstYearSalary,
-        years,
-        safeRaisePct
-      );
+      const salaries = buildSalarySeries(firstYearSalary, years, safeRaisePct);
       setSalaryInputs(toSalaryInputs(salaries, years));
       return {
         years,

--- a/src/shared/components/EditContractModal.form.hook.ts
+++ b/src/shared/components/EditContractModal.form.hook.ts
@@ -25,6 +25,7 @@ import type {
   SelectedContractAction,
   SigningExceptionOption,
   HookContractDataLike,
+  OfferSheetTimingLike,
 } from './EditContractModal.types';
 
 type GetCapSettingsResult = ReturnType<
@@ -95,6 +96,10 @@ export const useEditContractModalForm = ({
   const [salaryInputs, setSalaryInputs] = useState<string[]>(['']);
   const [selectedException, setSelectedException] = useState('None');
   const [isOfferSheet, setIsOfferSheet] = useState(false);
+  const [offerSheetTiming, setOfferSheetTiming] = useState<OfferSheetTimingLike>({
+    signedAt: '',
+    receivedAt: '',
+  });
   const [extReason, setExtReason] = useState('');
   const [extMax, setExtMax] = useState<ExtMaxState | null>(null);
 
@@ -240,15 +245,39 @@ export const useEditContractModalForm = ({
   );
 
   const buildOfferSheetDispatchPayload = useCallback(
-    (overrides: Partial<StagedSigningPayloadLike> = {}): StagedSigningPayloadLike =>
-      buildCanonicalSigningDispatchPayload({
+    (overrides: Partial<StagedSigningPayloadLike> = {}): StagedSigningPayloadLike => {
+      const staged = buildCanonicalSigningDispatchPayload({
         rfaOfferSheet: true,
         rfaOfferSheetOnly: true,
         rfaOfferSheetStatus: 'PENDING_MATCH',
         contractType: 'Offer Sheet',
         ...overrides,
-      }),
-    [buildCanonicalSigningDispatchPayload]
+      });
+      const playerId = String(
+        player?.id || player?.player_id || player?.playerId || 'unknown-player'
+      );
+      return {
+        ...staged,
+        offerSheetProposal: {
+          proposalVersion: 1,
+          signedAt: offerSheetTiming.signedAt,
+          receivedAt: offerSheetTiming.receivedAt,
+          principalTermsDocumentId: `architect-principal-terms:${playerId}:v1`,
+          noticeDocumentId: `architect-offer-sheet-notice:${playerId}:v1`,
+          salariesByYear: (staged.salariesByYear || []).map((row) => ({
+            season: row.season,
+            salaryExcludingIncentive: row.salary,
+            regularSalary: row.salary,
+            bonuses: [],
+            guaranteedForLackOfSkill: row.guaranteed,
+            guaranteedForInjuryOrIllness: row.guaranteed,
+            individuallyNegotiatedProtectionConditions: false,
+            option: null,
+          })),
+        },
+      };
+    },
+    [buildCanonicalSigningDispatchPayload, offerSheetTiming, player]
   );
 
   const signAndTradeDispatchPayload = useMemo(
@@ -433,6 +462,7 @@ export const useEditContractModalForm = ({
   // Reset non-buyout form state when action changes or modal closes
   useEffect(() => {
     setIsOfferSheet(false);
+    setOfferSheetTiming({ signedAt: '', receivedAt: '' });
   }, [selectedAction, isOpen]);
 
   return {
@@ -444,6 +474,8 @@ export const useEditContractModalForm = ({
     setSelectedException,
     isOfferSheet,
     setIsOfferSheet,
+    offerSheetTiming,
+    setOfferSheetTiming,
     extReason,
     extMax,
     signingGuardrails,

--- a/src/shared/components/EditContractModal.preflight.hook.ts
+++ b/src/shared/components/EditContractModal.preflight.hook.ts
@@ -14,6 +14,7 @@ import type {
   OfferSheetInitiation,
   SignAndTradeInitiation,
 } from './EditContractModal.types';
+import { MAX_OFFER_SHEET_SALARY_CAP_YEARS } from '@/schemas/governedOfferSheet';
 
 type UseEditContractModalPreflightParams = {
   isOpen: boolean | undefined;
@@ -140,7 +141,7 @@ export const useEditContractModalPreflight = ({
       );
       return;
     }
-    if (offerSheetDispatchPayload.years > 4) {
+    if (offerSheetDispatchPayload.years > MAX_OFFER_SHEET_SALARY_CAP_YEARS) {
       setOfferSheetPreflight(
         buildOfferSheetPreflightResult('blocked', [
           'An Offer Sheet may cover no more than four Salary Cap Years.',

--- a/src/shared/components/EditContractModal.preflight.hook.ts
+++ b/src/shared/components/EditContractModal.preflight.hook.ts
@@ -66,7 +66,9 @@ export const useEditContractModalPreflight = ({
     }
     if (signAndTradeActionDisabledReason) {
       setSignAndTradePreflight(
-        buildSignAndTradePreflightResult('blocked', [signAndTradeActionDisabledReason])
+        buildSignAndTradePreflightResult('blocked', [
+          signAndTradeActionDisabledReason,
+        ])
       );
       return;
     }
@@ -138,13 +140,24 @@ export const useEditContractModalPreflight = ({
       );
       return;
     }
+    if (offerSheetDispatchPayload.years > 4) {
+      setOfferSheetPreflight(
+        buildOfferSheetPreflightResult('blocked', [
+          'An Offer Sheet may cover no more than four Salary Cap Years.',
+        ])
+      );
+      return;
+    }
     setOfferSheetPreflight(
       buildOfferSheetPreflightResult('incomplete', [
         'Checking authoritative offer sheet legality...',
       ])
     );
     void Promise.resolve(
-      resolvedOfferSheetInitiation.getOfferSheetPreflight(player, offerSheetDispatchPayload)
+      resolvedOfferSheetInitiation.getOfferSheetPreflight(
+        player,
+        offerSheetDispatchPayload
+      )
     )
       .then((result) => {
         if (latestOfferSheetPreflightRequestId.current !== requestId) return;

--- a/src/shared/components/EditContractModal.tsx
+++ b/src/shared/components/EditContractModal.tsx
@@ -300,6 +300,8 @@ export const EditContractModal = ({
     setSelectedException,
     isOfferSheet,
     setIsOfferSheet,
+    offerSheetTiming,
+    setOfferSheetTiming,
     extReason,
     extMax,
     signingGuardrails,
@@ -1170,6 +1172,8 @@ export const EditContractModal = ({
             setSelectedException={setSelectedException}
             isOfferSheet={isOfferSheet}
             setIsOfferSheet={setIsOfferSheet}
+            offerSheetTiming={offerSheetTiming}
+            setOfferSheetTiming={setOfferSheetTiming}
             destinationTeamId={destinationTeamId}
             setDestinationTeamId={setDestinationTeamId}
             buyoutAmountInput={buyoutAmountInput}

--- a/src/shared/components/EditContractModal.types.ts
+++ b/src/shared/components/EditContractModal.types.ts
@@ -15,6 +15,7 @@ import type {
   GovernedExtensionProposal,
   GovernedExtensionRoute,
 } from '@/features/architect/utils/extensions';
+import type { GovernedOfferSheetProposal } from '@/schemas/governedOfferSheet';
 
 export type UseCapValidationParams = Parameters<typeof useCapValidation>[0];
 export type HookPlayerLike = NonNullable<UseCapValidationParams['player']>;
@@ -118,6 +119,11 @@ export type ExtensionStateLike = {
   agreedDesignatedVeteranPercentage?: number | null;
 };
 
+export type OfferSheetTimingLike = {
+  signedAt: string;
+  receivedAt: string;
+};
+
 export type PlayerRulesProfileLike = UseCapValidationParams['rulesProfile'];
 
 export type ExtMaxState = {
@@ -202,6 +208,7 @@ export type StagedSigningPayloadLike = {
   rfaOfferSheet?: boolean;
   rfaOfferSheetOnly?: boolean;
   rfaOfferSheetStatus?: string;
+  offerSheetProposal?: GovernedOfferSheetProposal;
 } & Partial<OverrideMetadataLike>;
 
 export type ExtensionPayloadLike = GovernedExtensionProposal;

--- a/src/tests/architect/OfferSheetList.freeAgency.test.tsx
+++ b/src/tests/architect/OfferSheetList.freeAgency.test.tsx
@@ -250,6 +250,42 @@ describe('OfferSheetList Free Agency wiring', () => {
     expect(screen.getByRole('button', { name: /^Decline$/i })).toBeDisabled();
   });
 
+  it('explains why an incomplete averaging election disables Match', () => {
+    const lifecycle = makePendingGovernedOfferSheetLifecycle();
+    render(
+      <OfferSheetList
+        title="Incoming"
+        offerSheets={[
+          {
+            ...baseOfferSheet,
+            status: 'PENDING_MATCH' as const,
+            governedLifecycle: {
+              ...lifecycle,
+              reservations: {
+                ...lifecycle.reservations,
+                arenasApplies: true,
+              },
+            },
+          },
+        ]}
+        surfaceRole="incoming"
+        onLifecycleAction={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('offer-sheet-resolution-at-os_1'), {
+      target: { value: RESOLUTION_AT },
+    });
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: /Elect average annual Salary/i })
+    );
+
+    expect(screen.getByRole('button', { name: /^Match$/i })).toHaveAttribute(
+      'title',
+      'Enter the averaging statement reference and exact Eastern relay time.'
+    );
+  });
+
   it('returns null for empty offer sheet arrays', () => {
     const { container } = render(
       <OfferSheetList

--- a/src/tests/architect/OfferSheetList.freeAgency.test.tsx
+++ b/src/tests/architect/OfferSheetList.freeAgency.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { OfferSheetList } from '@/features/architect/GMDashboard/components/OfferSheetList';
 import { FreeAgencySection } from '@/features/architect/GMDashboard/sections/FreeAgencySection';
+import { makePendingGovernedOfferSheetLifecycle } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 vi.mock('@/features/architect/freeAgency/FreeAgentPool', () => {
   const MockFreeAgentPool = () => (
@@ -23,6 +24,7 @@ const baseOfferSheet = {
   contractYears: 4,
   totalValue: 120_000_000,
   createdAt: '2026-02-12T00:00:00.000Z',
+  governedLifecycle: makePendingGovernedOfferSheetLifecycle(),
 };
 const RESOLUTION_AT = '2026-02-13T12:00:00-05:00';
 
@@ -76,9 +78,7 @@ describe('OfferSheetList Free Agency wiring', () => {
     fireEvent.change(screen.getByTestId('offer-sheet-resolution-at-os_1'), {
       target: { value: RESOLUTION_AT },
     });
-    fireEvent.click(
-      screen.getByRole('button', { name: /^Match$/i })
-    );
+    fireEvent.click(screen.getByRole('button', { name: /^Match$/i }));
     expect(onLifecycleAction).toHaveBeenCalledTimes(1);
     expect(onLifecycleAction).toHaveBeenCalledWith({
       action: 'match',
@@ -107,9 +107,7 @@ describe('OfferSheetList Free Agency wiring', () => {
     fireEvent.change(screen.getByTestId('offer-sheet-resolution-at-os_1'), {
       target: { value: RESOLUTION_AT },
     });
-    fireEvent.click(
-      screen.getByRole('button', { name: /^Decline$/i })
-    );
+    fireEvent.click(screen.getByRole('button', { name: /^Decline$/i }));
     expect(onLifecycleAction).toHaveBeenCalledTimes(1);
     expect(onLifecycleAction).toHaveBeenCalledWith({
       action: 'decline',
@@ -194,7 +192,7 @@ describe('OfferSheetList Free Agency wiring', () => {
     render(
       <OfferSheetList
         title="Incoming"
-        offerSheets={[{ ...baseOfferSheet, status: 'PENDING_MATCH' }]}
+        offerSheets={[{ ...baseOfferSheet, status: 'PENDING_MATCH' as const }]}
         surfaceRole="incoming"
         onLifecycleAction={vi.fn()}
         actionsDisabled
@@ -205,12 +203,51 @@ describe('OfferSheetList Free Agency wiring', () => {
     expect(
       screen.getByText(/Requires an active world to commit\./i)
     ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Match$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^Decline$/i })).toBeDisabled();
+  });
+
+  it('disables resolution when the retained governed lifecycle is missing', () => {
+    render(
+      <OfferSheetList
+        title="Incoming"
+        offerSheets={[
+          {
+            ...baseOfferSheet,
+            status: 'PENDING_MATCH',
+            governedLifecycle: undefined,
+          },
+        ]}
+        surfaceRole="incoming"
+        onLifecycleAction={vi.fn()}
+      />
+    );
+
     expect(
-      screen.getByRole('button', { name: /^Match$/i })
-    ).toBeDisabled();
-    expect(
-      screen.getByRole('button', { name: /^Decline$/i })
-    ).toBeDisabled();
+      screen.getByText(
+        /missing the saved notice record required to resolve it/i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Match$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^Decline$/i })).toBeDisabled();
+  });
+
+  it('keeps resolution disabled when the stated offset is not Eastern for that date', () => {
+    render(
+      <OfferSheetList
+        title="Incoming"
+        offerSheets={[{ ...baseOfferSheet, status: 'PENDING_MATCH' as const }]}
+        surfaceRole="incoming"
+        onLifecycleAction={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('offer-sheet-resolution-at-os_1'), {
+      target: { value: '2026-07-09T17:00:00-05:00' },
+    });
+
+    expect(screen.getByRole('button', { name: /^Match$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^Decline$/i })).toBeDisabled();
   });
 
   it('returns null for empty offer sheet arrays', () => {
@@ -304,16 +341,11 @@ describe('FreeAgencySection offer-sheet lifecycle routing', () => {
       />
     );
 
-    fireEvent.change(
-      screen.getByTestId('offer-sheet-resolution-at-os_match'),
-      { target: { value: RESOLUTION_AT } }
-    );
-    fireEvent.click(
-      screen.getByRole('button', { name: /^Match$/i })
-    );
-    fireEvent.click(
-      screen.getByRole('button', { name: /^Decline$/i })
-    );
+    fireEvent.change(screen.getByTestId('offer-sheet-resolution-at-os_match'), {
+      target: { value: RESOLUTION_AT },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Match$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Decline$/i }));
     fireEvent.click(screen.getByRole('button', { name: /Finalize Match/i }));
     fireEvent.click(screen.getByRole('button', { name: /Finalize Signing/i }));
 
@@ -401,13 +433,9 @@ describe('FreeAgencySection offer-sheet lifecycle routing', () => {
         /Offer-sheet lifecycle actions require an active world to commit\./i
       ).length
     ).toBeGreaterThan(0);
-    expect(
-      screen.getByRole('button', { name: /^Match$/i })
-    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^Match$/i })).toBeDisabled();
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /^Match$/i })
-    );
+    fireEvent.click(screen.getByRole('button', { name: /^Match$/i }));
 
     expect(matchOfferSheet).not.toHaveBeenCalled();
   });

--- a/src/tests/architect/OfferSheetList.freeAgency.test.tsx
+++ b/src/tests/architect/OfferSheetList.freeAgency.test.tsx
@@ -24,6 +24,7 @@ const baseOfferSheet = {
   totalValue: 120_000_000,
   createdAt: '2026-02-12T00:00:00.000Z',
 };
+const RESOLUTION_AT = '2026-02-13T12:00:00-05:00';
 
 afterEach(() => {
   cleanup();
@@ -72,6 +73,9 @@ describe('OfferSheetList Free Agency wiring', () => {
       />
     );
 
+    fireEvent.change(screen.getByTestId('offer-sheet-resolution-at-os_1'), {
+      target: { value: RESOLUTION_AT },
+    });
     fireEvent.click(
       screen.getByRole('button', { name: /^Match$/i })
     );
@@ -80,6 +84,10 @@ describe('OfferSheetList Free Agency wiring', () => {
       action: 'match',
       offerSheet,
       surfaceRole: 'incoming',
+      resolution: {
+        resolutionAt: RESOLUTION_AT,
+        averagingElection: null,
+      },
     });
   });
 
@@ -96,6 +104,9 @@ describe('OfferSheetList Free Agency wiring', () => {
       />
     );
 
+    fireEvent.change(screen.getByTestId('offer-sheet-resolution-at-os_1'), {
+      target: { value: RESOLUTION_AT },
+    });
     fireEvent.click(
       screen.getByRole('button', { name: /^Decline$/i })
     );
@@ -104,6 +115,10 @@ describe('OfferSheetList Free Agency wiring', () => {
       action: 'decline',
       offerSheet,
       surfaceRole: 'incoming',
+      resolution: {
+        resolutionAt: RESOLUTION_AT,
+        averagingElection: null,
+      },
     });
   });
 
@@ -289,6 +304,10 @@ describe('FreeAgencySection offer-sheet lifecycle routing', () => {
       />
     );
 
+    fireEvent.change(
+      screen.getByTestId('offer-sheet-resolution-at-os_match'),
+      { target: { value: RESOLUTION_AT } }
+    );
     fireEvent.click(
       screen.getByRole('button', { name: /^Match$/i })
     );
@@ -298,8 +317,18 @@ describe('FreeAgencySection offer-sheet lifecycle routing', () => {
     fireEvent.click(screen.getByRole('button', { name: /Finalize Match/i }));
     fireEvent.click(screen.getByRole('button', { name: /Finalize Signing/i }));
 
-    expect(matchOfferSheet).toHaveBeenCalledWith(incomingPendingOfferSheet);
-    expect(declineOfferSheet).toHaveBeenCalledWith(incomingPendingOfferSheet);
+    const resolution = {
+      resolutionAt: RESOLUTION_AT,
+      averagingElection: null,
+    };
+    expect(matchOfferSheet).toHaveBeenCalledWith(
+      incomingPendingOfferSheet,
+      resolution
+    );
+    expect(declineOfferSheet).toHaveBeenCalledWith(
+      incomingPendingOfferSheet,
+      resolution
+    );
     expect(finalizeOfferSheet).toHaveBeenCalledTimes(2);
     expect(finalizeOfferSheet).toHaveBeenNthCalledWith(
       1,

--- a/src/tests/architect/editContractModal.offerSheetPreflight.behavior.test.tsx
+++ b/src/tests/architect/editContractModal.offerSheetPreflight.behavior.test.tsx
@@ -240,6 +240,67 @@ afterEach(() => {
 });
 
 describe('EditContractModal offer-sheet preflight behavior', () => {
+  it('authors exact Offer Sheet notice evidence into the preview and saved payload', async () => {
+    const getOfferSheetPreflight = vi.fn().mockResolvedValue({
+      status: 'legal',
+      reasons: [],
+      warnings: [],
+      source: 'authoritative-preflight',
+    });
+    const onStoreOfferSheet = vi.fn().mockResolvedValue({ success: true });
+
+    render(
+      <EditContractModal
+        isOpen
+        onClose={vi.fn()}
+        player={RFA_PLAYER}
+        teamCapSheet={TEAM_CAP_SHEET}
+        currentYear={2026}
+        initialAction="signNew"
+        actionsOverride={['signNew']}
+        onStoreOfferSheet={onStoreOfferSheet}
+        getOfferSheetPreflight={getOfferSheetPreflight}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Offer Sheet/i }));
+    fireEvent.change(screen.getByTestId('governed-offer-sheet-signed-at'), {
+      target: { value: '2025-07-08T09:55:00-04:00' },
+    });
+    fireEvent.change(screen.getByTestId('governed-offer-sheet-received-at'), {
+      target: { value: '2025-07-08T10:00:00-04:00' },
+    });
+
+    await waitFor(() => {
+      expect(getOfferSheetPreflight).toHaveBeenLastCalledWith(
+        RFA_PLAYER,
+        expect.objectContaining({
+          offerSheetProposal: expect.objectContaining({
+            signedAt: '2025-07-08T09:55:00-04:00',
+            receivedAt: '2025-07-08T10:00:00-04:00',
+          }),
+        })
+      );
+    });
+
+    const confirmButton = screen.getByTestId('edit-contract-confirm-action-button');
+    await waitFor(() => expect(confirmButton).toBeEnabled());
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(onStoreOfferSheet).toHaveBeenCalledTimes(1));
+    expect(onStoreOfferSheet).toHaveBeenCalledWith(
+      RFA_PLAYER,
+      expect.objectContaining({
+        offerSheetProposal: expect.objectContaining({
+          signedAt: '2025-07-08T09:55:00-04:00',
+          receivedAt: '2025-07-08T10:00:00-04:00',
+          principalTermsDocumentId: 'architect-principal-terms:p_rfa:v1',
+          noticeDocumentId: 'architect-offer-sheet-notice:p_rfa:v1',
+        }),
+      })
+    );
+  });
+
   it('keeps confirm disabled while preflight is pending and enables only after legal result', async () => {
     const onClose = vi.fn();
     const onStoreOfferSheet = vi.fn().mockResolvedValue({ success: true });

--- a/src/tests/architect/editContractModal.offerSheetPreflight.behavior.test.tsx
+++ b/src/tests/architect/editContractModal.offerSheetPreflight.behavior.test.tsx
@@ -8,13 +8,7 @@
  */
 
 import React from 'react';
-import {
-  afterEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   cleanup,
   fireEvent,
@@ -112,7 +106,9 @@ vi.mock('@/features/architect/utils/contractUtils', () => ({
     startYear,
   }),
   getContractYearsForDisplay: (player: {
-    contract?: { salariesByYear?: Array<Record<string, unknown>> | null } | null;
+    contract?: {
+      salariesByYear?: Array<Record<string, unknown>> | null;
+    } | null;
   }) =>
     (player?.contract?.salariesByYear || []).map((row) => {
       const season = String(row.season || '');
@@ -129,9 +125,12 @@ vi.mock('@/features/architect/utils/contractUtils', () => ({
       };
     }),
   getContractYearSlice: (
-    contract: {
-      salariesByYear?: Array<Record<string, unknown>> | null;
-    } | null | undefined,
+    contract:
+      | {
+          salariesByYear?: Array<Record<string, unknown>> | null;
+        }
+      | null
+      | undefined,
     year: number
   ) =>
     (contract?.salariesByYear || []).find((row) => {
@@ -144,9 +143,10 @@ vi.mock('@/features/architect/utils/contractUtils', () => ({
 }));
 
 vi.mock('@/features/architect/utils/seasonFormat', async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import('@/features/architect/utils/seasonFormat')
-  >();
+  const actual =
+    await importOriginal<
+      typeof import('@/features/architect/utils/seasonFormat')
+    >();
   return {
     ...actual,
     toSeasonCode: (endYear: number) =>
@@ -283,7 +283,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
       );
     });
 
-    const confirmButton = screen.getByTestId('edit-contract-confirm-action-button');
+    const confirmButton = screen.getByTestId(
+      'edit-contract-confirm-action-button'
+    );
     await waitFor(() => expect(confirmButton).toBeEnabled());
     fireEvent.click(confirmButton);
 
@@ -298,6 +300,81 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
           noticeDocumentId: 'architect-offer-sheet-notice:p_rfa:v1',
         }),
       })
+    );
+  });
+
+  it('blocks a five-year Offer Sheet locally before authoritative dispatch', async () => {
+    const getOfferSheetPreflight = vi.fn();
+
+    render(
+      <EditContractModal
+        isOpen
+        onClose={vi.fn()}
+        player={RFA_PLAYER}
+        teamCapSheet={TEAM_CAP_SHEET}
+        currentYear={2026}
+        initialAction="signNew"
+        actionsOverride={['signNew']}
+        onStoreOfferSheet={vi.fn()}
+        getOfferSheetPreflight={getOfferSheetPreflight}
+        playerRulesProfile={{
+          birdRights: {
+            type: 'Full Bird',
+            signingAbilities: { maxYears: 5 },
+          },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('contract-years'), {
+      target: { value: '5' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /Offer Sheet/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('validation-warnings')).toHaveTextContent(
+        'An Offer Sheet may cover no more than four Salary Cap Years.'
+      );
+    });
+    expect(screen.getByRole('option', { name: '5yr' })).toBeDisabled();
+    expect(getOfferSheetPreflight).not.toHaveBeenCalled();
+    expect(
+      screen.getByTestId('edit-contract-confirm-action-button')
+    ).toBeDisabled();
+  });
+
+  it('omits retained notice IDs when the player has no canonical identifier', async () => {
+    const getOfferSheetPreflight = vi.fn().mockResolvedValue({
+      status: 'blocked',
+      reasons: ['Player identity is required.'],
+      warnings: [],
+      source: 'authoritative-preflight',
+    });
+    const playerWithoutId = {
+      ...RFA_PLAYER,
+      id: undefined,
+      player_id: undefined,
+    };
+
+    render(
+      <EditContractModal
+        isOpen
+        onClose={vi.fn()}
+        player={playerWithoutId}
+        teamCapSheet={{ ...TEAM_CAP_SHEET, players: [playerWithoutId] }}
+        currentYear={2026}
+        initialAction="signNew"
+        actionsOverride={['signNew']}
+        onStoreOfferSheet={vi.fn()}
+        getOfferSheetPreflight={getOfferSheetPreflight}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Offer Sheet/i }));
+
+    await waitFor(() => expect(getOfferSheetPreflight).toHaveBeenCalled());
+    expect(getOfferSheetPreflight.mock.calls.at(-1)?.[1]).not.toHaveProperty(
+      'offerSheetProposal'
     );
   });
 
@@ -328,7 +405,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
       />
     );
 
-    const confirmButton = screen.getByTestId('edit-contract-confirm-action-button');
+    const confirmButton = screen.getByTestId(
+      'edit-contract-confirm-action-button'
+    );
     const offerSheetCheckbox = screen.getByRole('checkbox');
 
     // Without toggle: confirm enabled (normal signNew validation)
@@ -400,7 +479,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
       />
     );
 
-    const confirmButton = screen.getByTestId('edit-contract-confirm-action-button');
+    const confirmButton = screen.getByTestId(
+      'edit-contract-confirm-action-button'
+    );
     fireEvent.click(screen.getByRole('checkbox'));
 
     await waitFor(() => {
@@ -436,7 +517,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
       />
     );
 
-    const confirmButton = screen.getByTestId('edit-contract-confirm-action-button');
+    const confirmButton = screen.getByTestId(
+      'edit-contract-confirm-action-button'
+    );
     const checkbox = screen.getByRole('checkbox');
 
     // Toggle on → preflight starts
@@ -466,7 +549,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
     await waitFor(() => {
       expect(confirmButton).toBeEnabled();
     });
-    expect(screen.queryByText('Checking authoritative offer sheet legality...')).toBeNull();
+    expect(
+      screen.queryByText('Checking authoritative offer sheet legality...')
+    ).toBeNull();
   });
 
   it('does not call getOfferSheetPreflight when offer sheet toggle is off', async () => {
@@ -486,7 +571,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
       />
     );
 
-    const confirmButton = screen.getByTestId('edit-contract-confirm-action-button');
+    const confirmButton = screen.getByTestId(
+      'edit-contract-confirm-action-button'
+    );
 
     // Do NOT click the checkbox
     await waitFor(() => {
@@ -691,7 +778,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
     // Modal must reflect the authoritative verdict, not its own local inference.
     const getOfferSheetPreflight = vi.fn().mockResolvedValue({
       status: 'blocked',
-      reasons: ['Offer sheet requires a distinct home team (offering team is the home team).'],
+      reasons: [
+        'Offer sheet requires a distinct home team (offering team is the home team).',
+      ],
       warnings: [],
       source: 'authoritative-preflight',
     });
@@ -710,7 +799,9 @@ describe('EditContractModal offer-sheet preflight behavior', () => {
       />
     );
 
-    const confirmButton = screen.getByTestId('edit-contract-confirm-action-button');
+    const confirmButton = screen.getByTestId(
+      'edit-contract-confirm-action-button'
+    );
     fireEvent.click(screen.getByRole('checkbox'));
 
     await waitFor(() => {

--- a/src/tests/architect/mutationPipeline.committedSnapshotRoundtrip.test.ts
+++ b/src/tests/architect/mutationPipeline.committedSnapshotRoundtrip.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const harness = vi.hoisted(() => ({
   writeBatchMock: vi.fn(() => ({
@@ -290,6 +291,17 @@ describe('mutationPipeline committed snapshot round-trip boundary', () => {
   });
 
   it('round-trips only the committed totals, draft-pick, and source slices on offer-sheet team updates', () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: 'world-committed-snapshot-roundtrip',
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'sheet_1',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
     const offerSheet = {
       id: 'sheet_1',
       dedupKey: 'sheet_1::BOS::NYK::rfa_1',
@@ -303,6 +315,7 @@ describe('mutationPipeline committed snapshot round-trip boundary', () => {
       contractYears: '2',
       totalValue: '18000000',
       salariesByYear: [{ season: SEASON_ID, salary: '9000000' }],
+      governedLifecycle: governed.lifecycle,
     };
     const draftPick = {
       id: 'nyk_2028_1',
@@ -362,6 +375,7 @@ describe('mutationPipeline committed snapshot round-trip boundary', () => {
         homeTeamCode: 'NYK',
         offeringTeamCode: 'BOS',
         offerSheetId: 'sheet_1',
+        offerSheetResolutionAt: governed.resolutionAt,
       },
       currentState: {
         homeTeam: homeTeam as CurrentStateInput['homeTeam'],
@@ -370,6 +384,7 @@ describe('mutationPipeline committed snapshot round-trip boundary', () => {
       },
       seasonId: SEASON_ID,
       timestamp: FIXED_TIMESTAMP,
+      asOfDate: governed.asOfDate,
     });
 
     expect(result.success).toBe(true);

--- a/src/tests/architect/mutationPipeline.compatibilityBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.compatibilityBoundary.test.ts
@@ -151,6 +151,7 @@ vi.mock('@/features/architect/utils/leagueInvariants', () => ({
 }));
 
 import { applyWorldMutation } from '@/features/architect/utils/mutationPipeline';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const WORLD_ID = 'world_boundary_test';
 const PARENT_WORLD_ID = 'world_boundary_parent';
@@ -495,7 +496,7 @@ describe('mutationPipeline compatibility boundary', () => {
       timestamp: FIXED_TIMESTAMP,
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
     expect(result.changedTeams).toHaveLength(2);
 
     const bostonTeam = result.changedTeams?.find(
@@ -545,7 +546,25 @@ describe('mutationPipeline compatibility boundary', () => {
   });
 
   it('applies storeOfferSheet from lineage snapshots and surfaces merged canonical player identity in the public result', async () => {
-    seedWorldMetadata(WORLD_ID, { parentWorldId: PARENT_WORLD_ID });
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    seedWorldMetadata(WORLD_ID, {
+      parentWorldId: PARENT_WORLD_ID,
+      asOfDate: governed.asOfDate,
+    });
+    seedDoc(`architect_worlds/${WORLD_ID}`, {
+      createdBy: 'user_boundary',
+      parentWorldId: PARENT_WORLD_ID,
+      asOfDate: governed.asOfDate,
+    });
     seedWorldMetadata(PARENT_WORLD_ID, { parentWorldId: null });
 
     const offeringTeam = makeTeam('BOS', []);
@@ -554,10 +573,12 @@ describe('mutationPipeline compatibility boundary', () => {
       contract: makeContract(7_500_000, {
         freeAgency: { type: 'RFA', year: 2026 },
       }),
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const homeTeamSnapshot = makeTeam('NYK', [homeSnapshotPlayer], {
       roster: ['rfa_1'],
       players: [homeSnapshotPlayer],
+      rightsLedger: governed.rightsLedger,
     });
 
     seedDoc(
@@ -592,29 +613,14 @@ describe('mutationPipeline compatibility boundary', () => {
         worldId: WORLD_ID,
         teamCode: 'BOS',
         playerId: 'rfa_1',
-        contract: makeContract(9_000_000, {
-          years: 2,
-          contractYears: 2,
-          totalValue: 18_000_000,
-          freeAgency: {
-            type: 'RFA',
-            year: 2026,
-            capHold: null,
-            qualifyingOffer: null,
-            earlyTerminationOption: null,
-            hasOption: false,
-            optionYear: null,
-            optionType: null,
-          },
-          rfaOfferSheet: true,
-          rfaOfferSheetOnly: true,
-        }),
+        contract: governed.contract,
+        offerSheetProposal: governed.proposal,
         signedUsing: 'Offer Sheet',
       },
       timestamp: FIXED_TIMESTAMP,
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
     expect(result.changedTeams).toHaveLength(2);
 
     const outgoingOfferSheet = result.changedTeams?.find(

--- a/src/tests/architect/mutationPipeline.compatibilityBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.compatibilityBoundary.test.ts
@@ -65,6 +65,23 @@ vi.mock('firebase/firestore', () => ({
     delete: testState.batchDelete,
     commit: testState.batchCommit,
   })),
+  runTransaction: vi.fn(
+    async (
+      _db: unknown,
+      updateFunction: (transaction: {
+        get: typeof testState.getDoc;
+        set: typeof testState.batchSet;
+        update: typeof testState.batchUpdate;
+        delete: typeof testState.batchDelete;
+      }) => Promise<unknown>
+    ) =>
+      updateFunction({
+        get: testState.getDoc,
+        set: testState.batchSet,
+        update: testState.batchUpdate,
+        delete: testState.batchDelete,
+      })
+  ),
   getDoc: testState.getDoc,
   serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
   collection: vi.fn((...segments: unknown[]) => segments.map(String).join('/')),

--- a/src/tests/architect/mutationPipeline.compatibilityBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.compatibilityBoundary.test.ts
@@ -603,6 +603,11 @@ describe('mutationPipeline compatibility boundary', () => {
       }
       throw new Error(`Unexpected team load: ${teamCode}`);
     });
+    testState.getPlayer.mockResolvedValue({
+      ...homeSnapshotPlayer,
+      displayName: 'Immutable Base Name',
+      rfaContext: { governedEvidence: governed.evidence },
+    });
 
     const result = await applyWorldMutation({
       userId: 'user_boundary',

--- a/src/tests/architect/mutationPipeline.currentStateIngressFunnel.test.ts
+++ b/src/tests/architect/mutationPipeline.currentStateIngressFunnel.test.ts
@@ -6,6 +6,7 @@ import {
   type ArchitectMutationPlayerRecord,
   type ArchitectMutationTeamRecord,
 } from '@/features/architect/utils/mutationPipeline';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 type ComputeArgs = Parameters<typeof computeWorldMutation>[0];
 type CurrentStateFor<TMutationType extends ComputeArgs['mutationType']> =
@@ -286,8 +287,20 @@ describe('mutationPipeline current-state ingress funnel', () => {
   });
 
   it('keeps offer-sheet family normalization working after the funnel split', () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: 'world_offer_sheet',
+      playerId: 'rfa_1',
+      homeTeamId: 'LAL',
+      offeringTeamId: 'BOS',
+      salariesByYear: [
+        { season: '2025-26', salary: 8_000_000 },
+        { season: '2026-27', salary: 8_400_000 },
+      ],
+    });
     const homePlayer = makePlayer('rfa_1', 'Offer Sheet Player', 7_000_000, 'LAL');
-    const homeTeam = makeTeam('LAL', [homePlayer]);
+    const homeTeam = makeTeam('LAL', [homePlayer], {
+      rightsLedger: governed.rightsLedger,
+    });
     const offeringTeam = makeTeam('BOS', []);
 
     const result = computeWorldMutation({
@@ -296,31 +309,8 @@ describe('mutationPipeline current-state ingress funnel', () => {
         teamCode: 'BOS',
         playerId: 'rfa_1',
         worldId: 'world_offer_sheet',
-        contract: makeContract(8_000_000, {
-          contractType: 'Offer Sheet',
-          years: 2,
-          contractYears: 2,
-          totalValue: 16_400_000,
-          rfaOfferSheet: true,
-          rfaOfferSheetOnly: true,
-          rfaOfferSheetStatus: 'PENDING_MATCH',
-          salariesByYear: [
-            {
-              season: '2025-26',
-              salary: 8_000_000,
-              capHit: 8_000_000,
-              guaranteed: true,
-              guaranteedAmount: 8_000_000,
-            },
-            {
-              season: '2026-27',
-              salary: 8_400_000,
-              capHit: 8_400_000,
-              guaranteed: true,
-              guaranteedAmount: 8_400_000,
-            },
-          ],
-        }),
+        contract: governed.contract,
+        offerSheetProposal: governed.proposal,
         signedUsing: 'TPMLE',
       },
       currentState: {
@@ -329,12 +319,14 @@ describe('mutationPipeline current-state ingress funnel', () => {
           ...homePlayer,
           teamCode: 'LAL',
           teamName: 'Team LAL',
+          rfaContext: { governedEvidence: governed.evidence },
         } as StoreOfferSheetCurrentState['player'],
         homeTeam: homeTeam as StoreOfferSheetCurrentState['homeTeam'],
         teamCode: 'BOS',
       } as StoreOfferSheetCurrentState,
       seasonId: SEASON_ID,
       timestamp: FIXED_TIMESTAMP,
+      asOfDate: governed.asOfDate,
     });
 
     expect(result.success).toBe(true);

--- a/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
+++ b/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
@@ -143,6 +143,7 @@ import {
   computeWorldMutation,
   type ArchitectMutationContract,
 } from '@/features/architect/utils/mutationPipeline';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const FIXED_TIMESTAMP = Date.parse('2026-04-10T12:00:00.000Z');
 const FIXED_TIMESTAMP_ISO = '2026-04-10T12:00:00.000Z';
@@ -279,6 +280,17 @@ describe('mutationPipeline current-state ingress hardening', () => {
   });
 
   it('keeps the committed match-offer-sheet flow working while stripping team-side compatibility bags at ingress', async () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'offer_sheet_1',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
     const mirroredOfferSheet = {
       id: 'offer_sheet_1',
       dedupKey: 'offer_sheet_1::BOS::NYK::rfa_1',
@@ -301,6 +313,7 @@ describe('mutationPipeline current-state ingress hardening', () => {
       ],
       createdAt: FIXED_TIMESTAMP_ISO,
       compatBag: { shouldDrop: true },
+      governedLifecycle: governed.lifecycle,
     };
     const homeTeam = makeTeam('NYK', [
       makePlayer('rfa_1', 'RFA One', 9_000_000, 'NYK'),
@@ -327,6 +340,7 @@ describe('mutationPipeline current-state ingress hardening', () => {
         homeTeamCode: 'NYK',
         offeringTeamCode: 'BOS',
         offerSheetId: 'offer_sheet_1',
+        offerSheetResolutionAt: governed.resolutionAt,
       },
       timestamp: FIXED_TIMESTAMP,
     });

--- a/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
+++ b/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
@@ -8,10 +8,15 @@ const testState = vi.hoisted(() => ({
   batchUpdate: vi.fn(),
   batchDelete: vi.fn(),
   batchCommit: vi.fn(async (): Promise<void> => undefined),
-  getDoc: vi.fn(async (): Promise<{ exists: () => boolean; data: () => DocShape }> => ({
-    exists: () => false,
-    data: () => null,
-  })),
+  getDoc: vi.fn(async (ref: unknown) => {
+    const rawPath = String(ref);
+    const path = rawPath.startsWith('db/') ? rawPath.slice(3) : rawPath;
+    const data = testState.docsByPath.get(path);
+    return {
+      exists: () => data !== null && data !== undefined,
+      data: () => data || {},
+    };
+  }),
   getTeam: vi.fn(),
   getPlayer: vi.fn(),
   getLeague: vi.fn(async (): Promise<unknown[]> => []),
@@ -60,6 +65,23 @@ vi.mock('firebase/firestore', () => ({
     delete: testState.batchDelete,
     commit: testState.batchCommit,
   })),
+  runTransaction: vi.fn(
+    async (
+      _db: unknown,
+      updateFunction: (transaction: {
+        get: typeof testState.getDoc;
+        set: typeof testState.batchSet;
+        update: typeof testState.batchUpdate;
+        delete: typeof testState.batchDelete;
+      }) => Promise<unknown>
+    ) =>
+      updateFunction({
+        get: testState.getDoc,
+        set: testState.batchSet,
+        update: testState.batchUpdate,
+        delete: testState.batchDelete,
+      })
+  ),
   getDoc: testState.getDoc,
   serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
   collection: vi.fn((...segments: unknown[]) => segments.map(String).join('/')),
@@ -323,6 +345,14 @@ describe('mutationPipeline current-state ingress hardening', () => {
     const offeringTeam = makeTeam('BOS', [], {
       offerSheets: [{ ...mirroredOfferSheet }],
     });
+    testState.docsByPath.set(
+      `architect_worlds/${WORLD_ID}/teams/NYK`,
+      homeTeam
+    );
+    testState.docsByPath.set(
+      `architect_worlds/${WORLD_ID}/teams/BOS`,
+      offeringTeam
+    );
 
     testState.getTeam.mockImplementation(async (_worldId: string, teamCode: string) => {
       if (teamCode === 'NYK') return homeTeam;

--- a/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
+++ b/src/tests/architect/mutationPipeline.currentStateIngressHardening.test.ts
@@ -165,6 +165,7 @@ import {
   computeWorldMutation,
   type ArchitectMutationContract,
 } from '@/features/architect/utils/mutationPipeline';
+import { buildGovernedOfferSheetAuthorization } from '@/features/architect/utils/offerSheets';
 import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const FIXED_TIMESTAMP = Date.parse('2026-04-10T12:00:00.000Z');
@@ -345,6 +346,26 @@ describe('mutationPipeline current-state ingress hardening', () => {
     const offeringTeam = makeTeam('BOS', [], {
       offerSheets: [{ ...mirroredOfferSheet }],
     });
+    const immutableBasePlayer = makePlayer(
+      'rfa_1',
+      'RFA One',
+      9_000_000,
+      'NYK',
+      { rfaContext: { governedEvidence: governed.evidence } }
+    );
+    testState.getPlayer.mockResolvedValue(immutableBasePlayer);
+    testState.docsByPath.set(
+      'architect_basePlayers/rfa_1',
+      immutableBasePlayer
+    );
+    testState.docsByPath.set(
+      `architect_worlds/${WORLD_ID}/offerSheetAuthorizations/${mirroredOfferSheet.id}`,
+      buildGovernedOfferSheetAuthorization({
+        lifecycle: governed.lifecycle,
+        offerSheetId: mirroredOfferSheet.id,
+        dedupKey: mirroredOfferSheet.dedupKey,
+      })
+    );
     testState.docsByPath.set(
       `architect_worlds/${WORLD_ID}/teams/NYK`,
       homeTeam

--- a/src/tests/architect/mutationPipeline.offerSheetCreation.emulator.test.ts
+++ b/src/tests/architect/mutationPipeline.offerSheetCreation.emulator.test.ts
@@ -1,0 +1,364 @@
+/**
+ * BZE-283 real-Firestore proof for governed Offer Sheet creation concurrency.
+ *
+ * Admin seeds only the immutable base player and world root because production
+ * Firestore rules prohibit browser creation of those documents. The owner Web
+ * SDK seeds the two starting Team snapshots. All Offer Sheet creation reads,
+ * computation, transaction writes, and proof reads use production code and the
+ * real Firestore emulator; no Firebase mocks or direct output seeding are used.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import admin from 'firebase-admin';
+import { signInAnonymously, signOut } from 'firebase/auth';
+import { collection, doc, getDoc, getDocs, setDoc } from 'firebase/firestore';
+
+import { db, auth } from '@/firebaseConfig';
+import {
+  computeWorldMutation,
+  persistWorldMutation,
+} from '@/features/architect/utils/mutationPipeline';
+import { loadStateForMutation } from '@/features/architect/utils/mutationPipeline.read.stateLoader';
+import { buildGeneralMutationCommittedTeamUpdates } from '@/features/architect/utils/mutationPipeline.read.persistence.snapshots';
+import { buildGovernedOfferSheetAuthorization } from '@/features/architect/utils/offerSheets';
+import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
+
+const WORLD_ID = 'bze_283_offer_sheet_creation_emulator';
+const PLAYER_ID = 'bze_283_creation_race_rfa';
+const HOME_TEAM = 'BOS';
+const OFFERING_TEAM = 'LAL';
+const SEASON_ID = '2025-26';
+const FIRST_TIMESTAMP = Date.parse('2025-07-08T14:00:01.000Z');
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+function makeStandardContract(salary: number) {
+  return {
+    contractType: 'Standard',
+    signingTeam: HOME_TEAM,
+    totalValue: salary,
+    salariesByYear: [
+      {
+        season: SEASON_ID,
+        salary,
+        capHit: salary,
+        guaranteed: true,
+        guaranteedAmount: salary,
+        option: null,
+      },
+    ],
+  };
+}
+
+function makePlayer({
+  playerId,
+  teamCode,
+  salary,
+  governedEvidence,
+}: {
+  playerId: string;
+  teamCode: string;
+  salary: number;
+  governedEvidence?: unknown;
+}) {
+  return {
+    id: playerId,
+    playerId,
+    player_id: playerId,
+    name: playerId,
+    displayName: playerId,
+    teamCode,
+    teamName: teamCode === HOME_TEAM ? 'Boston Celtics' : 'Los Angeles Lakers',
+    bio: { position: 'G', age: 24, experience: 3 },
+    contract: makeStandardContract(salary),
+    ...(governedEvidence === undefined
+      ? {}
+      : { rfaContext: { governedEvidence } }),
+    source: { provider: 'BZE-283 emulator fixture' },
+    lastUpdated: '2025-07-08T14:00:00.000Z',
+    version: '1.0.0',
+  };
+}
+
+function makeTeam({
+  teamCode,
+  players,
+  rightsLedger,
+}: {
+  teamCode: string;
+  players: ReturnType<typeof makePlayer>[];
+  rightsLedger?: unknown;
+}) {
+  const totalSalary = players.reduce(
+    (sum, player) =>
+      sum + Number(player.contract.salariesByYear[0]?.capHit || 0),
+    0
+  );
+  return {
+    teamCode,
+    teamName: teamCode === HOME_TEAM ? 'Boston Celtics' : 'Los Angeles Lakers',
+    season: SEASON_ID,
+    roster: players.map((player) => player.playerId),
+    players,
+    capHolds: [],
+    draftPicks: [],
+    entitlementIds: [],
+    tradeExceptions: [],
+    exceptionHistory: [],
+    offerSheets: [],
+    incomingOfferSheets: [],
+    totals: { totalSalary, capHit: totalSalary },
+    ...(rightsLedger === undefined ? {} : { rightsLedger }),
+  };
+}
+
+describe('BZE-283 governed Offer Sheet creation on the Firestore emulator', () => {
+  let adminDb: FirebaseFirestore.Firestore;
+  let userId = '';
+  let fixture: ReturnType<typeof makeGovernedOfferSheetFixture>;
+
+  beforeAll(async () => {
+    if (!process.env.FIRESTORE_EMULATOR_HOST) {
+      throw new Error(
+        'FIRESTORE_EMULATOR_HOST is required; this proof refuses non-emulator execution.'
+      );
+    }
+
+    if (admin.apps.length === 0) {
+      admin.initializeApp({
+        projectId: process.env.GCLOUD_PROJECT || 'scoutzero-bf1ae',
+      });
+    }
+    adminDb = admin.firestore();
+
+    await adminDb.recursiveDelete(adminDb.doc(`architect_worlds/${WORLD_ID}`));
+    await adminDb.doc(`architect_basePlayers/${PLAYER_ID}`).delete();
+
+    const credential = await signInAnonymously(auth);
+    userId = credential.user.uid;
+    fixture = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: PLAYER_ID,
+      homeTeamId: HOME_TEAM,
+      offeringTeamId: OFFERING_TEAM,
+      offerSheetId: 'bze-283-emulator-creation-race',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 10_000_000 },
+        { season: '2026-27', salary: 10_500_000 },
+      ],
+    });
+
+    const homePlayer = makePlayer({
+      playerId: PLAYER_ID,
+      teamCode: HOME_TEAM,
+      salary: 9_000_000,
+      governedEvidence: fixture.evidence,
+    });
+    const offeringPlayer = makePlayer({
+      playerId: 'bze_283_lal_keeper',
+      teamCode: OFFERING_TEAM,
+      salary: 7_000_000,
+    });
+
+    // These two roots are Admin-authored in production and cannot be created
+    // by a browser under firestore.rules. They are fixture setup, not proof
+    // output; all governed creation artifacts below come from production code.
+    await Promise.all([
+      adminDb.doc(`architect_worlds/${WORLD_ID}`).set({
+        worldId: WORLD_ID,
+        worldName: 'BZE-283 Offer Sheet Creation Emulator Proof',
+        name: 'BZE-283 Offer Sheet Creation Emulator Proof',
+        createdBy: userId,
+        currentSeason: SEASON_ID,
+        baselineSeason: SEASON_ID,
+        asOfDate: fixture.asOfDate,
+        parentWorldId: null,
+        childWorlds: [],
+        isArchived: false,
+        status: 'active',
+      }),
+      adminDb.doc(`architect_basePlayers/${PLAYER_ID}`).set(clone(homePlayer)),
+    ]);
+
+    // Initial mutable Team state is written as the authenticated world owner.
+    await Promise.all([
+      setDoc(
+        doc(db, 'architect_worlds', WORLD_ID, 'teams', HOME_TEAM),
+        clone(
+          makeTeam({
+            teamCode: HOME_TEAM,
+            players: [homePlayer],
+            rightsLedger: fixture.rightsLedger,
+          })
+        )
+      ),
+      setDoc(
+        doc(db, 'architect_worlds', WORLD_ID, 'teams', OFFERING_TEAM),
+        clone(makeTeam({ teamCode: OFFERING_TEAM, players: [offeringPlayer] }))
+      ),
+    ]);
+  }, 60_000);
+
+  afterAll(async () => {
+    await signOut(auth);
+    if (adminDb) {
+      await adminDb.recursiveDelete(
+        adminDb.doc(`architect_worlds/${WORLD_ID}`)
+      );
+      await adminDb.doc(`architect_basePlayers/${PLAYER_ID}`).delete();
+    }
+  });
+
+  it('commits exactly one complete creation and rejects its stale competitor without partial writes', async () => {
+    const payload = {
+      teamCode: OFFERING_TEAM,
+      playerId: PLAYER_ID,
+      worldId: WORLD_ID,
+      contract: {
+        ...fixture.contract,
+        contractType: 'Offer Sheet',
+      },
+      offerSheetProposal: fixture.proposal,
+      signedUsing: 'Cap Space',
+    };
+
+    // Both candidates consume the same persisted starting state before either
+    // transaction begins. The emulator then arbitrates the competing commits.
+    const [firstState, competingState] = await Promise.all([
+      loadStateForMutation(WORLD_ID, 'storeOfferSheet', payload),
+      loadStateForMutation(WORLD_ID, 'storeOfferSheet', payload),
+    ]);
+    const candidates = [firstState, competingState].map((currentState, index) =>
+      computeWorldMutation({
+        mutationType: 'storeOfferSheet',
+        payload,
+        currentState,
+        seasonId: SEASON_ID,
+        timestamp: FIRST_TIMESTAMP + index,
+        asOfDate: fixture.asOfDate,
+        worldId: WORLD_ID,
+      })
+    );
+    for (const candidate of candidates) {
+      expect(candidate.success, String(candidate.error)).toBe(true);
+    }
+
+    const results = await Promise.all(
+      candidates.map((candidate, index) =>
+        persistWorldMutation({
+          worldId: WORLD_ID,
+          seasonId: SEASON_ID,
+          mutationType: 'storeOfferSheet',
+          computeResult: candidate,
+          committedTeamUpdates: buildGeneralMutationCommittedTeamUpdates(
+            candidate.teamUpdates,
+            SEASON_ID
+          ),
+          timestamp: FIRST_TIMESTAMP + index,
+        })
+      )
+    );
+
+    const winnerIndexes = results
+      .map((result, index) => (result.success ? index : -1))
+      .filter((index) => index >= 0);
+    const loserIndexes = results
+      .map((result, index) => (!result.success ? index : -1))
+      .filter((index) => index >= 0);
+    expect(winnerIndexes).toHaveLength(1);
+    expect(loserIndexes).toHaveLength(1);
+
+    const winnerIndex = winnerIndexes[0] as number;
+    const loserIndex = loserIndexes[0] as number;
+    const winner = candidates[winnerIndex];
+    const loserResult = results[loserIndex];
+    expect(loserResult.error).toContain('changed before commit');
+
+    const expectedTeams = new Map(
+      buildGeneralMutationCommittedTeamUpdates(
+        winner.teamUpdates,
+        SEASON_ID
+      ).map(({ teamCode, team }) => [teamCode, team])
+    );
+    const [
+      homeSnapshot,
+      offeringSnapshot,
+      worldSnapshot,
+      eventSnapshots,
+      authorizationSnapshots,
+    ] = await Promise.all([
+      getDoc(doc(db, 'architect_worlds', WORLD_ID, 'teams', HOME_TEAM)),
+      getDoc(doc(db, 'architect_worlds', WORLD_ID, 'teams', OFFERING_TEAM)),
+      getDoc(doc(db, 'architect_worlds', WORLD_ID)),
+      getDocs(collection(db, 'architect_worlds', WORLD_ID, 'events')),
+      getDocs(
+        collection(db, 'architect_worlds', WORLD_ID, 'offerSheetAuthorizations')
+      ),
+    ]);
+
+    expect(homeSnapshot.data()).toEqual(expectedTeams.get(HOME_TEAM));
+    expect(offeringSnapshot.data()).toEqual(expectedTeams.get(OFFERING_TEAM));
+
+    const homeSheets = homeSnapshot.data()?.incomingOfferSheets;
+    const offeringSheets = offeringSnapshot.data()?.offerSheets;
+    expect(homeSheets).toHaveLength(1);
+    expect(offeringSheets).toHaveLength(1);
+    expect(homeSheets?.[0]).toEqual(offeringSheets?.[0]);
+
+    const winningLifecycle = GovernedOfferSheetLifecycleZ.parse(
+      winner.metadata?.governedOfferSheetLifecycle
+    );
+    const winningOfferSheetId = String(winner.metadata?.offerSheetId || '');
+    const winningDedupKey = String(winner.metadata?.dedupKey || '');
+    expect(offeringSheets?.[0]).toMatchObject({
+      id: winningOfferSheetId,
+      dedupKey: winningDedupKey,
+      playerId: PLAYER_ID,
+      homeTeamCode: HOME_TEAM,
+      offeringTeamCode: OFFERING_TEAM,
+    });
+
+    expect(authorizationSnapshots.docs).toHaveLength(1);
+    expect(authorizationSnapshots.docs[0]?.id).toBe(winningOfferSheetId);
+    expect(authorizationSnapshots.docs[0]?.data()).toEqual(
+      buildGovernedOfferSheetAuthorization({
+        lifecycle: winningLifecycle,
+        offerSheetId: winningOfferSheetId,
+        dedupKey: winningDedupKey,
+      })
+    );
+
+    expect(eventSnapshots.docs).toHaveLength(1);
+    expect(eventSnapshots.docs[0]?.data()).toMatchObject({
+      mutationType: 'storeOfferSheet',
+      timestamp: new Date(FIRST_TIMESTAMP + winnerIndex).toISOString(),
+      metadata: {
+        offerSheetId: winningOfferSheetId,
+        dedupKey: winningDedupKey,
+      },
+    });
+    expect(new Set(worldSnapshot.data()?.lastModifiedTeams)).toEqual(
+      new Set([HOME_TEAM, OFFERING_TEAM])
+    );
+
+    const losingOfferSheetId = String(
+      candidates[loserIndex].metadata?.offerSheetId || ''
+    );
+    if (losingOfferSheetId !== winningOfferSheetId) {
+      expect(
+        (
+          await getDoc(
+            doc(
+              db,
+              'architect_worlds',
+              WORLD_ID,
+              'offerSheetAuthorizations',
+              losingOfferSheetId
+            )
+          )
+        ).exists()
+      ).toBe(false);
+    }
+  }, 60_000);
+});

--- a/src/tests/architect/mutationPipeline.playerOverrideBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.playerOverrideBoundary.test.ts
@@ -439,6 +439,11 @@ describe('mutationPipeline player override boundary', () => {
       }
       throw new Error(`Unexpected team load: ${teamCode}`);
     });
+    testState.getPlayer.mockResolvedValue({
+      ...homeSnapshotPlayer,
+      displayName: 'Immutable Base Name',
+      rfaContext: { governedEvidence: governed.evidence },
+    });
 
     const result = await applyWorldMutation({
       userId: 'user_boundary',

--- a/src/tests/architect/mutationPipeline.playerOverrideBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.playerOverrideBoundary.test.ts
@@ -145,6 +145,7 @@ vi.mock('@/features/architect/utils/leagueInvariants', () => ({
 }));
 
 import { applyWorldMutation } from '@/features/architect/utils/mutationPipeline';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const WORLD_ID = 'world_player_override_boundary';
 const PARENT_WORLD_ID = 'world_player_override_boundary_parent';
@@ -375,7 +376,25 @@ describe('mutationPipeline player override boundary', () => {
   });
 
   it('storeOfferSheet still resolves canonical public player identity through the narrowed lineage merge boundary', async () => {
-    seedWorldMetadata(WORLD_ID, { parentWorldId: PARENT_WORLD_ID });
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    seedWorldMetadata(WORLD_ID, {
+      parentWorldId: PARENT_WORLD_ID,
+      asOfDate: governed.asOfDate,
+    });
+    seedDoc(`architect_worlds/${WORLD_ID}`, {
+      createdBy: 'user_boundary',
+      parentWorldId: PARENT_WORLD_ID,
+      asOfDate: governed.asOfDate,
+    });
     seedWorldMetadata(PARENT_WORLD_ID, { parentWorldId: null });
 
     const offeringTeam = makeTeam('BOS', []);
@@ -383,10 +402,12 @@ describe('mutationPipeline player override boundary', () => {
       contract: makeContract(7_500_000, {
         freeAgency: { type: 'RFA', year: 2026 },
       }),
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const homeTeamSnapshot = makeTeam('NYK', [homeSnapshotPlayer], {
       roster: ['rfa_1'],
       players: [homeSnapshotPlayer],
+      rightsLedger: governed.rightsLedger,
     });
 
     seedDoc(
@@ -428,29 +449,14 @@ describe('mutationPipeline player override boundary', () => {
         worldId: WORLD_ID,
         teamCode: 'BOS',
         playerId: 'rfa_1',
-        contract: makeContract(9_000_000, {
-          years: 2,
-          contractYears: 2,
-          totalValue: 18_000_000,
-          freeAgency: {
-            type: 'RFA',
-            year: 2026,
-            capHold: null,
-            qualifyingOffer: null,
-            earlyTerminationOption: null,
-            hasOption: false,
-            optionYear: null,
-            optionType: null,
-          },
-          rfaOfferSheet: true,
-          rfaOfferSheetOnly: true,
-        }),
+        contract: governed.contract,
+        offerSheetProposal: governed.proposal,
         signedUsing: 'Offer Sheet',
       },
       timestamp: FIXED_TIMESTAMP,
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
 
     const outgoingOfferSheet = result.changedTeams?.find(
       (update) => update.teamCode === 'BOS'

--- a/src/tests/architect/mutationPipeline.playerOverrideBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.playerOverrideBoundary.test.ts
@@ -65,6 +65,23 @@ vi.mock('firebase/firestore', () => ({
     delete: testState.batchDelete,
     commit: testState.batchCommit,
   })),
+  runTransaction: vi.fn(
+    async (
+      _db: unknown,
+      updateFunction: (transaction: {
+        get: typeof testState.getDoc;
+        set: typeof testState.batchSet;
+        update: typeof testState.batchUpdate;
+        delete: typeof testState.batchDelete;
+      }) => Promise<unknown>
+    ) =>
+      updateFunction({
+        get: testState.getDoc,
+        set: testState.batchSet,
+        update: testState.batchUpdate,
+        delete: testState.batchDelete,
+      })
+  ),
   getDoc: testState.getDoc,
   serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
   collection: vi.fn((...segments: unknown[]) => segments.map(String).join('/')),

--- a/src/tests/architect/mutationPipeline.rfaContextContract.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaContextContract.test.ts
@@ -168,6 +168,7 @@ vi.mock('@/features/architect/utils/leagueInvariants', () => ({
 }));
 
 import { applyWorldMutation } from '@/features/architect/utils/mutationPipeline';
+import { buildGovernedOfferSheetAuthorization } from '@/features/architect/utils/offerSheets';
 import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const WORLD_ID = 'world_rfa_context_contract';
@@ -527,6 +528,23 @@ describe('mutationPipeline rfaContext contract', () => {
         retainedUntilFinalize: true,
       },
     });
+    const immutableHomePlayer = {
+      ...homePlayer,
+      rfaContext: { governedEvidence: governed.evidence },
+    };
+    testState.docsByPath.set(
+      'architect_basePlayers/rfa_1',
+      immutableHomePlayer
+    );
+    testState.getPlayer.mockResolvedValue(immutableHomePlayer);
+    testState.docsByPath.set(
+      `architect_worlds/${WORLD_ID}/offerSheetAuthorizations/${offerSheet.id}`,
+      buildGovernedOfferSheetAuthorization({
+        lifecycle: governed.lifecycle,
+        offerSheetId: offerSheet.id,
+        dedupKey: offerSheet.dedupKey,
+      })
+    );
     const homeTeam = makeTeam('NYK', [homePlayer], {
       incomingOfferSheets: [offerSheet],
     });

--- a/src/tests/architect/mutationPipeline.rfaContextContract.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaContextContract.test.ts
@@ -151,6 +151,7 @@ vi.mock('@/features/architect/utils/leagueInvariants', () => ({
 }));
 
 import { applyWorldMutation } from '@/features/architect/utils/mutationPipeline';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const WORLD_ID = 'world_rfa_context_contract';
 const SEASON_ID = '2025-26';
@@ -453,6 +454,22 @@ describe('mutationPipeline rfaContext contract', () => {
   });
 
   it('finalizeMatchedOfferSheet still strips the narrowed rfaContext sidecar after resolution', async () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'os_rfa_1',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    testState.docsByPath.set(`architect_worlds/${WORLD_ID}`, {
+      createdBy: 'user_boundary',
+      parentWorldId: null,
+      asOfDate: governed.asOfDate,
+    });
     const offerSheet = {
       id: 'os_rfa_1',
       dedupKey: `os:${WORLD_ID}:BOS:rfa_1:${SEASON_ID}`,
@@ -482,6 +499,7 @@ describe('mutationPipeline rfaContext contract', () => {
       ],
       status: 'MATCHED',
       createdAt: FIXED_TIMESTAMP_ISO,
+      governedLifecycle: governed.lifecycle,
     };
     const homePlayer = makePlayer('rfa_1', 'Home Player', 7_500_000, 'NYK', {
       rfaOfferSheet: true,
@@ -518,6 +536,7 @@ describe('mutationPipeline rfaContext contract', () => {
         offeringTeamCode: 'BOS',
         offerSheetId: 'os_rfa_1',
         dedupKey: `os:${WORLD_ID}:BOS:rfa_1:${SEASON_ID}`,
+        offerSheetResolutionAt: governed.resolutionAt,
       },
       timestamp: FIXED_TIMESTAMP,
     });

--- a/src/tests/architect/mutationPipeline.rfaContextContract.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaContextContract.test.ts
@@ -71,6 +71,23 @@ vi.mock('firebase/firestore', () => ({
     delete: testState.batchDelete,
     commit: testState.batchCommit,
   })),
+  runTransaction: vi.fn(
+    async (
+      _db: unknown,
+      updateFunction: (transaction: {
+        get: typeof testState.getDoc;
+        set: typeof testState.batchSet;
+        update: typeof testState.batchUpdate;
+        delete: typeof testState.batchDelete;
+      }) => Promise<unknown>
+    ) =>
+      updateFunction({
+        get: testState.getDoc,
+        set: testState.batchSet,
+        update: testState.batchUpdate,
+        delete: testState.batchDelete,
+      })
+  ),
   getDoc: testState.getDoc,
   serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
   collection: vi.fn((...segments: unknown[]) => segments.map(String).join('/')),
@@ -516,6 +533,14 @@ describe('mutationPipeline rfaContext contract', () => {
     const offeringTeam = makeTeam('BOS', [], {
       offerSheets: [offerSheet],
     });
+    testState.docsByPath.set(
+      `architect_worlds/${WORLD_ID}/teams/NYK`,
+      homeTeam
+    );
+    testState.docsByPath.set(
+      `architect_worlds/${WORLD_ID}/teams/BOS`,
+      offeringTeam
+    );
 
     testState.getTeam.mockImplementation(
       async (_worldId: string, teamCode: string) => {

--- a/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
@@ -40,18 +40,25 @@ const testState = vi.hoisted(() => ({
       bio:
         base.bio || override.bio
           ? {
-              ...((base.bio as Record<string, unknown> | null | undefined) || {}),
-              ...((override.bio as Record<string, unknown> | null | undefined) ||
+              ...((base.bio as Record<string, unknown> | null | undefined) ||
                 {}),
+              ...((override.bio as
+                | Record<string, unknown>
+                | null
+                | undefined) || {}),
             }
           : undefined,
       contract:
         base.contract || override.contract
           ? {
-              ...((base.contract as Record<string, unknown> | null | undefined) ||
-                {}),
-              ...((override.contract as Record<string, unknown> | null | undefined) ||
-                {}),
+              ...((base.contract as
+                | Record<string, unknown>
+                | null
+                | undefined) || {}),
+              ...((override.contract as
+                | Record<string, unknown>
+                | null
+                | undefined) || {}),
             }
           : undefined,
     })
@@ -103,7 +110,11 @@ vi.mock('@/features/architect/utils/tradeMachine', () => ({
 vi.mock('@/features/architect/utils/capLegalityValidation', () => ({
   validateSigning: vi.fn(() => ({ valid: true, violations: [], warnings: [] })),
   validateWaive: vi.fn(() => ({ valid: true, violations: [], warnings: [] })),
-  validateExtension: vi.fn(() => ({ valid: true, violations: [], warnings: [] })),
+  validateExtension: vi.fn(() => ({
+    valid: true,
+    violations: [],
+    warnings: [],
+  })),
   validateOptionDecision: vi.fn(() => ({
     valid: true,
     violations: [],
@@ -151,6 +162,7 @@ vi.mock('@/features/architect/utils/leagueInvariants', () => ({
 }));
 
 import { applyWorldMutation } from '@/features/architect/utils/mutationPipeline';
+import { resolveStoreOfferSheetAuthority } from '@/features/architect/utils/mutationPipeline.read.stateLoader';
 import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const WORLD_ID = 'world_rfa_sidecar_boundary';
@@ -303,7 +315,9 @@ describe('mutationPipeline RFA sidecar boundary', () => {
           ? input.teams.map((team) => ({
               teamCode: team.teamCode ?? null,
               legal: true,
-              incomingPlayers: Array.isArray(team.receives) ? team.receives : [],
+              incomingPlayers: Array.isArray(team.receives)
+                ? team.receives
+                : [],
             }))
           : [],
       })
@@ -351,10 +365,7 @@ describe('mutationPipeline RFA sidecar boundary', () => {
       rightsLedger: governed.rightsLedger,
     });
 
-    seedDoc(
-      `architect_worlds/${PARENT_WORLD_ID}/teams/NYK`,
-      homeTeamSnapshot
-    );
+    seedDoc(`architect_worlds/${PARENT_WORLD_ID}/teams/NYK`, homeTeamSnapshot);
     seedDoc(`architect_worlds/${WORLD_ID}/teams/NYK`, null);
     seedDoc(`architect_worlds/${WORLD_ID}/teams/NYK/players/rfa_1`, {
       playerId: 'rfa_1',
@@ -418,6 +429,67 @@ describe('mutationPipeline RFA sidecar boundary', () => {
     });
   });
 
+  it('strips governed RFA evidence authored only by a mutable player override', async () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'os_rfa_1',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    seedWorldMetadata(WORLD_ID, {
+      parentWorldId: PARENT_WORLD_ID,
+      asOfDate: governed.asOfDate,
+    });
+    seedWorldMetadata(PARENT_WORLD_ID, { parentWorldId: null });
+
+    const offeringTeam = makeTeam('BOS', []);
+    const sourcePlayerWithoutEvidence = makePlayer(
+      'rfa_1',
+      'Source Player',
+      7_500_000,
+      'NYK',
+      {
+        contract: makeContract(7_500_000, {
+          freeAgency: { type: 'RFA', year: 2026 },
+        }),
+      }
+    );
+    seedDoc(
+      `architect_worlds/${PARENT_WORLD_ID}/teams/NYK`,
+      makeTeam('NYK', [sourcePlayerWithoutEvidence], {
+        roster: ['rfa_1'],
+        players: [sourcePlayerWithoutEvidence],
+        rightsLedger: governed.rightsLedger,
+      })
+    );
+    seedDoc(`architect_worlds/${WORLD_ID}/teams/NYK`, null);
+    seedDoc(`architect_worlds/${WORLD_ID}/teams/NYK/players/rfa_1`, {
+      playerId: 'rfa_1',
+      displayName: 'Override Player',
+      rfaContext: { governedEvidence: governed.evidence },
+    });
+    testState.getTeam.mockImplementation(
+      async (_worldId: string, teamCode: string) => {
+        if (teamCode === 'BOS') return offeringTeam;
+        throw new Error(`Unexpected team load: ${teamCode}`);
+      }
+    );
+
+    const authority = await resolveStoreOfferSheetAuthority({
+      worldId: WORLD_ID,
+      offeringTeamCode: 'BOS',
+      playerId: 'rfa_1',
+    });
+
+    expect(authority.player.rfaContext?.governedEvidence).toBeUndefined();
+    expect(authority.player.displayName).toBe('Override Player');
+  });
+
   it('executeTrade writes the normalized player-level RFA sidecar through the persisted override payload', async () => {
     const playerA = makePlayer('player_a', 'Player A', 10_000_000, 'LAL', {
       tradeTo: 'BOS',
@@ -471,7 +543,9 @@ describe('mutationPipeline RFA sidecar boundary', () => {
     expect(result.success).toBe(true);
 
     const destinationPlayerWrite = testState.batchSet.mock.calls.find(([ref]) =>
-      String(ref).includes(`architect_worlds/${WORLD_ID}/teams/BOS/players/player_a`)
+      String(ref).includes(
+        `architect_worlds/${WORLD_ID}/teams/BOS/players/player_a`
+      )
     );
     const writtenPlayer = destinationPlayerWrite?.[1] as
       | Record<string, unknown>
@@ -584,7 +658,9 @@ describe('mutationPipeline RFA sidecar boundary', () => {
     expect(result.success).toBe(true);
 
     const matchedPlayerWrite = testState.batchSet.mock.calls.find(([ref]) =>
-      String(ref).includes(`architect_worlds/${WORLD_ID}/teams/NYK/players/rfa_1`)
+      String(ref).includes(
+        `architect_worlds/${WORLD_ID}/teams/NYK/players/rfa_1`
+      )
     );
     const writtenPlayer = matchedPlayerWrite?.[1] as
       | Record<string, unknown>

--- a/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
@@ -490,6 +490,72 @@ describe('mutationPipeline RFA sidecar boundary', () => {
     expect(authority.player.displayName).toBe('Override Player');
   });
 
+  it('loads immutable base evidence for cap-hold-only RFA ownership', async () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'os_rfa_1',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    seedWorldMetadata(WORLD_ID, { parentWorldId: null });
+
+    const immutableBasePlayer = makePlayer(
+      'rfa_1',
+      'Base Player',
+      7_500_000,
+      'NYK',
+      {
+        contract: makeContract(7_500_000, {
+          freeAgency: { type: 'RFA', year: 2026 },
+        }),
+      }
+    );
+    seedDoc(
+      `architect_worlds/${WORLD_ID}/teams/NYK`,
+      makeTeam('NYK', [], {
+        roster: [],
+        players: [],
+        capHolds: [{ playerId: 'rfa_1', active: true, isSigned: false }],
+        rightsLedger: governed.rightsLedger,
+      })
+    );
+    seedDoc(`architect_worlds/${WORLD_ID}/teams/NYK/players/rfa_1`, {
+      playerId: 'rfa_1',
+      displayName: 'Override Player',
+      rfaContext: { governedEvidence: governed.evidence },
+    });
+    testState.getTeam.mockImplementation(
+      async (_worldId: string, teamCode: string) => {
+        if (teamCode === 'BOS') return makeTeam('BOS', []);
+        throw new Error(`Unexpected team load: ${teamCode}`);
+      }
+    );
+    testState.getPlayer.mockImplementation(
+      async (requestedWorldId: string | null) =>
+        requestedWorldId === null
+          ? immutableBasePlayer
+          : {
+              ...immutableBasePlayer,
+              rfaContext: { governedEvidence: governed.evidence },
+            }
+    );
+
+    const authority = await resolveStoreOfferSheetAuthority({
+      worldId: WORLD_ID,
+      offeringTeamCode: 'BOS',
+      playerId: 'rfa_1',
+    });
+
+    expect(testState.getPlayer).toHaveBeenCalledWith(null, 'NYK', 'rfa_1');
+    expect(authority.player.rfaContext?.governedEvidence).toBeUndefined();
+    expect(authority.player.displayName).toBe('Override Player');
+  });
+
   it('executeTrade writes the normalized player-level RFA sidecar through the persisted override payload', async () => {
     const playerA = makePlayer('player_a', 'Player A', 10_000_000, 'LAL', {
       tradeTo: 'BOS',

--- a/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
@@ -180,6 +180,7 @@ vi.mock('@/features/architect/utils/leagueInvariants', () => ({
 
 import { applyWorldMutation } from '@/features/architect/utils/mutationPipeline';
 import { resolveStoreOfferSheetAuthority } from '@/features/architect/utils/mutationPipeline.read.stateLoader';
+import { buildGovernedOfferSheetAuthorization } from '@/features/architect/utils/offerSheets';
 import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const WORLD_ID = 'world_rfa_sidecar_boundary';
@@ -776,6 +777,20 @@ describe('mutationPipeline RFA sidecar boundary', () => {
     const offeringTeam = makeTeam('BOS', [], {
       offerSheets: [offerSheet],
     });
+    const immutableBasePlayer = {
+      ...homePlayer,
+      rfaContext: { governedEvidence: governed.evidence },
+    };
+    testState.getPlayer.mockResolvedValue(immutableBasePlayer);
+    seedDoc('architect_basePlayers/rfa_1', immutableBasePlayer);
+    seedDoc(
+      `architect_worlds/${WORLD_ID}/offerSheetAuthorizations/${offerSheet.id}`,
+      buildGovernedOfferSheetAuthorization({
+        lifecycle: governed.lifecycle,
+        offerSheetId: offerSheet.id,
+        dedupKey: offerSheet.dedupKey,
+      })
+    );
     seedDoc(`architect_worlds/${WORLD_ID}/teams/NYK`, homeTeam);
     seedDoc(`architect_worlds/${WORLD_ID}/teams/BOS`, offeringTeam);
 

--- a/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
@@ -151,6 +151,7 @@ vi.mock('@/features/architect/utils/leagueInvariants', () => ({
 }));
 
 import { applyWorldMutation } from '@/features/architect/utils/mutationPipeline';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 const WORLD_ID = 'world_rfa_sidecar_boundary';
 const PARENT_WORLD_ID = 'world_rfa_sidecar_boundary_parent';
@@ -310,7 +311,25 @@ describe('mutationPipeline RFA sidecar boundary', () => {
   });
 
   it('storeOfferSheet still resolves canonical public player identity through lineage merge output', async () => {
-    seedWorldMetadata(WORLD_ID, { parentWorldId: PARENT_WORLD_ID });
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    seedWorldMetadata(WORLD_ID, {
+      parentWorldId: PARENT_WORLD_ID,
+      asOfDate: governed.asOfDate,
+    });
+    seedDoc(`architect_worlds/${WORLD_ID}`, {
+      createdBy: 'user_boundary',
+      parentWorldId: PARENT_WORLD_ID,
+      asOfDate: governed.asOfDate,
+    });
     seedWorldMetadata(PARENT_WORLD_ID, { parentWorldId: null });
 
     const offeringTeam = makeTeam('BOS', []);
@@ -323,11 +342,13 @@ describe('mutationPipeline RFA sidecar boundary', () => {
         contract: makeContract(7_500_000, {
           freeAgency: { type: 'RFA', year: 2026 },
         }),
+        rfaContext: { governedEvidence: governed.evidence },
       }
     );
     const homeTeamSnapshot = makeTeam('NYK', [homeSnapshotPlayer], {
       roster: ['rfa_1'],
       players: [homeSnapshotPlayer],
+      rightsLedger: governed.rightsLedger,
     });
 
     seedDoc(
@@ -368,29 +389,14 @@ describe('mutationPipeline RFA sidecar boundary', () => {
         worldId: WORLD_ID,
         teamCode: 'BOS',
         playerId: 'rfa_1',
-        contract: makeContract(9_000_000, {
-          years: 2,
-          contractYears: 2,
-          totalValue: 18_000_000,
-          freeAgency: {
-            type: 'RFA',
-            year: 2026,
-            capHold: null,
-            qualifyingOffer: null,
-            earlyTerminationOption: null,
-            hasOption: false,
-            optionYear: null,
-            optionType: null,
-          },
-          rfaOfferSheet: true,
-          rfaOfferSheetOnly: true,
-        }),
+        contract: governed.contract,
+        offerSheetProposal: governed.proposal,
         signedUsing: 'Offer Sheet',
       },
       timestamp: FIXED_TIMESTAMP,
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
 
     const outgoingOfferSheet = result.changedTeams?.find(
       (update) => update.teamCode === 'BOS'
@@ -488,6 +494,23 @@ describe('mutationPipeline RFA sidecar boundary', () => {
   });
 
   it('finalizeMatchedOfferSheet omits the player-level RFA sidecar from the persisted override payload', async () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'os_rfa_1',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    seedWorldMetadata(WORLD_ID, { asOfDate: governed.asOfDate });
+    seedDoc(`architect_worlds/${WORLD_ID}`, {
+      createdBy: 'user_boundary',
+      parentWorldId: null,
+      asOfDate: governed.asOfDate,
+    });
     const offerSheet = {
       id: 'os_rfa_1',
       dedupKey: `os:${WORLD_ID}:BOS:rfa_1:${SEASON_ID}`,
@@ -517,6 +540,7 @@ describe('mutationPipeline RFA sidecar boundary', () => {
       ],
       status: 'MATCHED',
       createdAt: FIXED_TIMESTAMP_ISO,
+      governedLifecycle: governed.lifecycle,
     };
     const homePlayer = makePlayer('rfa_1', 'Home Player', 7_500_000, 'NYK', {
       rfaOfferSheet: true,
@@ -552,6 +576,7 @@ describe('mutationPipeline RFA sidecar boundary', () => {
         offeringTeamCode: 'BOS',
         offerSheetId: 'os_rfa_1',
         dedupKey: `os:${WORLD_ID}:BOS:rfa_1:${SEASON_ID}`,
+        offerSheetResolutionAt: governed.resolutionAt,
       },
       timestamp: FIXED_TIMESTAMP,
     });

--- a/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
+++ b/src/tests/architect/mutationPipeline.rfaSidecarBoundary.test.ts
@@ -78,6 +78,23 @@ vi.mock('firebase/firestore', () => ({
     delete: testState.batchDelete,
     commit: testState.batchCommit,
   })),
+  runTransaction: vi.fn(
+    async (
+      _db: unknown,
+      updateFunction: (transaction: {
+        get: typeof testState.getDoc;
+        set: typeof testState.batchSet;
+        update: typeof testState.batchUpdate;
+        delete: typeof testState.batchDelete;
+      }) => Promise<unknown>
+    ) =>
+      updateFunction({
+        get: testState.getDoc,
+        set: testState.batchSet,
+        update: testState.batchUpdate,
+        delete: testState.batchDelete,
+      })
+  ),
   getDoc: testState.getDoc,
   serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
   collection: vi.fn((...segments: unknown[]) => segments.map(String).join('/')),
@@ -390,6 +407,11 @@ describe('mutationPipeline RFA sidecar boundary', () => {
         throw new Error(`Unexpected team load: ${teamCode}`);
       }
     );
+    testState.getPlayer.mockResolvedValue({
+      ...homeSnapshotPlayer,
+      displayName: 'Immutable Base Name',
+      rfaContext: { governedEvidence: governed.evidence },
+    });
 
     const result = await applyWorldMutation({
       userId: 'user_boundary',
@@ -479,6 +501,7 @@ describe('mutationPipeline RFA sidecar boundary', () => {
         throw new Error(`Unexpected team load: ${teamCode}`);
       }
     );
+    testState.getPlayer.mockResolvedValue(sourcePlayerWithoutEvidence);
 
     const authority = await resolveStoreOfferSheetAuthority({
       worldId: WORLD_ID,
@@ -488,6 +511,63 @@ describe('mutationPipeline RFA sidecar boundary', () => {
 
     expect(authority.player.rfaContext?.governedEvidence).toBeUndefined();
     expect(authority.player.displayName).toBe('Override Player');
+  });
+
+  it('strips governed RFA evidence authored only in a mutable Team snapshot', async () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: WORLD_ID,
+      playerId: 'rfa_1',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'os_rfa_1',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_000_000 },
+      ],
+    });
+    seedWorldMetadata(WORLD_ID, { parentWorldId: null });
+
+    const immutableBasePlayer = makePlayer(
+      'rfa_1',
+      'Immutable Base Player',
+      7_500_000,
+      'NYK',
+      {
+        contract: makeContract(7_500_000, {
+          freeAgency: { type: 'RFA', year: 2026 },
+        }),
+      }
+    );
+    const mutableSnapshotPlayer = {
+      ...immutableBasePlayer,
+      displayName: 'Mutable Snapshot Name',
+      rfaContext: { governedEvidence: governed.evidence },
+    };
+    seedDoc(
+      `architect_worlds/${WORLD_ID}/teams/NYK`,
+      makeTeam('NYK', [mutableSnapshotPlayer], {
+        roster: ['rfa_1'],
+        players: [mutableSnapshotPlayer],
+        rightsLedger: governed.rightsLedger,
+      })
+    );
+    testState.getTeam.mockImplementation(
+      async (_worldId: string, teamCode: string) => {
+        if (teamCode === 'BOS') return makeTeam('BOS', []);
+        throw new Error(`Unexpected team load: ${teamCode}`);
+      }
+    );
+    testState.getPlayer.mockResolvedValue(immutableBasePlayer);
+
+    const authority = await resolveStoreOfferSheetAuthority({
+      worldId: WORLD_ID,
+      offeringTeamCode: 'BOS',
+      playerId: 'rfa_1',
+    });
+
+    expect(testState.getPlayer).toHaveBeenCalledWith(null, 'NYK', 'rfa_1');
+    expect(authority.player.displayName).toBe('Mutable Snapshot Name');
+    expect(authority.player.rfaContext?.governedEvidence).toBeUndefined();
   });
 
   it('loads immutable base evidence for cap-hold-only RFA ownership', async () => {
@@ -696,6 +776,8 @@ describe('mutationPipeline RFA sidecar boundary', () => {
     const offeringTeam = makeTeam('BOS', [], {
       offerSheets: [offerSheet],
     });
+    seedDoc(`architect_worlds/${WORLD_ID}/teams/NYK`, homeTeam);
+    seedDoc(`architect_worlds/${WORLD_ID}/teams/BOS`, offeringTeam);
 
     testState.getTeam.mockImplementation(
       async (_worldId: string, teamCode: string) => {

--- a/src/tests/architect/mutationPipeline.sharedTeamNormalizerClosure.test.ts
+++ b/src/tests/architect/mutationPipeline.sharedTeamNormalizerClosure.test.ts
@@ -6,6 +6,7 @@ import {
   type ArchitectMutationPlayerRecord,
   type ArchitectMutationTeamRecord,
 } from '@/features/architect/utils/mutationPipeline';
+import { makeGovernedOfferSheetFixture } from '../../../tests/fixtures/architect/governedOfferSheet';
 
 type ComputeArgs = Parameters<typeof computeWorldMutation>[0];
 type CurrentStateFor<TMutationType extends ComputeArgs['mutationType']> =
@@ -322,6 +323,17 @@ describe('mutationPipeline shared team normalizer closure', () => {
   });
 
   it('keeps offer-sheet mirror updates working while preserving roster and exception state', () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: 'world-shared-team-normalizer',
+      playerId: 'rfa_match',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'sheet_match',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_500_000 },
+      ],
+    });
     const homePlayer = makePlayer('rfa_match', 'RFA Match', 7_000_000, 'NYK');
     const offerSheet = makeOfferSheet('rfa_match', {
       id: 'sheet_match',
@@ -329,6 +341,7 @@ describe('mutationPipeline shared team normalizer closure', () => {
       homeTeamCode: 'NYK',
       offeringTeamCode: 'BOS',
       status: 'PENDING_MATCH',
+      governedLifecycle: governed.lifecycle,
     });
     const homeTeam = makeTeam('NYK', [homePlayer], {
       incomingOfferSheets: [offerSheet],
@@ -359,6 +372,7 @@ describe('mutationPipeline shared team normalizer closure', () => {
         homeTeamCode: 'NYK',
         offeringTeamCode: 'BOS',
         offerSheetId: 'sheet_match',
+        offerSheetResolutionAt: governed.resolutionAt,
       },
       currentState: {
         homeTeam: homeTeam as MatchOfferSheetCurrentState['homeTeam'],
@@ -368,6 +382,7 @@ describe('mutationPipeline shared team normalizer closure', () => {
       } as MatchOfferSheetCurrentState,
       seasonId: SEASON_ID,
       timestamp: FIXED_TIMESTAMP,
+      asOfDate: governed.asOfDate,
     });
 
     expect(result.success).toBe(true);
@@ -403,6 +418,17 @@ describe('mutationPipeline shared team normalizer closure', () => {
   });
 
   it('keeps offer-sheet finalization working after the resolution-lane split', () => {
+    const governed = makeGovernedOfferSheetFixture({
+      worldId: 'world-shared-team-normalizer',
+      playerId: 'rfa_finalize',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'BOS',
+      offerSheetId: 'sheet_finalize',
+      salariesByYear: [
+        { season: SEASON_ID, salary: 9_000_000 },
+        { season: '2026-27', salary: 9_500_000 },
+      ],
+    });
     const homePlayer = makePlayer('rfa_finalize', 'RFA Finalize', 7_000_000, 'NYK');
     const matchedOfferSheet = makeOfferSheet('rfa_finalize', {
       id: 'sheet_finalize',
@@ -411,6 +437,7 @@ describe('mutationPipeline shared team normalizer closure', () => {
       offeringTeamCode: 'BOS',
       status: 'MATCHED',
       matchedAt: FIXED_TIMESTAMP_ISO,
+      governedLifecycle: governed.lifecycle,
     });
     const homeTeam = makeTeam('NYK', [homePlayer], {
       incomingOfferSheets: [matchedOfferSheet],
@@ -451,6 +478,7 @@ describe('mutationPipeline shared team normalizer closure', () => {
         offeringTeamCode: 'BOS',
         offerSheetId: 'sheet_finalize',
         dedupKey: 'sheet_finalize',
+        offerSheetResolutionAt: governed.resolutionAt,
       },
       currentState: {
         homeTeam:
@@ -461,6 +489,7 @@ describe('mutationPipeline shared team normalizer closure', () => {
       } as FinalizeMatchedOfferSheetCurrentState,
       seasonId: SEASON_ID,
       timestamp: FIXED_TIMESTAMP,
+      asOfDate: governed.asOfDate,
     });
 
     expect(result.success).toBe(true);

--- a/src/tests/architect/offerSheets_closure.gate.test.ts
+++ b/src/tests/architect/offerSheets_closure.gate.test.ts
@@ -237,9 +237,11 @@ describe('Gate 2: loadStateForMutation loads BOTH teams for offer sheet mutation
   });
 
   it('returns both homeTeam and offeringTeam from state loader', () => {
-    // Wave 4 Step 4c: ternary bodies in return block require wider constraints
+    // The exact stale-write receipts now follow the three required state fields
+    // in this return block, so keep the structural gate focused on those fields
+    // while allowing the receipt object before the closing brace.
     const returnsBothTeams =
-      /return\s*\{[\s\S]{0,600}homeTeam[\s\S]{0,600}offeringTeam[\s\S]{0,600}offerSheetId[\s\S]{0,300}\}/.test(
+      /return\s*\{[\s\S]{0,600}homeTeam[\s\S]{0,600}offeringTeam[\s\S]{0,600}offerSheetId[\s\S]{0,1200}\}/.test(
         content
       );
     expect(returnsBothTeams).toBe(true);

--- a/src/tests/architect/offerSheets_closure.gate.test.ts
+++ b/src/tests/architect/offerSheets_closure.gate.test.ts
@@ -470,7 +470,7 @@ describe('Gate 6: Finalize matched recomputes home totals (E1)', () => {
 
   it('removes offer sheet from home team incomingOfferSheets', () => {
     const removesFromHome =
-      /computeMatchedOfferSheetOutcome[\s\S]{0,2500}updatedHomeTeam\.incomingOfferSheets\s*=[\s\S]{0,200}removeOfferSheetEntries/.test(
+      /computeMatchedOfferSheetOutcome[\s\S]{0,4500}updatedHomeTeam\.incomingOfferSheets\s*=[\s\S]{0,200}removeOfferSheetEntries/.test(
         content
       );
     expect(removesFromHome).toBe(true);

--- a/src/tests/architect/useArchitectActions.freeAgency.test.tsx
+++ b/src/tests/architect/useArchitectActions.freeAgency.test.tsx
@@ -16,7 +16,10 @@ const mutationMocks = vi.hoisted(() => ({
   computeWorldMutation: vi.fn(),
   findUpdatedTeamSnapshot: vi.fn(
     (
-      teamUpdates: Array<{ teamCode?: string; team?: unknown }> | null | undefined,
+      teamUpdates:
+        | Array<{ teamCode?: string; team?: unknown }>
+        | null
+        | undefined,
       targetTeamCode: string
     ) =>
       (teamUpdates || []).find(
@@ -25,7 +28,10 @@ const mutationMocks = vi.hoisted(() => ({
   ),
   findCommittedTeamSnapshot: vi.fn(
     (
-      teamUpdates: Array<{ teamCode?: string; team?: unknown }> | null | undefined,
+      teamUpdates:
+        | Array<{ teamCode?: string; team?: unknown }>
+        | null
+        | undefined,
       targetTeamCode: string
     ) =>
       (teamUpdates || []).find(
@@ -81,7 +87,9 @@ vi.mock('react-hot-toast', () => ({
   default: toastMocks,
 }));
 
-type FreeAgencyPlayerFixture = Parameters<UseArchitectActionsReturn['handleSign']>[0];
+type FreeAgencyPlayerFixture = Parameters<
+  UseArchitectActionsReturn['handleSign']
+>[0];
 type FreeAgencyContractFixture = Parameters<
   UseArchitectActionsReturn['handleSign']
 >[1];
@@ -130,11 +138,13 @@ type FreeAgencyTradeInput = Parameters<
 type FreeAgencyTeamCapSheet = NonNullable<
   UseArchitectActionsParams['state']['teamCapSheet']
 >;
-type FreeAgencyStateCapSheet = UseArchitectActionsParams['state']['teamCapSheet'];
-type FreeAgencyCapHold = NonNullable<FreeAgencyTeamCapSheet['capHolds']>[number];
-type StateSetterValue<T> = T extends Dispatch<SetStateAction<infer TValue>>
-  ? TValue
-  : never;
+type FreeAgencyStateCapSheet =
+  UseArchitectActionsParams['state']['teamCapSheet'];
+type FreeAgencyCapHold = NonNullable<
+  FreeAgencyTeamCapSheet['capHolds']
+>[number];
+type StateSetterValue<T> =
+  T extends Dispatch<SetStateAction<infer TValue>> ? TValue : never;
 type FreeAgencySelectedPlayerState = StateSetterValue<
   UseArchitectActionsParams['state']['setSelectedPlayer']
 >;
@@ -212,7 +222,8 @@ const baseTeamFixture = {
 } satisfies FreeAgencyTeamCapSheet;
 
 function buildSignedTeamFixture(
-  baseTeam: Partial<FreeAgencyTeamCapSheet> & Record<string, unknown> = baseTeamFixture,
+  baseTeam: Partial<FreeAgencyTeamCapSheet> &
+    Record<string, unknown> = baseTeamFixture,
   overrides: Record<string, unknown> = {}
 ) {
   return {
@@ -248,7 +259,8 @@ function buildSignedTeamFixture(
 }
 
 function buildSignAndTradeCommittedSourceTeamFixture(
-  baseTeam: Partial<FreeAgencyTeamCapSheet> & Record<string, unknown> = baseTeamFixture,
+  baseTeam: Partial<FreeAgencyTeamCapSheet> &
+    Record<string, unknown> = baseTeamFixture,
   overrides: Record<string, unknown> = {}
 ) {
   return {
@@ -432,9 +444,7 @@ function renderActionsHarness({
         teamCapSheet,
         currentYear: 2026,
         worldAsOfDate: worldId ? '2025-07-15' : null,
-        rightsLedgerWorldVersion: worldId
-          ? RIGHTS_LEDGER_WORLD_VERSION
-          : null,
+        rightsLedgerWorldVersion: worldId ? RIGHTS_LEDGER_WORLD_VERSION : null,
         setTeamCapSheet,
         setSelectedRulesYear,
         setSelectedPlayer,
@@ -445,9 +455,7 @@ function renderActionsHarness({
         setOffseasonRun,
         setOffseasonSummary,
         refreshWorldRosterIndex,
-        ...(reloadActiveWorldTeamData
-          ? { reloadActiveWorldTeamData }
-          : {}),
+        ...(reloadActiveWorldTeamData ? { reloadActiveWorldTeamData } : {}),
       },
       playersMap: {
         [playerFixture.id]: playerFixture,
@@ -531,8 +539,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
         showOfferSheetToggle: true,
         signAndTradeInitiation: null,
         offerSheetInitiation: {
-          getOfferSheetPreflight:
-            result.current.actions.getOfferSheetPreflight,
+          getOfferSheetPreflight: result.current.actions.getOfferSheetPreflight,
           storeOfferSheet: result.current.actions.handleStoreOfferSheet,
         },
       },
@@ -883,10 +890,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     });
 
     await act(async () => {
-      await result.current.actions.handleSign(
-        playerFixture,
-        contractFixture
-      );
+      await result.current.actions.handleSign(playerFixture, contractFixture);
     });
 
     expect(reloadActiveWorldTeamData).not.toHaveBeenCalled();
@@ -1035,10 +1039,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     });
 
     await act(async () => {
-      await result.current.actions.handleSign(
-        playerFixture,
-        contractFixture
-      );
+      await result.current.actions.handleSign(playerFixture, contractFixture);
     });
 
     expect(reloadActiveWorldTeamData).toHaveBeenCalledWith({
@@ -1178,9 +1179,9 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       );
     });
 
-    const worldMutationArgs =
-      mutationMocks.applyWorldMutation.mock.calls.at(-1)
-        ?.[0] as FreeAgencyWorldMutationArgs;
+    const worldMutationArgs = mutationMocks.applyWorldMutation.mock.calls.at(
+      -1
+    )?.[0] as FreeAgencyWorldMutationArgs;
     const dispatchedContract = worldMutationArgs?.payload?.contract;
 
     expect(worldMutationArgs).toEqual(
@@ -1242,10 +1243,12 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       );
     });
 
-    const validationArgs = validationMocks.validateSigning.mock.calls.at(-1)
-      ?.[0] as FreeAgencyValidationArgs;
-    const computeArgs = mutationMocks.computeWorldMutation.mock.calls.at(-1)
-      ?.[0] as FreeAgencyComputeArgs;
+    const validationArgs = validationMocks.validateSigning.mock.calls.at(
+      -1
+    )?.[0] as FreeAgencyValidationArgs;
+    const computeArgs = mutationMocks.computeWorldMutation.mock.calls.at(
+      -1
+    )?.[0] as FreeAgencyComputeArgs;
 
     expect(actionResult).toEqual(
       expect.objectContaining({
@@ -1316,8 +1319,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
   it('surfaces authoritative world-mode mutation failure when TPMLE ownership is missing', async () => {
     mutationMocks.applyWorldMutation.mockResolvedValue({
       success: false,
-      error:
-        'Cannot use TPMLE - canonical TPMLE owner is missing.',
+      error: 'Cannot use TPMLE - canonical TPMLE owner is missing.',
     });
 
     const { result } = renderActionsHarness({
@@ -1336,14 +1338,11 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
 
     let actionResult: FreeAgencyMutationResult | undefined;
     await act(async () => {
-      actionResult = await result.current.actions.handleSign(
-        playerFixture,
-        {
-          ...contractFixture,
-          totalValue: 5_000_000,
-          signedUsing: 'Taxpayer MLE',
-        }
-      );
+      actionResult = await result.current.actions.handleSign(playerFixture, {
+        ...contractFixture,
+        totalValue: 5_000_000,
+        signedUsing: 'Taxpayer MLE',
+      });
     });
 
     expect(actionResult).toEqual(
@@ -1446,9 +1445,9 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       );
     });
 
-    const worldMutationArgs =
-      mutationMocks.applyWorldMutation.mock.calls.at(-1)
-        ?.[0] as FreeAgencyWorldMutationArgs;
+    const worldMutationArgs = mutationMocks.applyWorldMutation.mock.calls.at(
+      -1
+    )?.[0] as FreeAgencyWorldMutationArgs;
     const dispatchedContract = worldMutationArgs?.payload?.contract;
 
     expect(actionResult).toEqual({ success: true });
@@ -1527,10 +1526,12 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     });
 
     const preflightArgs =
-      mutationMocks.preflightSignAndTradeMutation.mock.calls.at(-1)
-        ?.[0] as FreeAgencyPreflightArgs;
-    const commitArgs = mutationMocks.applyWorldMutation.mock.calls.at(-1)
-      ?.[0] as FreeAgencyWorldMutationArgs;
+      mutationMocks.preflightSignAndTradeMutation.mock.calls.at(
+        -1
+      )?.[0] as FreeAgencyPreflightArgs;
+    const commitArgs = mutationMocks.applyWorldMutation.mock.calls.at(
+      -1
+    )?.[0] as FreeAgencyWorldMutationArgs;
 
     expect(preflightArgs?.seasonId).toBe('2027-28');
     expect(commitArgs?.seasonId).toBe('2027-28');
@@ -1737,14 +1738,12 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
 
     let actionResult: FreeAgencyMutationResult | undefined;
     await act(async () => {
-      actionResult = await result.current.actions.handleRenounceRights(
-        {
-          id: 'player_1',
-          player_id: 'player_1',
-          name: 'Test Player',
-          displayName: 'Test Player',
-        }
-      );
+      actionResult = await result.current.actions.handleRenounceRights({
+        id: 'player_1',
+        player_id: 'player_1',
+        name: 'Test Player',
+        displayName: 'Test Player',
+      });
     });
 
     expect(actionResult).toEqual({ success: true });
@@ -1800,9 +1799,9 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       expect(offerSheets[0].id).toBe('os_1');
     });
 
-    const worldMutationArgs =
-      mutationMocks.applyWorldMutation.mock.calls.at(-1)
-        ?.[0] as FreeAgencyWorldMutationArgs;
+    const worldMutationArgs = mutationMocks.applyWorldMutation.mock.calls.at(
+      -1
+    )?.[0] as FreeAgencyWorldMutationArgs;
     const dispatchedContract = worldMutationArgs?.payload?.contract;
 
     expect(worldMutationArgs).toEqual(
@@ -2115,22 +2114,29 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       worldId: 'world_1',
       publishPostActionReceipt,
     });
+    const resolutionAt = '2025-07-09T17:00:00-04:00';
+    const averagingElection = {
+      statementId: 'statement-1',
+      deliveredToNbaAt: resolutionAt,
+      relayedToPlayersAssociationAt: '2025-07-10T17:00:00-04:00',
+    };
 
     act(() => {
-      result.current.actions.handleMatchOfferSheet({
-        offeringTeamCode: 'BOS',
-        id: 'offer_match_1',
-        playerId: 'player_1',
-      });
+      result.current.actions.handleMatchOfferSheet(
+        {
+          offeringTeamCode: 'BOS',
+          id: 'offer_match_1',
+          playerId: 'player_1',
+        },
+        { resolutionAt, averagingElection }
+      );
     });
 
     await waitFor(() => {
       expect(result.current.teamCapSheet?.incomingOfferSheets).toEqual([]);
     });
 
-    expect(
-      mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]
-    ).toEqual(
+    expect(mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]).toEqual(
       expect.objectContaining({
         mutationType: 'matchOfferSheet',
         worldId: 'world_1',
@@ -2138,6 +2144,8 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
           teamCode: 'LAL',
           offeringTeamCode: 'BOS',
           offerSheetId: 'offer_match_1',
+          offerSheetResolutionAt: resolutionAt,
+          offerSheetAveragingElection: averagingElection,
         }),
       })
     );
@@ -2192,9 +2200,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       expect(result.current.teamCapSheet?.incomingOfferSheets).toEqual([]);
     });
 
-    expect(
-      mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]
-    ).toEqual(
+    expect(mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]).toEqual(
       expect.objectContaining({
         mutationType: 'declineOfferSheet',
         worldId: 'world_1',
@@ -2247,9 +2253,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       expect(result.current.teamCapSheet?.incomingOfferSheets).toEqual([]);
     });
 
-    expect(
-      mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]
-    ).toEqual(
+    expect(mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]).toEqual(
       expect.objectContaining({
         mutationType: 'finalizeMatchedOfferSheet',
         worldId: 'world_1',
@@ -2365,9 +2369,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       expect(result.current.teamCapSheet?.offerSheets).toEqual([]);
     });
 
-    expect(
-      mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]
-    ).toEqual(
+    expect(mutationMocks.applyWorldMutation.mock.calls.at(-1)?.[0]).toEqual(
       expect.objectContaining({
         mutationType: 'finalizeDeclinedOfferSheet',
         worldId: 'world_1',
@@ -2389,9 +2391,7 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
         kind: 'offerSheet',
         headline: 'Declined offer sheet finalized',
         actionType: 'offer-sheet-finalize-declined',
-        message: expect.stringContaining(
-          'offering team LAL adds the player'
-        ),
+        message: expect.stringContaining('offering team LAL adds the player'),
       })
     );
   });
@@ -2409,7 +2409,9 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
       incomingOfferSheets: [],
     };
     const refreshError = new Error('refresh unavailable');
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
     mutationMocks.applyWorldMutation.mockResolvedValue({
       success: true,
       changedTeams: [{ teamCode: 'LAL', team: finalizedTeam }],
@@ -2907,7 +2909,9 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     expect(caughtError).toBeTruthy();
     const caughtErrorMessage =
       (caughtError as { message?: string } | null)?.message || '';
-    expect(caughtErrorMessage).toContain('Trade blocked by authoritative validation');
+    expect(caughtErrorMessage).toContain(
+      'Trade blocked by authoritative validation'
+    );
     expect(mutationMocks.computeWorldMutation).toHaveBeenCalledWith(
       expect.objectContaining({
         mutationType: 'executeTrade',
@@ -2921,9 +2925,11 @@ describe('useArchitectActions Free Agency SSOT wiring', () => {
     );
     expect(result.current.teamCapSheet).toBe(beforeApplyTeam);
     expect(
-      (result.current.teamCapSheet as FreeAgencyTeamCapSheet & {
-        marker?: unknown;
-      }).marker
+      (
+        result.current.teamCapSheet as FreeAgencyTeamCapSheet & {
+          marker?: unknown;
+        }
+      ).marker
     ).toBeUndefined();
   });
 

--- a/src/tests/security/architectSecurity.rulesSource.guardrail.test.ts
+++ b/src/tests/security/architectSecurity.rulesSource.guardrail.test.ts
@@ -37,6 +37,20 @@ describe('Architect security rules source guardrails', () => {
     expect(rules).toMatch(/match\s+\/architect_worlds\/\{worldId\}/);
   });
 
+  it('makes Offer Sheet authorization anchors create-once and owner-scoped', () => {
+    const rules = readRules();
+    expect(rules).toMatch(
+      /match\s+\/offerSheetAuthorizations\/\{offerSheetId\}/
+    );
+    expect(rules).toMatch(
+      /allow\s+create\s*:\s*if\s+isOpenForClientWorldWrites\(worldId\)/
+    );
+    expect(rules).toMatch(
+      /request\.resource\.data\.pendingLifecycleDigest\.matches\('\^fnv1a64:\[0-9a-f\]\{16\}\$'\)/
+    );
+    expect(rules).toMatch(/allow\s+update\s*,\s*delete\s*:\s*if\s*false\s*;/);
+  });
+
   it('explicitly denies writes to base collections and root teams', () => {
     const rules = readRules();
     const denyBlocks = [

--- a/src/tests/security/firestoreRules.integration.test.ts
+++ b/src/tests/security/firestoreRules.integration.test.ts
@@ -32,6 +32,7 @@ const TEAM_CODE = 'LAL';
 const EVENT_ID = 'evt_1';
 const ENTITLEMENT_ID = 'ent_1';
 const PLAYER_ID = 'player_1';
+const OFFER_SHEET_ID = 'offer_sheet_1';
 const UID_A = 'uid-owner-a';
 const UID_B = 'uid-non-owner-b';
 const HAS_FIRESTORE_EMULATOR_HOST = Boolean(
@@ -98,6 +99,24 @@ async function seedOwnedTierList(tierListId: string): Promise<void> {
       title: 'Owner Tier List',
     });
   });
+}
+
+function offerSheetAuthorizationData(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    authorizationVersion: 1,
+    worldId: WORLD_ID,
+    offerSheetId: OFFER_SHEET_ID,
+    dedupKey: `os:${WORLD_ID}:LAL:${PLAYER_ID}:2025-26`,
+    playerId: PLAYER_ID,
+    homeTeamId: 'BOS',
+    offeringTeamId: 'LAL',
+    salaryCapYear: 2026,
+    pendingLifecycleDigest: `fnv1a64:${'a'.repeat(16)}`,
+    immutableEvidenceDigest: `fnv1a64:${'b'.repeat(16)}`,
+    ...overrides,
+  };
 }
 
 beforeAll(async () => {
@@ -372,6 +391,81 @@ describeWithFirestoreEmulator(
         setDoc(doc(db, 'architect_worlds', WORLD_ID, 'events', EVENT_ID), {
           type: 'transaction',
         })
+      );
+    });
+
+    it('5b) owner can create and read an immutable Offer Sheet authorization anchor', async () => {
+      await seedOwnedWorld();
+      const db = ownerDb();
+      const authorizationRef = doc(
+        db,
+        'architect_worlds',
+        WORLD_ID,
+        'offerSheetAuthorizations',
+        OFFER_SHEET_ID
+      );
+      await assertSucceeds(
+        setDoc(authorizationRef, offerSheetAuthorizationData())
+      );
+      await assertSucceeds(getDoc(authorizationRef));
+      await assertFails(
+        updateDoc(authorizationRef, {
+          immutableEvidenceDigest: `fnv1a64:${'c'.repeat(16)}`,
+        })
+      );
+      await assertFails(deleteDoc(authorizationRef));
+    });
+
+    it('5c) non-owners cannot create or read Offer Sheet authorization anchors', async () => {
+      await seedOwnedWorld();
+      const ownerAuthorizationRef = doc(
+        ownerDb(),
+        'architect_worlds',
+        WORLD_ID,
+        'offerSheetAuthorizations',
+        OFFER_SHEET_ID
+      );
+      await assertSucceeds(
+        setDoc(ownerAuthorizationRef, offerSheetAuthorizationData())
+      );
+      const nonOwnerAuthorizationRef = doc(
+        nonOwnerDb(),
+        'architect_worlds',
+        WORLD_ID,
+        'offerSheetAuthorizations',
+        OFFER_SHEET_ID
+      );
+      await assertFails(getDoc(nonOwnerAuthorizationRef));
+      await assertFails(
+        setDoc(
+          doc(
+            nonOwnerDb(),
+            'architect_worlds',
+            WORLD_ID,
+            'offerSheetAuthorizations',
+            'offer_sheet_2'
+          ),
+          offerSheetAuthorizationData({ offerSheetId: 'offer_sheet_2' })
+        )
+      );
+    });
+
+    it('5d) rejects malformed Offer Sheet authorization anchors', async () => {
+      await seedOwnedWorld();
+      const db = ownerDb();
+      await assertFails(
+        setDoc(
+          doc(
+            db,
+            'architect_worlds',
+            WORLD_ID,
+            'offerSheetAuthorizations',
+            OFFER_SHEET_ID
+          ),
+          offerSheetAuthorizationData({
+            pendingLifecycleDigest: `sha256:${'a'.repeat(64)}`,
+          })
+        )
       );
     });
 

--- a/tests/architect/governedOfferSheetRestrictions.test.ts
+++ b/tests/architect/governedOfferSheetRestrictions.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateExtension } from '@/features/architect/utils/capLegalityValidation/extension';
+import { validateConsent } from '@/features/architect/utils/tradeMachine/rules/validateConsent';
+import { validateSignAndTrade } from '@/features/architect/utils/tradeMachine/rules/validateSignAndTrade';
+
+const restriction = {
+  restrictionVersion: 1 as const,
+  lifecycleId: 'offer-sheet-ledger:world_test:os-1',
+  eventId: 'offer-sheet-ledger:world_test:os-1:matched:v2',
+  matchedAt: '2025-07-09T17:00:00-04:00',
+  restrictedUntil: '2026-07-09T17:00:00-04:00',
+  offeringTeamId: 'LAL',
+  playerTradeConsentRequired: true as const,
+  offeringTeamTradeBarred: true as const,
+  signAndTradeBarred: true as const,
+};
+
+function restrictedPlayer(consent = false) {
+  return {
+    id: 'player123',
+    player_id: 'player123',
+    name: 'Restricted RFA',
+    consent,
+    contract: {
+      contractType: 'Standard',
+      salariesByYear: [
+        { season: '2025-26', salary: 15_000_000, capHit: 15_000_000 },
+      ],
+      offerSheetMatchRestriction: restriction,
+    },
+  };
+}
+
+function consentResult(
+  destination: string,
+  consent = false,
+  tradeDate = '2025-12-01'
+) {
+  return validateConsent(
+    {
+      teamId: 'BOS',
+      teamName: 'Boston',
+      sends: [restrictedPlayer(consent)],
+    },
+    {
+      tradeDate,
+      teams: [
+        { teamId: 'BOS', teamName: 'Boston' },
+        { teamId: destination, teamName: destination },
+      ],
+    }
+  );
+}
+
+describe('BZE-283 matched Offer Sheet restrictions', () => {
+  it('bars a trade back to the offering Team even with player consent', () => {
+    const result = consentResult('LAL', true);
+
+    expect(result.passed).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'CONSENT__OFFER_SHEET_OFFERING_TEAM_BARRED',
+        }),
+      ])
+    );
+  });
+
+  it('requires player consent for another destination during the first year', () => {
+    const blocked = consentResult('NYK');
+    const allowed = consentResult('NYK', true);
+
+    expect(blocked.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'CONSENT__OFFER_SHEET_PLAYER_CONSENT_REQUIRED',
+        }),
+      ])
+    );
+    expect(allowed.passed).toBe(true);
+  });
+
+  it('releases the trade restrictions at the exact one-year instant', () => {
+    const result = consentResult('LAL', false, '2026-07-09T17:00:00-04:00');
+
+    expect(result.passed).toBe(true);
+  });
+
+  it('bars sign-and-trade use while the matched restriction is active', () => {
+    const player = { ...restrictedPlayer(), signAndTrade: true };
+    const result = validateSignAndTrade(
+      {
+        teamId: 'BOS',
+        teamCode: 'BOS',
+        teamName: 'Boston',
+        sends: [player],
+      },
+      {
+        currentYear: 2026,
+        yearKey: 2026,
+        tradeDate: '2025-12-01',
+        offseason: true,
+      }
+    );
+
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'SIGN_AND_TRADE__OFFER_SHEET_MATCH_RESTRICTED',
+        }),
+      ])
+    );
+  });
+
+  it('bars a contract extension while the matched restriction is active', () => {
+    const result = validateExtension({
+      team: {
+        teamCode: 'BOS',
+        teamName: 'Boston',
+        players: [],
+        roster: [],
+        totals: { capHit: 100_000_000 },
+      },
+      player: restrictedPlayer(),
+      extension: {
+        salariesByYear: [{ season: '2026-27', salary: 16_000_000 }],
+      },
+      year: 2026,
+      asOfDate: '2025-12-01',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'offer_sheet_match_amendment_restricted',
+        }),
+      ])
+    );
+  });
+});

--- a/tests/architect/governedOfferSheetWorkflow.test.ts
+++ b/tests/architect/governedOfferSheetWorkflow.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { computeWorldMutation } from '@/features/architect/utils/mutationPipeline';
-import {
-  exerciseNoticeDeadline,
-} from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
+import { exerciseNoticeDeadline } from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
 import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
 import {
   makeGovernedOfferSheetContract,
@@ -14,7 +12,10 @@ import {
 
 function store(overrides: Record<string, unknown> = {}) {
   const defaultProposal = makeGovernedOfferSheetProposal();
-  const proposalInput = Object.prototype.hasOwnProperty.call(overrides, 'proposal')
+  const proposalInput = Object.prototype.hasOwnProperty.call(
+    overrides,
+    'proposal'
+  )
     ? overrides.proposal
     : defaultProposal;
   const proposal = (proposalInput ?? defaultProposal) as ReturnType<
@@ -50,7 +51,9 @@ function changedTeam(
   result: ReturnType<typeof computeWorldMutation>,
   teamCode: string
 ) {
-  const team = result.teamUpdates?.find((update) => update.teamCode === teamCode)?.team;
+  const team = result.teamUpdates?.find(
+    (update) => update.teamCode === teamCode
+  )?.team;
   if (!team) throw new Error(`Missing changed Team ${teamCode}`);
   return team;
 }
@@ -78,6 +81,7 @@ function resolve(
       offeringTeamCode: 'LAL',
       offerSheetId: 'os-governed-1',
       dedupKey: 'os:world_test_123:LAL:player123:2025-26',
+      offerSheetResolutionAt: asOfDate,
       ...payloadPatch,
     },
     currentState: {
@@ -88,7 +92,16 @@ function resolve(
     },
     seasonId: '2025-26',
     timestamp: Date.parse('2025-07-10T04:00:00Z'),
-    asOfDate,
+    asOfDate:
+      typeof payloadPatch.offerSheetAveragingElection === 'object' &&
+      payloadPatch.offerSheetAveragingElection !== null &&
+      'relayedToPlayersAssociationAt' in
+        payloadPatch.offerSheetAveragingElection
+        ? String(
+            payloadPatch.offerSheetAveragingElection
+              .relayedToPlayersAssociationAt
+          ).slice(0, 10)
+        : String(asOfDate).slice(0, 10),
     worldId: 'world_test_123',
   } as Parameters<typeof computeWorldMutation>[0]);
 }
@@ -127,6 +140,33 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
   it.each([
     ['missing proposal', { proposal: null }, 'Principal Terms'],
     [
+      'non-Eastern signing time',
+      {
+        proposal: makeGovernedOfferSheetProposal({
+          signedAt: '2025-07-08T13:55:00Z',
+        }),
+      },
+      'Eastern-time instant',
+    ],
+    [
+      'wrong seasonal Eastern offset',
+      {
+        proposal: makeGovernedOfferSheetProposal({
+          signedAt: '2025-07-08T09:55:00-05:00',
+        }),
+      },
+      'Eastern-time instant',
+    ],
+    [
+      'receipt before signing',
+      {
+        proposal: makeGovernedOfferSheetProposal({
+          receivedAt: '2025-07-08T09:54:59-04:00',
+        }),
+      },
+      'received before it is signed',
+    ],
+    [
       'wrong world evidence',
       {
         currentState: makeGovernedOfferSheetState(
@@ -164,6 +204,20 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
       'withdrawn',
     ],
     [
+      'undocumented QO extension',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            qualifyingOffer: {
+              ...makeGovernedOfferSheetEvidence().qualifyingOffer,
+              openThrough: '2025-10-02T23:59:59-04:00',
+            },
+          })
+        ),
+      },
+      'written extension record',
+    ],
+    [
       'stale authority',
       {
         currentState: makeGovernedOfferSheetState(
@@ -196,6 +250,20 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
       'conflicts',
     ],
     [
+      'internally conflicting RFA category',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            eligibility: {
+              ...makeGovernedOfferSheetEvidence().eligibility,
+              qualifyingTwoWayService: true,
+            },
+          })
+        ),
+      },
+      'internally conflicting',
+    ],
+    [
       'QO calculation mismatch',
       {
         currentState: makeGovernedOfferSheetState(
@@ -211,6 +279,58 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
         ),
       },
       'certified calculation',
+    ],
+    [
+      'Maximum QO schedule mismatch',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            qualifyingOffer: {
+              ...makeGovernedOfferSheetEvidence().qualifyingOffer,
+              branch: 'maximum',
+              amount: 40_000_000,
+              contractYears: 5,
+              annualRaiseBasisPoints: 800,
+              annualBaseSchedule: [
+                40_000_000, 43_200_000, 46_400_000, 49_600_000, 52_800_001,
+              ],
+              calculation: {
+                ...makeGovernedOfferSheetEvidence().qualifyingOffer.calculation,
+                certifiedAmount: 40_000_000,
+              },
+            },
+          })
+        ),
+      },
+      'does not use 8% of first-year Base',
+    ],
+    [
+      'expired home matching authority',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            homeTeamMatchingAuthority: {
+              ...makeGovernedOfferSheetEvidence().homeTeamMatchingAuthority,
+              effectiveThrough: '2025-07-09T23:59:58-04:00',
+            },
+          })
+        ),
+      },
+      'throughout the Exercise Notice period',
+    ],
+    [
+      'insufficient home matching authority',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            homeTeamMatchingAuthority: {
+              ...makeGovernedOfferSheetEvidence().homeTeamMatchingAuthority,
+              amount: 9_999_999,
+            },
+          })
+        ),
+      },
+      'insufficient for the signed Principal Terms',
     ],
     ['missing world date', { asOfDate: null }, 'Team Plan date'],
   ])('fails closed with no mutation for %s', (_label, overrides, message) => {
@@ -240,6 +360,63 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(retry.error).toContain('changed its signed Principal Terms');
   });
 
+  it('rejects a saved Contract whose bonus totals diverge from signed Principal Terms', () => {
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: makeGovernedOfferSheetProposal().salariesByYear.map(
+        (row, index) => ({
+          ...row,
+          salaryExcludingIncentive: row.regularSalary - 500_000,
+          bonuses: [
+            {
+              bonusId: `likely-${index + 1}`,
+              classification: 'likely' as const,
+              amount: 500_000,
+            },
+          ],
+        })
+      ),
+    });
+    const contract = makeGovernedOfferSheetContract(proposal);
+    const result = store({
+      proposal,
+      contract: {
+        ...contract,
+        salariesByYear: contract.salariesByYear.map((row) => ({
+          ...row,
+          incentives: { likely: 499_999, unlikely: 0 },
+        })),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('do not match the saved Contract');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it('blocks a second outstanding Offer Sheet for the same player', () => {
+    const first = store();
+    const offeringTeam = changedTeam(first, 'LAL');
+    const homeTeam = changedTeam(first, 'BOS');
+    const existing = offeringTeam.offerSheets?.[0];
+    if (!existing) throw new Error('Missing first Offer Sheet');
+
+    const result = store({
+      offerSheetId: 'os-governed-2',
+      currentState: {
+        ...makeGovernedOfferSheetState(),
+        team: {
+          ...offeringTeam,
+          offerSheets: [{ ...existing, dedupKey: 'another-outstanding-key' }],
+        },
+        homeTeam,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('another outstanding Offer Sheet');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
   it('blocks when dated Team Salary does not preserve the offered Room', () => {
     const currentState = makeGovernedOfferSheetState();
     const result = store({
@@ -252,7 +429,11 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
               player_id: 'room-consumer',
               contract: {
                 salariesByYear: [
-                  { season: '2025-26', salary: 499_000_000, capHit: 499_000_000 },
+                  {
+                    season: '2025-26',
+                    salary: 499_000_000,
+                    capHit: 499_000_000,
+                  },
                 ],
               },
             },
@@ -284,6 +465,23 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     });
     expect(matched.playerUpdates).toHaveLength(1);
     expect(matched.playerDeletes).toEqual([]);
+    expect(matched.playerUpdates?.[0]?.player.contract).toMatchObject({
+      offerSheetMatchRestriction: {
+        restrictionVersion: 1,
+        lifecycleId: lifecycle.ledgerId,
+        eventId: lifecycle.events.at(-1)?.eventId,
+        matchedAt: '2025-07-09T23:59:59-04:00',
+        restrictedUntil: '2026-07-09T23:59:59-04:00',
+        offeringTeamId: 'LAL',
+        playerTradeConsentRequired: true,
+        offeringTeamTradeBarred: true,
+        signAndTradeBarred: true,
+      },
+      tradeRestrictions: expect.arrayContaining([
+        expect.stringContaining('player consent required'),
+        expect.stringContaining('contract amendment'),
+      ]),
+    });
   });
 
   it('blocks a match one second late without changing either Team', () => {
@@ -297,12 +495,23 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(result.teamUpdates ?? []).toHaveLength(0);
   });
 
+  it('blocks a resolution before the certified Offer Sheet receipt', () => {
+    const result = resolve(
+      store(),
+      'declineOfferSheet',
+      '2025-07-08T09:59:59-04:00'
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('before the home Team receives it');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
   it('declines atomically and moves the player exactly once', () => {
     const declined = resolve(store(), 'declineOfferSheet');
     expect(declined.success, declined.error).toBe(true);
-    expect(changedTeam(declined, 'LAL').players?.map((player) => player.player_id)).toEqual([
-      'player123',
-    ]);
+    expect(
+      changedTeam(declined, 'LAL').players?.map((player) => player.player_id)
+    ).toEqual(['player123']);
     expect(changedTeam(declined, 'BOS').players).toEqual([]);
     expect(declined.playerUpdates).toHaveLength(1);
     expect(declined.playerDeletes).toEqual([
@@ -390,9 +599,9 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(lifecycle.reservations.offeringTeamAccounting).toBe(
       'average-annual-salary'
     );
-    expect(lifecycle.reservations.offeringTeam.map((row) => row.amount)).toEqual([
-      28_137_500, 28_137_500, 28_137_500, 28_137_500,
-    ]);
+    expect(
+      lifecycle.reservations.offeringTeam.map((row) => row.amount)
+    ).toEqual([28_137_500, 28_137_500, 28_137_500, 28_137_500]);
   });
 
   it('records a timely matching-Team averaging election with the Exercise Notice', () => {
@@ -421,12 +630,18 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     const resolutionAt = '2025-07-09T17:00:00-04:00';
     const election = {
       statementId: 'averaging-election-player123-v1',
-      deliveredToNbaAt: resolutionAt,
+      deliveredToNbaAt: '2025-07-09T18:00:00-04:00',
       relayedToPlayersAssociationAt: '2025-07-10T17:00:00-04:00',
     };
-    const matched = resolve(stored, 'matchOfferSheet', resolutionAt, {}, {
-      offerSheetAveragingElection: election,
-    });
+    const matched = resolve(
+      stored,
+      'matchOfferSheet',
+      resolutionAt,
+      {},
+      {
+        offerSheetAveragingElection: election,
+      }
+    );
     expect(matched.success, matched.error).toBe(true);
     const lifecycle = GovernedOfferSheetLifecycleZ.parse(
       matched.metadata?.governedOfferSheetLifecycle
@@ -437,10 +652,128 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(lifecycle.events.at(-1)).toMatchObject({
       eventKind: 'offer-sheet-matched',
       averagingElection: election,
+      matchingTeamSalaryReference: {
+        ledgerKind: 'team-salary',
+        asOfDate: resolutionAt,
+        salaryCap: 500_000_000,
+        canonLeafIds: ['CBA2-C15.10'],
+      },
     });
+    expect(matched.playerUpdates?.[0]?.player.contract?.salariesByYear).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          season: '2025-26',
+          salary: 15_000_000,
+          capHit: 23_583_333.33,
+        }),
+        expect.objectContaining({
+          season: '2027-28',
+          salary: 40_000_000,
+          capHit: 23_583_333.33,
+        }),
+      ])
+    );
   });
 
-  it('blocks an averaging election that was not delivered with the Exercise Notice', () => {
+  it('persists the signed incentive breakdown when the home Team declines', () => {
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: makeGovernedOfferSheetProposal().salariesByYear.map(
+        (row, index) => ({
+          ...row,
+          salaryExcludingIncentive: row.regularSalary - 500_000,
+          bonuses: [
+            {
+              bonusId: `likely-${index + 1}`,
+              classification: 'likely' as const,
+              amount: 500_000,
+            },
+          ],
+        })
+      ),
+    });
+    const declined = resolve(
+      store({ proposal, contract: makeGovernedOfferSheetContract(proposal) }),
+      'declineOfferSheet'
+    );
+
+    expect(declined.success, declined.error).toBe(true);
+    expect(
+      declined.playerUpdates?.[0]?.player.contract?.salariesByYear
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          season: '2025-26',
+          salary: 10_000_000,
+          capHit: 10_000_000,
+          incentives: { likely: 500_000, unlikely: 0 },
+        }),
+      ])
+    );
+  });
+
+  it('blocks the averaging election when the matching Team is not below the cap', () => {
+    const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [15_000_000, 15_750_000, 40_000_000].map(
+        (salary, index) => ({
+          ...base,
+          season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+          salaryExcludingIncentive: salary,
+          regularSalary: salary,
+        })
+      ),
+    });
+    const evidence = makeGovernedOfferSheetEvidence({
+      eligibility: {
+        ...makeGovernedOfferSheetEvidence().eligibility,
+        yearsOfService: 2,
+      },
+    });
+    const stored = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+      currentState: makeGovernedOfferSheetState(evidence),
+    });
+    const homeTeam = changedTeam(stored, 'BOS');
+    const resolutionAt = '2025-07-09T17:00:00-04:00';
+    const result = resolve(
+      stored,
+      'matchOfferSheet',
+      resolutionAt,
+      {
+        homeTeam: {
+          ...homeTeam,
+          players: [
+            ...(homeTeam.players ?? []),
+            {
+              player_id: 'above-cap-player',
+              contract: {
+                salariesByYear: [
+                  {
+                    season: '2025-26',
+                    salary: 500_000_000,
+                    capHit: 500_000_000,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        offerSheetAveragingElection: {
+          statementId: 'averaging-election-player123-v1',
+          deliveredToNbaAt: resolutionAt,
+          relayedToPlayersAssociationAt: '2025-07-10T17:00:00-04:00',
+        },
+      }
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('below-cap matching Team');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it('blocks an averaging election that was not delivered on the Exercise Notice date', () => {
     const base = makeGovernedOfferSheetProposal().salariesByYear[0];
     const proposal = makeGovernedOfferSheetProposal({
       salariesByYear: [15_000_000, 15_750_000, 40_000_000].map(
@@ -471,30 +804,27 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
       {
         offerSheetAveragingElection: {
           statementId: 'averaging-election-player123-v1',
-          deliveredToNbaAt: '2025-07-09T17:00:01-04:00',
+          deliveredToNbaAt: '2025-07-10T00:00:00-04:00',
           relayedToPlayersAssociationAt: '2025-07-10T17:00:00-04:00',
         },
       }
     );
     expect(result.success).toBe(false);
-    expect(result.error).toContain('with the Exercise Notice');
+    expect(result.error).toContain('on the Exercise Notice date');
     expect(result.teamUpdates ?? []).toHaveLength(0);
   });
 
-  it.each([
-    ['first-year NTMLE', 15_000_001, 15_750_000, 40_000_000, 41_800_000, 'NTMLE'],
-    ['second-year basis', 15_000_000, 15_750_001, 40_000_000, 41_800_000, 'more than 5%'],
-    ['third-year maximum', 15_000_000, 15_750_000, 40_000_001, 41_800_000, 'maximum'],
-    ['fourth-year change', 15_000_000, 15_750_000, 40_000_000, 41_800_001, '4.5%'],
-  ])('blocks the Arenas %s boundary independently', (_label, y1, y2, y3, y4, message) => {
+  it('blocks an averaging-election relay after one business day', () => {
     const base = makeGovernedOfferSheetProposal().salariesByYear[0];
     const proposal = makeGovernedOfferSheetProposal({
-      salariesByYear: [y1, y2, y3, y4].map((salary, index) => ({
-        ...base,
-        season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
-        salaryExcludingIncentive: salary,
-        regularSalary: salary,
-      })),
+      salariesByYear: [15_000_000, 15_750_000, 40_000_000].map(
+        (salary, index) => ({
+          ...base,
+          season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+          salaryExcludingIncentive: salary,
+          regularSalary: salary,
+        })
+      ),
     });
     const evidence = makeGovernedOfferSheetEvidence({
       eligibility: {
@@ -502,12 +832,197 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
         yearsOfService: 2,
       },
     });
+    const stored = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+      currentState: makeGovernedOfferSheetState(evidence),
+    });
+    const result = resolve(
+      stored,
+      'matchOfferSheet',
+      '2025-07-09T17:00:00-04:00',
+      {},
+      {
+        offerSheetAveragingElection: {
+          statementId: 'averaging-election-player123-v1',
+          deliveredToNbaAt: '2025-07-09T18:00:00-04:00',
+          relayedToPlayersAssociationAt: '2025-07-11T17:00:00-04:00',
+        },
+      }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('within one business day');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it('requires an exact Eastern Players Association relay instant', () => {
+    const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [15_000_000, 15_750_000, 40_000_000].map(
+        (salary, index) => ({
+          ...base,
+          season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+          salaryExcludingIncentive: salary,
+          regularSalary: salary,
+        })
+      ),
+    });
+    const evidence = makeGovernedOfferSheetEvidence({
+      eligibility: {
+        ...makeGovernedOfferSheetEvidence().eligibility,
+        yearsOfService: 2,
+      },
+    });
+    const stored = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+      currentState: makeGovernedOfferSheetState(evidence),
+    });
+    const result = resolve(
+      stored,
+      'matchOfferSheet',
+      '2025-07-09T17:00:00-04:00',
+      {},
+      {
+        offerSheetAveragingElection: {
+          statementId: 'averaging-election-player123-v1',
+          deliveredToNbaAt: '2025-07-09T18:00:00-04:00',
+          relayedToPlayersAssociationAt: '2025-07-10T21:00:00Z',
+        },
+      }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(
+      'Players Association relay must be an exact Eastern-time instant'
+    );
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      'first-year NTMLE',
+      15_000_001,
+      15_750_000,
+      40_000_000,
+      41_800_000,
+      'NTMLE',
+    ],
+    [
+      'second-year basis',
+      15_000_000,
+      15_750_001,
+      40_000_000,
+      41_800_000,
+      'more than 5%',
+    ],
+    [
+      'third-year maximum',
+      15_000_000,
+      15_750_000,
+      40_000_001,
+      41_800_000,
+      'maximum',
+    ],
+    [
+      'fourth-year change',
+      15_000_000,
+      15_750_000,
+      40_000_000,
+      41_800_001,
+      '4.5%',
+    ],
+    [
+      'third-year jump prerequisite',
+      15_000_000,
+      15_749_999,
+      40_000_000,
+      41_800_000,
+      'maximum permitted first two',
+    ],
+  ])(
+    'blocks the Arenas %s boundary independently',
+    (_label, y1, y2, y3, y4, message) => {
+      const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+      const proposal = makeGovernedOfferSheetProposal({
+        salariesByYear: [y1, y2, y3, y4].map((salary, index) => ({
+          ...base,
+          season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+          salaryExcludingIncentive: salary,
+          regularSalary: salary,
+        })),
+      });
+      const evidence = makeGovernedOfferSheetEvidence({
+        eligibility: {
+          ...makeGovernedOfferSheetEvidence().eligibility,
+          yearsOfService: 2,
+        },
+      });
+      const result = store({
+        proposal,
+        contract: makeGovernedOfferSheetContract(proposal),
+        currentState: makeGovernedOfferSheetState(evidence),
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(message);
+    }
+  );
+
+  it('blocks nonconsecutive Principal Terms Salary Cap Years', () => {
+    const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [
+        base,
+        {
+          ...base,
+          season: '2027-28',
+          salaryExcludingIncentive: 10_500_000,
+          regularSalary: 10_500_000,
+        },
+      ],
+    });
+    const result = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('consecutive Salary Cap Years');
+  });
+
+  it('requires a dated third-year maximum for an Arenas jump', () => {
+    const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [15_000_000, 15_750_000, 40_000_000].map(
+        (salary, index) => ({
+          ...base,
+          season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+          salaryExcludingIncentive: salary,
+          regularSalary: salary,
+        })
+      ),
+    });
+    const originalEvidence = makeGovernedOfferSheetEvidence();
+    const evidence = makeGovernedOfferSheetEvidence({
+      eligibility: { ...originalEvidence.eligibility, yearsOfService: 2 },
+      league: {
+        ...originalEvidence.league,
+        maximumSalaryBySeason:
+          originalEvidence.league.maximumSalaryBySeason.filter(
+            (row) => row.season !== '2027-28'
+          ),
+      },
+    });
     const result = store({
       proposal,
       contract: makeGovernedOfferSheetContract(proposal),
       currentState: makeGovernedOfferSheetState(evidence),
     });
+
     expect(result.success).toBe(false);
-    expect(result.error).toContain(message);
+    expect(result.error).toContain(
+      'third-year offering Team maximum is missing'
+    );
   });
 });

--- a/tests/architect/governedOfferSheetWorkflow.test.ts
+++ b/tests/architect/governedOfferSheetWorkflow.test.ts
@@ -7,6 +7,7 @@ import {
   oneYearAfter,
 } from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
 import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
+import { getSalaryForYear } from '@/features/architect/utils/tradeHelpers';
 import {
   makeGovernedOfferSheetContract,
   makeGovernedOfferSheetEvidence,
@@ -681,6 +682,41 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(result.teamUpdates ?? []).toHaveLength(0);
   });
 
+  it('rejects mirrored lifecycle identity drift from its immutable evidence', () => {
+    const stored = store();
+    const homeTeam = changedTeam(stored, 'BOS');
+    const offeringTeam = changedTeam(stored, 'LAL');
+    const lifecycle = GovernedOfferSheetLifecycleZ.parse(
+      homeTeam.incomingOfferSheets?.[0]?.governedLifecycle
+    );
+    const driftedLifecycle = { ...lifecycle, playerId: 'drifted-player' };
+    expect(
+      GovernedOfferSheetLifecycleZ.safeParse(driftedLifecycle).success
+    ).toBe(false);
+    const result = resolve(stored, 'declineOfferSheet', undefined, {
+      homeTeam: {
+        ...homeTeam,
+        incomingOfferSheets: homeTeam.incomingOfferSheets?.map((sheet) => ({
+          ...sheet,
+          playerId: 'drifted-player',
+          governedLifecycle: driftedLifecycle,
+        })),
+      },
+      offeringTeam: {
+        ...offeringTeam,
+        offerSheets: offeringTeam.offerSheets?.map((sheet) => ({
+          ...sheet,
+          playerId: 'drifted-player',
+          governedLifecycle: driftedLifecycle,
+        })),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('readable governed Offer Sheet lifecycle');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
   it('applies exact before-noon, at-noon, and Moratorium notice deadlines', () => {
     expect(exerciseNoticeDeadline('2025-07-08T11:59:59-04:00')).toBe(
       '2025-07-09T23:59:59-04:00'
@@ -854,9 +890,8 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     );
 
     expect(declined.success, declined.error).toBe(true);
-    expect(
-      declined.playerUpdates?.[0]?.player.contract?.salariesByYear
-    ).toEqual(
+    const finalizedPlayer = declined.playerUpdates?.[0]?.player;
+    expect(finalizedPlayer?.contract?.salariesByYear).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           season: '2025-26',
@@ -866,6 +901,7 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
         }),
       ])
     );
+    expect(getSalaryForYear(finalizedPlayer, 2026)).toBe(10_000_000);
   });
 
   it('blocks the averaging election when the matching Team is not below the cap', () => {

--- a/tests/architect/governedOfferSheetWorkflow.test.ts
+++ b/tests/architect/governedOfferSheetWorkflow.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 import { computeWorldMutation } from '@/features/architect/utils/mutationPipeline';
-import { exerciseNoticeDeadline } from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
+import {
+  compareInstant,
+  exerciseNoticeDeadline,
+  oneYearAfter,
+} from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
 import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
 import {
   makeGovernedOfferSheetContract,
   makeGovernedOfferSheetEvidence,
+  makeGovernedOfferSheetFixture,
   makeGovernedOfferSheetProposal,
   makeGovernedOfferSheetState,
 } from '../fixtures/architect/governedOfferSheet';
@@ -446,12 +451,74 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(result.teamUpdates ?? []).toHaveLength(0);
   });
 
+  it('counts every other governed reservation exactly once in the Room test', () => {
+    const currentState = makeGovernedOfferSheetState();
+    const other = makeGovernedOfferSheetFixture({
+      worldId: 'world_test_123',
+      playerId: 'other-player',
+      homeTeamId: 'NYK',
+      offeringTeamId: 'LAL',
+      offerSheetId: 'os-other-player',
+      salariesByYear: [
+        { season: '2025-26', salary: 15_000_000 },
+        { season: '2026-27', salary: 15_750_000 },
+      ],
+    });
+    const result = store({
+      currentState: {
+        ...currentState,
+        team: {
+          ...currentState.team,
+          players: [
+            {
+              player_id: 'room-consumer',
+              contract: {
+                salariesByYear: [
+                  {
+                    season: '2025-26',
+                    salary: 480_000_000,
+                    capHit: 480_000_000,
+                  },
+                ],
+              },
+            },
+          ],
+          offerSheets: [
+            {
+              id: 'os-other-player',
+              dedupKey: 'os:world_test_123:LAL:other-player:2025-26',
+              playerId: 'other-player',
+              playerName: 'Other Player',
+              offeringTeamCode: 'LAL',
+              homeTeamCode: 'NYK',
+              seasonKey: '2025-26',
+              year: 2026,
+              contractYears: 2,
+              salariesByYear: other.contract.salariesByYear,
+              status: 'PENDING_MATCH',
+              createdAt: other.proposal.receivedAt,
+              totalValue: other.contract.totalValue,
+              governedLifecycle: other.lifecycle,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('sufficient governed Room');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
   it('matches at the exact deadline, archives restrictions, and removes both active mirrors', () => {
     const stored = store();
     const matched = resolve(stored, 'matchOfferSheet');
     expect(matched.success, matched.error).toBe(true);
     expect(changedTeam(matched, 'BOS').incomingOfferSheets).toEqual([]);
     expect(changedTeam(matched, 'LAL').offerSheets).toEqual([]);
+    expect(changedTeam(matched, 'LAL').totals?.outstandingOfferSheetTotal).toBe(
+      0
+    );
     const lifecycle = GovernedOfferSheetLifecycleZ.parse(
       matched.metadata?.governedOfferSheetLifecycle
     );
@@ -542,6 +609,38 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(result.error).toContain('mirrors disagree');
   });
 
+  it('rejects a mirror envelope whose player identity disagrees with its lifecycle', () => {
+    const stored = store();
+    const homeTeam = changedTeam(stored, 'BOS');
+    const incoming = homeTeam.incomingOfferSheets?.[0];
+    const result = resolve(stored, 'matchOfferSheet', undefined, {
+      homeTeam: {
+        ...homeTeam,
+        incomingOfferSheets: [{ ...incoming, playerId: 'wrong-player' }],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('authenticated lifecycle identity');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it('rejects ambiguous identity matches instead of selecting the first mirror', () => {
+    const stored = store();
+    const homeTeam = changedTeam(stored, 'BOS');
+    const incoming = homeTeam.incomingOfferSheets?.[0];
+    const result = resolve(stored, 'matchOfferSheet', undefined, {
+      homeTeam: {
+        ...homeTeam,
+        incomingOfferSheets: [incoming, { ...incoming, id: 'duplicate-id' }],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('exactly one matching mirror');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
   it('applies exact before-noon, at-noon, and Moratorium notice deadlines', () => {
     expect(exerciseNoticeDeadline('2025-07-08T11:59:59-04:00')).toBe(
       '2025-07-09T23:59:59-04:00'
@@ -552,6 +651,23 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(exerciseNoticeDeadline('2025-07-06T23:59:59-04:00')).toBe(
       '2025-07-07T23:59:59-04:00'
     );
+    expect(exerciseNoticeDeadline('2025-10-31T12:00:00-04:00')).toBe(
+      '2025-11-02T23:59:59-05:00'
+    );
+  });
+
+  it('uses the target date Eastern offset for one-year restrictions and normalizes leap day', () => {
+    expect(oneYearAfter('2025-11-01T17:00:00-04:00')).toBe(
+      '2026-11-01T17:00:00-05:00'
+    );
+    expect(oneYearAfter('2024-02-29T17:00:00-05:00')).toBe(
+      '2025-02-28T17:00:00-05:00'
+    );
+    expect(
+      Number.isNaN(
+        compareInstant('2025-02-30T12:00:00-05:00', '2025-03-01T12:00:00-05:00')
+      )
+    ).toBe(true);
   });
 
   it('uses Average Annual Salary for the offering Team on an Arenas sheet', () => {

--- a/tests/architect/governedOfferSheetWorkflow.test.ts
+++ b/tests/architect/governedOfferSheetWorkflow.test.ts
@@ -642,6 +642,10 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     const stored = store();
     const homeTeam = changedTeam(stored, 'BOS');
     const incoming = homeTeam.incomingOfferSheets?.[0];
+    expect(
+      incoming,
+      'stored mirror should exist on the home Team'
+    ).toBeDefined();
     const result = resolve(stored, 'matchOfferSheet', undefined, {
       homeTeam: {
         ...homeTeam,
@@ -658,6 +662,10 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     const stored = store();
     const homeTeam = changedTeam(stored, 'BOS');
     const incoming = homeTeam.incomingOfferSheets?.[0];
+    expect(
+      incoming,
+      'stored mirror should exist on the home Team'
+    ).toBeDefined();
     const result = resolve(stored, 'matchOfferSheet', undefined, {
       homeTeam: {
         ...homeTeam,

--- a/tests/architect/governedOfferSheetWorkflow.test.ts
+++ b/tests/architect/governedOfferSheetWorkflow.test.ts
@@ -1,0 +1,513 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeWorldMutation } from '@/features/architect/utils/mutationPipeline';
+import {
+  exerciseNoticeDeadline,
+} from '@/features/architect/utils/offerSheets/governedOfferSheetTime';
+import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
+import {
+  makeGovernedOfferSheetContract,
+  makeGovernedOfferSheetEvidence,
+  makeGovernedOfferSheetProposal,
+  makeGovernedOfferSheetState,
+} from '../fixtures/architect/governedOfferSheet';
+
+function store(overrides: Record<string, unknown> = {}) {
+  const defaultProposal = makeGovernedOfferSheetProposal();
+  const proposalInput = Object.prototype.hasOwnProperty.call(overrides, 'proposal')
+    ? overrides.proposal
+    : defaultProposal;
+  const proposal = (proposalInput ?? defaultProposal) as ReturnType<
+    typeof makeGovernedOfferSheetProposal
+  >;
+  const contract =
+    (overrides.contract as ReturnType<typeof makeGovernedOfferSheetContract>) ??
+    makeGovernedOfferSheetContract(proposal);
+  return computeWorldMutation({
+    mutationType: 'storeOfferSheet',
+    payload: {
+      teamCode: 'LAL',
+      playerId: 'player123',
+      worldId: 'world_test_123',
+      offerSheetId: String(overrides.offerSheetId ?? 'os-governed-1'),
+      contract,
+      offerSheetProposal: proposalInput,
+    },
+    currentState:
+      (overrides.currentState as ReturnType<
+        typeof makeGovernedOfferSheetState
+      >) ?? makeGovernedOfferSheetState(),
+    seasonId: '2025-26',
+    timestamp: Date.parse('2025-07-08T14:00:01Z'),
+    asOfDate: Object.prototype.hasOwnProperty.call(overrides, 'asOfDate')
+      ? (overrides.asOfDate as string | number | null)
+      : '2025-07-08',
+    worldId: String(overrides.worldId ?? 'world_test_123'),
+  } as Parameters<typeof computeWorldMutation>[0]);
+}
+
+function changedTeam(
+  result: ReturnType<typeof computeWorldMutation>,
+  teamCode: string
+) {
+  const team = result.teamUpdates?.find((update) => update.teamCode === teamCode)?.team;
+  if (!team) throw new Error(`Missing changed Team ${teamCode}`);
+  return team;
+}
+
+function pendingSheet(result: ReturnType<typeof computeWorldMutation>) {
+  const sheet = changedTeam(result, 'LAL').offerSheets?.[0];
+  if (!sheet) throw new Error('Missing pending Offer Sheet');
+  return sheet;
+}
+
+function resolve(
+  storeResult: ReturnType<typeof computeWorldMutation>,
+  action: 'matchOfferSheet' | 'declineOfferSheet',
+  asOfDate = '2025-07-09T23:59:59-04:00',
+  statePatch: Record<string, unknown> = {},
+  payloadPatch: Record<string, unknown> = {}
+) {
+  const homeTeam = changedTeam(storeResult, 'BOS');
+  const offeringTeam = changedTeam(storeResult, 'LAL');
+  return computeWorldMutation({
+    mutationType: action,
+    payload: {
+      teamCode: 'BOS',
+      homeTeamCode: 'BOS',
+      offeringTeamCode: 'LAL',
+      offerSheetId: 'os-governed-1',
+      dedupKey: 'os:world_test_123:LAL:player123:2025-26',
+      ...payloadPatch,
+    },
+    currentState: {
+      homeTeam,
+      offeringTeam,
+      offerSheetId: 'os-governed-1',
+      ...statePatch,
+    },
+    seasonId: '2025-26',
+    timestamp: Date.parse('2025-07-10T04:00:00Z'),
+    asOfDate,
+    worldId: 'world_test_123',
+  } as Parameters<typeof computeWorldMutation>[0]);
+}
+
+describe('BZE-283 governed RFA Offer Sheet workflow', () => {
+  it('stores one certified lifecycle identically on both Teams and reserves Team Salary', () => {
+    const result = store();
+    expect(result.success, result.error).toBe(true);
+    const offering = changedTeam(result, 'LAL');
+    const home = changedTeam(result, 'BOS');
+    const outgoing = offering.offerSheets?.[0];
+    const incoming = home.incomingOfferSheets?.[0];
+    expect(outgoing?.createdAt).toBe('2025-07-08T10:00:00-04:00');
+    expect(outgoing?.governedLifecycle).toEqual(incoming?.governedLifecycle);
+    const lifecycle = GovernedOfferSheetLifecycleZ.parse(
+      outgoing?.governedLifecycle
+    );
+    expect(lifecycle.status).toBe('pending-match');
+    expect(lifecycle.reservations.offeringTeamSalaryReference).toMatchObject({
+      ledgerKind: 'team-salary',
+      asOfDate: '2025-07-08T09:55:00-04:00',
+      salaryCap: 500_000_000,
+      canonLeafIds: ['CBA2-L04.3'],
+    });
+    expect(
+      lifecycle.reservations.offeringTeamSalaryReference.teamStateReference
+    ).toMatch(/^world_test_123:LAL:/);
+    expect(lifecycle.events[0]).toMatchObject({
+      eventKind: 'offer-sheet-signed',
+      exerciseNoticeDeadline: '2025-07-09T23:59:59-04:00',
+    });
+    expect(offering.totals?.outstandingOfferSheetTotal).toBe(10_000_000);
+    expect(result.metadata?.governedOfferSheetLifecycle).toEqual(lifecycle);
+  });
+
+  it.each([
+    ['missing proposal', { proposal: null }, 'Principal Terms'],
+    [
+      'wrong world evidence',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({ worldId: 'another-world' })
+        ),
+      },
+      'does not match',
+    ],
+    [
+      'tardy QO',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            qualifyingOffer: {
+              ...makeGovernedOfferSheetEvidence().qualifyingOffer,
+              deliveredAt: '2025-06-29T17:00:01-04:00',
+            },
+          })
+        ),
+      },
+      'June 29',
+    ],
+    [
+      'withdrawn QO',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            qualifyingOffer: {
+              ...makeGovernedOfferSheetEvidence().qualifyingOffer,
+              withdrawnAt: '2025-07-08T09:00:00-04:00',
+            },
+          })
+        ),
+      },
+      'withdrawn',
+    ],
+    [
+      'stale authority',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            qualifyingOffer: {
+              ...makeGovernedOfferSheetEvidence().qualifyingOffer,
+              recordStatus: 'superseded',
+            },
+          })
+        ),
+      },
+      'stale',
+    ],
+    [
+      'unknown evidence',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({ status: 'unknown' })
+        ),
+      },
+      'incomplete',
+    ],
+    [
+      'conflicting evidence',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({ status: 'conflicting' })
+        ),
+      },
+      'conflicts',
+    ],
+    [
+      'QO calculation mismatch',
+      {
+        currentState: makeGovernedOfferSheetState(
+          makeGovernedOfferSheetEvidence({
+            qualifyingOffer: {
+              ...makeGovernedOfferSheetEvidence().qualifyingOffer,
+              calculation: {
+                ...makeGovernedOfferSheetEvidence().qualifyingOffer.calculation,
+                certifiedAmount: 4_999_999,
+              },
+            },
+          })
+        ),
+      },
+      'certified calculation',
+    ],
+    ['missing world date', { asOfDate: null }, 'Team Plan date'],
+  ])('fails closed with no mutation for %s', (_label, overrides, message) => {
+    const result = store(overrides as Record<string, unknown>);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(message);
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it('does not let a mutable retry replace signed Principal Terms', () => {
+    const first = store();
+    expect(first.success).toBe(true);
+    const changedProposal = makeGovernedOfferSheetProposal({
+      principalTermsDocumentId: 'different-principal-terms',
+    });
+    const retry = store({
+      offerSheetId: 'os-governed-retry',
+      proposal: changedProposal,
+      contract: makeGovernedOfferSheetContract(changedProposal),
+      currentState: {
+        ...makeGovernedOfferSheetState(),
+        team: changedTeam(first, 'LAL'),
+        homeTeam: changedTeam(first, 'BOS'),
+      },
+    });
+    expect(retry.success).toBe(false);
+    expect(retry.error).toContain('changed its signed Principal Terms');
+  });
+
+  it('blocks when dated Team Salary does not preserve the offered Room', () => {
+    const currentState = makeGovernedOfferSheetState();
+    const result = store({
+      currentState: {
+        ...currentState,
+        team: {
+          ...currentState.team,
+          players: [
+            {
+              player_id: 'room-consumer',
+              contract: {
+                salariesByYear: [
+                  { season: '2025-26', salary: 499_000_000, capHit: 499_000_000 },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('sufficient governed Room');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it('matches at the exact deadline, archives restrictions, and removes both active mirrors', () => {
+    const stored = store();
+    const matched = resolve(stored, 'matchOfferSheet');
+    expect(matched.success, matched.error).toBe(true);
+    expect(changedTeam(matched, 'BOS').incomingOfferSheets).toEqual([]);
+    expect(changedTeam(matched, 'LAL').offerSheets).toEqual([]);
+    const lifecycle = GovernedOfferSheetLifecycleZ.parse(
+      matched.metadata?.governedOfferSheetLifecycle
+    );
+    expect(lifecycle.status).toBe('matched');
+    expect(lifecycle.events.at(-1)).toMatchObject({
+      eventKind: 'offer-sheet-matched',
+      restrictionsUntil: '2026-07-09T23:59:59-04:00',
+      playerTradeConsentRequired: true,
+      offeringTeamTradeBarred: true,
+      signAndTradeBarred: true,
+    });
+    expect(matched.playerUpdates).toHaveLength(1);
+    expect(matched.playerDeletes).toEqual([]);
+  });
+
+  it('blocks a match one second late without changing either Team', () => {
+    const result = resolve(
+      store(),
+      'matchOfferSheet',
+      '2025-07-10T00:00:00-04:00'
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('deadline has passed');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it('declines atomically and moves the player exactly once', () => {
+    const declined = resolve(store(), 'declineOfferSheet');
+    expect(declined.success, declined.error).toBe(true);
+    expect(changedTeam(declined, 'LAL').players?.map((player) => player.player_id)).toEqual([
+      'player123',
+    ]);
+    expect(changedTeam(declined, 'BOS').players).toEqual([]);
+    expect(declined.playerUpdates).toHaveLength(1);
+    expect(declined.playerDeletes).toEqual([
+      { playerId: 'player123', teamCode: 'BOS' },
+    ]);
+  });
+
+  it('rejects divergent Team mirrors before resolution', () => {
+    const stored = store();
+    const homeTeam = changedTeam(stored, 'BOS');
+    const incoming = homeTeam.incomingOfferSheets?.[0];
+    const corruptedHome = {
+      ...homeTeam,
+      incomingOfferSheets: [
+        {
+          ...incoming,
+          governedLifecycle: {
+            ...(incoming?.governedLifecycle as Record<string, unknown>),
+            ledgerVersion: 99,
+          },
+        },
+      ],
+    };
+    const result = resolve(stored, 'matchOfferSheet', undefined, {
+      homeTeam: corruptedHome,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('mirrors disagree');
+  });
+
+  it('applies exact before-noon, at-noon, and Moratorium notice deadlines', () => {
+    expect(exerciseNoticeDeadline('2025-07-08T11:59:59-04:00')).toBe(
+      '2025-07-09T23:59:59-04:00'
+    );
+    expect(exerciseNoticeDeadline('2025-07-08T12:00:00-04:00')).toBe(
+      '2025-07-10T23:59:59-04:00'
+    );
+    expect(exerciseNoticeDeadline('2025-07-06T23:59:59-04:00')).toBe(
+      '2025-07-07T23:59:59-04:00'
+    );
+  });
+
+  it('uses Average Annual Salary for the offering Team on an Arenas sheet', () => {
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [
+        {
+          ...makeGovernedOfferSheetProposal().salariesByYear[0],
+          regularSalary: 15_000_000,
+          salaryExcludingIncentive: 15_000_000,
+        },
+        {
+          ...makeGovernedOfferSheetProposal().salariesByYear[1],
+          regularSalary: 15_750_000,
+          salaryExcludingIncentive: 15_750_000,
+        },
+        {
+          ...makeGovernedOfferSheetProposal().salariesByYear[0],
+          season: '2027-28',
+          regularSalary: 40_000_000,
+          salaryExcludingIncentive: 40_000_000,
+        },
+        {
+          ...makeGovernedOfferSheetProposal().salariesByYear[0],
+          season: '2028-29',
+          regularSalary: 41_800_000,
+          salaryExcludingIncentive: 41_800_000,
+        },
+      ],
+    });
+    const evidence = makeGovernedOfferSheetEvidence({
+      eligibility: {
+        ...makeGovernedOfferSheetEvidence().eligibility,
+        yearsOfService: 2,
+      },
+    });
+    const result = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+      currentState: makeGovernedOfferSheetState(evidence),
+    });
+    expect(result.success, result.error).toBe(true);
+    const lifecycle = GovernedOfferSheetLifecycleZ.parse(
+      pendingSheet(result).governedLifecycle
+    );
+    expect(lifecycle.reservations.offeringTeamAccounting).toBe(
+      'average-annual-salary'
+    );
+    expect(lifecycle.reservations.offeringTeam.map((row) => row.amount)).toEqual([
+      28_137_500, 28_137_500, 28_137_500, 28_137_500,
+    ]);
+  });
+
+  it('records a timely matching-Team averaging election with the Exercise Notice', () => {
+    const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [15_000_000, 15_750_000, 40_000_000].map(
+        (salary, index) => ({
+          ...base,
+          season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+          salaryExcludingIncentive: salary,
+          regularSalary: salary,
+        })
+      ),
+    });
+    const evidence = makeGovernedOfferSheetEvidence({
+      eligibility: {
+        ...makeGovernedOfferSheetEvidence().eligibility,
+        yearsOfService: 2,
+      },
+    });
+    const stored = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+      currentState: makeGovernedOfferSheetState(evidence),
+    });
+    const resolutionAt = '2025-07-09T17:00:00-04:00';
+    const election = {
+      statementId: 'averaging-election-player123-v1',
+      deliveredToNbaAt: resolutionAt,
+      relayedToPlayersAssociationAt: '2025-07-10T17:00:00-04:00',
+    };
+    const matched = resolve(stored, 'matchOfferSheet', resolutionAt, {}, {
+      offerSheetAveragingElection: election,
+    });
+    expect(matched.success, matched.error).toBe(true);
+    const lifecycle = GovernedOfferSheetLifecycleZ.parse(
+      matched.metadata?.governedOfferSheetLifecycle
+    );
+    expect(lifecycle.reservations.homeTeamAccounting).toBe(
+      'average-annual-salary'
+    );
+    expect(lifecycle.events.at(-1)).toMatchObject({
+      eventKind: 'offer-sheet-matched',
+      averagingElection: election,
+    });
+  });
+
+  it('blocks an averaging election that was not delivered with the Exercise Notice', () => {
+    const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [15_000_000, 15_750_000, 40_000_000].map(
+        (salary, index) => ({
+          ...base,
+          season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+          salaryExcludingIncentive: salary,
+          regularSalary: salary,
+        })
+      ),
+    });
+    const evidence = makeGovernedOfferSheetEvidence({
+      eligibility: {
+        ...makeGovernedOfferSheetEvidence().eligibility,
+        yearsOfService: 2,
+      },
+    });
+    const stored = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+      currentState: makeGovernedOfferSheetState(evidence),
+    });
+    const result = resolve(
+      stored,
+      'matchOfferSheet',
+      '2025-07-09T17:00:00-04:00',
+      {},
+      {
+        offerSheetAveragingElection: {
+          statementId: 'averaging-election-player123-v1',
+          deliveredToNbaAt: '2025-07-09T17:00:01-04:00',
+          relayedToPlayersAssociationAt: '2025-07-10T17:00:00-04:00',
+        },
+      }
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('with the Exercise Notice');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
+  it.each([
+    ['first-year NTMLE', 15_000_001, 15_750_000, 40_000_000, 41_800_000, 'NTMLE'],
+    ['second-year basis', 15_000_000, 15_750_001, 40_000_000, 41_800_000, 'more than 5%'],
+    ['third-year maximum', 15_000_000, 15_750_000, 40_000_001, 41_800_000, 'maximum'],
+    ['fourth-year change', 15_000_000, 15_750_000, 40_000_000, 41_800_001, '4.5%'],
+  ])('blocks the Arenas %s boundary independently', (_label, y1, y2, y3, y4, message) => {
+    const base = makeGovernedOfferSheetProposal().salariesByYear[0];
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: [y1, y2, y3, y4].map((salary, index) => ({
+        ...base,
+        season: `${2025 + index}-${String(26 + index).padStart(2, '0')}`,
+        salaryExcludingIncentive: salary,
+        regularSalary: salary,
+      })),
+    });
+    const evidence = makeGovernedOfferSheetEvidence({
+      eligibility: {
+        ...makeGovernedOfferSheetEvidence().eligibility,
+        yearsOfService: 2,
+      },
+    });
+    const result = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+      currentState: makeGovernedOfferSheetState(evidence),
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(message);
+  });
+});

--- a/tests/architect/governedOfferSheetWorkflow.test.ts
+++ b/tests/architect/governedOfferSheetWorkflow.test.ts
@@ -398,6 +398,34 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(result.teamUpdates ?? []).toHaveLength(0);
   });
 
+  it('rejects internally inconsistent Salary and Likely Bonus components before reservation math', () => {
+    const proposal = makeGovernedOfferSheetProposal({
+      salariesByYear: makeGovernedOfferSheetProposal().salariesByYear.map(
+        (row, index) => ({
+          ...row,
+          salaryExcludingIncentive: row.regularSalary - 400_000,
+          bonuses: [
+            {
+              bonusId: `likely-${index + 1}`,
+              classification: 'likely' as const,
+              amount: 500_000,
+            },
+          ],
+        })
+      ),
+    });
+    const result = store({
+      proposal,
+      contract: makeGovernedOfferSheetContract(proposal),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(
+      'Salary excluding Incentive Compensation plus Likely Bonuses must equal Regular Salary'
+    );
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
   it('blocks a second outstanding Offer Sheet for the same player', () => {
     const first = store();
     const offeringTeam = changedTeam(first, 'LAL');
@@ -641,6 +669,18 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(result.teamUpdates ?? []).toHaveLength(0);
   });
 
+  it('rejects mirrors stored under Team containers that disagree with the lifecycle', () => {
+    const stored = store();
+    const offeringTeam = changedTeam(stored, 'LAL');
+    const result = resolve(stored, 'declineOfferSheet', undefined, {
+      offeringTeam: { ...offeringTeam, teamCode: 'MIA' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Team containers');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
+  });
+
   it('applies exact before-noon, at-noon, and Moratorium notice deadlines', () => {
     expect(exerciseNoticeDeadline('2025-07-08T11:59:59-04:00')).toBe(
       '2025-07-09T23:59:59-04:00'
@@ -663,6 +703,7 @@ describe('BZE-283 governed RFA Offer Sheet workflow', () => {
     expect(oneYearAfter('2024-02-29T17:00:00-05:00')).toBe(
       '2025-02-28T17:00:00-05:00'
     );
+    expect(oneYearAfter('2025-03-08T02:30:00-05:00')).toBeNull();
     expect(
       Number.isNaN(
         compareInstant('2025-02-30T12:00:00-05:00', '2025-03-01T12:00:00-05:00')

--- a/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
+++ b/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
@@ -26,6 +26,9 @@ import { getAllMockData, resetMockDataStore } from '../__mocks__/firebase.js';
 import { getPlayer } from '@/features/architect/utils/teamLoader';
 import { worldPlayerRef } from '@/features/architect/utils/architectFirestorePaths';
 import { makeGovernedOfferSheetFixture } from '../fixtures/architect/governedOfferSheet';
+import { GovernedOfferSheetLifecycleZ } from '@/schemas/governedOfferSheet';
+import { buildGeneralMutationCommittedTeamUpdates } from '@/features/architect/utils/mutationPipeline.read.persistence.snapshots';
+import { buildGovernedOfferSheetAuthorization } from '@/features/architect/utils/offerSheets';
 
 vi.mock('@/features/architect/utils/capLegalityValidation', () => ({
   validateSigning: vi.fn(() => ({ valid: true, violations: [], warnings: [] })),
@@ -428,6 +431,23 @@ function makeStoredOfferSheetContract(
 
 function seedBasePlayer(player: TradePlayerFixture) {
   seedMockData(`architect_basePlayers/${player.playerId}`, player);
+}
+
+function seedOfferSheetAuthorization(
+  worldId: string,
+  offerSheet: TradeOfferSheetFixture
+) {
+  const lifecycle = GovernedOfferSheetLifecycleZ.parse(
+    offerSheet.governedLifecycle
+  );
+  seedMockData(
+    `architect_worlds/${worldId}/offerSheetAuthorizations/${offerSheet.id}`,
+    buildGovernedOfferSheetAuthorization({
+      lifecycle,
+      offerSheetId: offerSheet.id,
+      dedupKey: offerSheet.dedupKey,
+    })
+  );
 }
 
 function seedPlayerOverride(
@@ -1176,6 +1196,286 @@ describe('mutationPipeline trade persistence truth', () => {
     ).toHaveLength(0);
   });
 
+  it('rejects a concurrent Offer Sheet creation computed from stale Team snapshots', async () => {
+    const worldId = 'world_offer_sheet_creation_race';
+    const playerId = 'creation_race_rfa';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId,
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      salariesByYear: makeStoredOfferSheetContract().salariesByYear,
+    });
+    seedWorldMetadata(
+      worldId,
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
+    );
+
+    const player = makePlayer(playerId, 'BOS', 9_000_000, {
+      displayName: 'Creation Race Player',
+      contract: makeContract(9_000_000, {
+        contractType: 'Standard',
+        signingTeam: 'BOS',
+      }),
+      rfaContext: { governedEvidence: governed.evidence },
+    });
+    const lalKeeper = makePlayer('lal_keeper_creation_race', 'LAL', 7_000_000);
+    seedBasePlayer(player);
+    seedBasePlayer(lalKeeper);
+    seedTeamSnapshot(
+      worldId,
+      'BOS',
+      {
+        ...makeTeam('BOS', [player]),
+        incomingOfferSheets: [],
+        rightsLedger: governed.rightsLedger,
+      },
+      { padRoster: false }
+    );
+    seedTeamSnapshot(
+      worldId,
+      'LAL',
+      { ...makeTeam('LAL', [lalKeeper]), offerSheets: [] },
+      { padRoster: false }
+    );
+
+    const payload = {
+      teamCode: 'LAL',
+      playerId,
+      worldId,
+      contract: makeStoredOfferSheetContract(),
+      offerSheetProposal: governed.proposal,
+      signedUsing: 'Cap Space',
+    };
+    const staleState = await loadStateForMutation(
+      worldId,
+      'storeOfferSheet',
+      payload
+    );
+    const firstCreation = computeWorldMutation({
+      mutationType: 'storeOfferSheet',
+      payload,
+      currentState: staleState,
+      seasonId: SEASON_ID,
+      timestamp: TIMESTAMP,
+      asOfDate: governed.asOfDate,
+      worldId,
+    });
+    const staleCreation = computeWorldMutation({
+      mutationType: 'storeOfferSheet',
+      payload,
+      currentState: staleState,
+      seasonId: SEASON_ID,
+      timestamp: TIMESTAMP + 1,
+      asOfDate: governed.asOfDate,
+      worldId,
+    });
+    expect(firstCreation.success, String(firstCreation.error)).toBe(true);
+    expect(staleCreation.success, String(staleCreation.error)).toBe(true);
+
+    const firstPersisted = await persistWorldMutation({
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'storeOfferSheet',
+      computeResult: firstCreation,
+      committedTeamUpdates: buildGeneralMutationCommittedTeamUpdates(
+        firstCreation.teamUpdates,
+        SEASON_ID
+      ),
+      timestamp: TIMESTAMP,
+    });
+    expect(firstPersisted.success, String(firstPersisted.error)).toBe(true);
+    const firstOfferSheetId = requireValue(
+      getOfferSheets(requireTeamSnapshot(worldId, 'LAL'))[0]?.id,
+      'Expected the winning Offer Sheet to persist'
+    );
+    const eventCountAfterWinner = [...getAllMockData().keys()].filter((key) =>
+      key.includes('/events/')
+    ).length;
+
+    const stalePersisted = await persistWorldMutation({
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'storeOfferSheet',
+      computeResult: staleCreation,
+      committedTeamUpdates: buildGeneralMutationCommittedTeamUpdates(
+        staleCreation.teamUpdates,
+        SEASON_ID
+      ),
+      timestamp: TIMESTAMP + 1,
+    });
+
+    expect(stalePersisted.success).toBe(false);
+    if (!stalePersisted.success) {
+      expect(stalePersisted.error).toContain('changed before commit');
+    }
+    expect(getOfferSheets(requireTeamSnapshot(worldId, 'LAL'))).toMatchObject([
+      { id: firstOfferSheetId },
+    ]);
+    expect(
+      getIncomingOfferSheets(requireTeamSnapshot(worldId, 'BOS'))
+    ).toMatchObject([{ id: firstOfferSheetId }]);
+    expect(
+      [...getAllMockData().keys()].filter((key) => key.includes('/events/'))
+    ).toHaveLength(eventCountAfterWinner);
+  });
+
+  it('rejects identically tampered Team mirrors before resolving an Offer Sheet', async () => {
+    const worldId = 'world_offer_sheet_tampered_mirrors';
+    const playerId = 'tampered_mirror_rfa';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId,
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      salariesByYear: makeStoredOfferSheetContract().salariesByYear,
+    });
+    seedWorldMetadata(
+      worldId,
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
+    );
+
+    const player = makePlayer(playerId, 'BOS', 9_000_000, {
+      displayName: 'Tampered Mirror Player',
+      contract: makeContract(9_000_000, {
+        contractType: 'Standard',
+        signingTeam: 'BOS',
+      }),
+      rfaContext: { governedEvidence: governed.evidence },
+    });
+    const lalKeeper = makePlayer('lal_keeper_tampered_mirror', 'LAL', 7_000_000);
+    seedBasePlayer(player);
+    seedBasePlayer(lalKeeper);
+    seedTeamSnapshot(
+      worldId,
+      'BOS',
+      {
+        ...makeTeam('BOS', [player]),
+        incomingOfferSheets: [],
+        rightsLedger: governed.rightsLedger,
+      },
+      { padRoster: false }
+    );
+    seedTeamSnapshot(
+      worldId,
+      'LAL',
+      { ...makeTeam('LAL', [lalKeeper]), offerSheets: [] },
+      { padRoster: false }
+    );
+
+    const stored = await applyWorldMutation({
+      userId: USER_ID,
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'storeOfferSheet',
+      timestamp: TIMESTAMP,
+      payload: {
+        teamCode: 'LAL',
+        playerId,
+        worldId,
+        contract: makeStoredOfferSheetContract(),
+        offerSheetProposal: governed.proposal,
+        signedUsing: 'Cap Space',
+      },
+    });
+    expect(stored.success, String(stored.error)).toBe(true);
+
+    const homeBeforeTamper = requireTeamSnapshot(worldId, 'BOS');
+    const offeringBeforeTamper = requireTeamSnapshot(worldId, 'LAL');
+    const originalSheet = requireValue(
+      getOfferSheets(offeringBeforeTamper)[0],
+      'Expected a pending Offer Sheet before mirror tampering'
+    );
+    const originalLifecycle = GovernedOfferSheetLifecycleZ.parse(
+      originalSheet.governedLifecycle
+    );
+    const tamperedLifecycle = GovernedOfferSheetLifecycleZ.parse({
+      ...originalLifecycle,
+      evidenceSnapshot: {
+        ...originalLifecycle.evidenceSnapshot,
+        homeTeamMatchingAuthority: {
+          ...originalLifecycle.evidenceSnapshot.homeTeamMatchingAuthority,
+          amount:
+            originalLifecycle.evidenceSnapshot.homeTeamMatchingAuthority
+              .amount + 1,
+        },
+      },
+      reservations: {
+        ...originalLifecycle.reservations,
+        offeringTeam: originalLifecycle.reservations.offeringTeam.map(
+          (reservation, index) =>
+            index === 0
+              ? { ...reservation, amount: reservation.amount - 1 }
+              : reservation
+        ),
+      },
+      events: originalLifecycle.events.map((event) =>
+        event.eventKind === 'offer-sheet-signed'
+          ? {
+              ...event,
+              proposal: {
+                ...event.proposal,
+                principalTermsDocumentId: 'tampered-principal-terms',
+              },
+            }
+          : event
+      ),
+    });
+    const tamperedSheet = {
+      ...originalSheet,
+      governedLifecycle: tamperedLifecycle,
+    };
+    seedMockData(`architect_worlds/${worldId}/teams/BOS`, {
+      ...homeBeforeTamper,
+      incomingOfferSheets: [tamperedSheet],
+    });
+    seedMockData(`architect_worlds/${worldId}/teams/LAL`, {
+      ...offeringBeforeTamper,
+      offerSheets: [tamperedSheet],
+    });
+    const eventCountBeforeResolution = [...getAllMockData().keys()].filter(
+      (key) => key.includes('/events/')
+    ).length;
+
+    const result = await applyWorldMutation({
+      userId: USER_ID,
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'matchOfferSheet',
+      timestamp: TIMESTAMP + 1,
+      payload: {
+        teamCode: 'BOS',
+        offeringTeamCode: 'LAL',
+        offerSheetId: originalSheet.id,
+        offerSheetResolutionAt: governed.resolutionAt,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain('authorization');
+    expect(
+      GovernedOfferSheetLifecycleZ.parse(
+        getOfferSheets(requireTeamSnapshot(worldId, 'LAL'))[0]
+          ?.governedLifecycle
+      ).events[0]
+    ).toMatchObject({
+      proposal: { principalTermsDocumentId: 'tampered-principal-terms' },
+    });
+    expect(
+      [...getAllMockData().keys()].filter((key) => key.includes('/events/'))
+    ).toHaveLength(eventCountBeforeResolution);
+  });
+
   it('rejects a stale competing resolution without overwriting the committed lifecycle', async () => {
     const worldId = 'world_offer_sheet_resolution_race';
     const governed = makeGovernedOfferSheetFixture({
@@ -1544,6 +1844,7 @@ describe('mutationPipeline trade persistence truth', () => {
         contractType: 'Standard',
         signingTeam: 'BOS',
       }),
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const lalKeeper = makePlayer('lal_keeper', 'LAL', 7_000_000);
     const matchedOfferSheet = makeOfferSheet({
@@ -1560,6 +1861,7 @@ describe('mutationPipeline trade persistence truth', () => {
 
     seedBasePlayer(matchedPlayer);
     seedBasePlayer(lalKeeper);
+    seedOfferSheetAuthorization(worldId, matchedOfferSheet);
     seedTeamSnapshot(
       worldId,
       'BOS',
@@ -1669,6 +1971,7 @@ describe('mutationPipeline trade persistence truth', () => {
         contractType: 'Standard',
         signingTeam: 'BOS',
       }),
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const lalKeeper = makePlayer('lal_keeper_2', 'LAL', 6_500_000);
     const declinedOfferSheet = makeOfferSheet({
@@ -1685,6 +1988,7 @@ describe('mutationPipeline trade persistence truth', () => {
 
     seedBasePlayer(declinedPlayer);
     seedBasePlayer(lalKeeper);
+    seedOfferSheetAuthorization(worldId, declinedOfferSheet);
     seedTeamSnapshot(
       worldId,
       'BOS',

--- a/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
+++ b/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
@@ -23,6 +23,7 @@ import {
 import { resetMockDataStore } from '../__mocks__/firebase.js';
 import { getPlayer } from '@/features/architect/utils/teamLoader';
 import { worldPlayerRef } from '@/features/architect/utils/architectFirestorePaths';
+import { makeGovernedOfferSheetFixture } from '../fixtures/architect/governedOfferSheet';
 
 vi.mock('@/features/architect/utils/capLegalityValidation', () => ({
   validateSigning: vi.fn(() => ({ valid: true, violations: [], warnings: [] })),
@@ -497,7 +498,7 @@ describe('mutationPipeline trade persistence truth', () => {
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
     const updatedTeam = requireValue(
       result.teamUpdates?.[0]?.team,
       'waive result team'
@@ -520,7 +521,11 @@ describe('mutationPipeline trade persistence truth', () => {
     const worldId = 'world_trade_truth_standard';
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+      })
     );
 
     const lalOut = makePlayer('lal_out_18m', 'LAL', 18_000_000);
@@ -562,7 +567,7 @@ describe('mutationPipeline trade persistence truth', () => {
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
     expect(
       result.changedPlayers?.map((entry) => entry.playerId).sort()
     ).toEqual(['bos_out_10m', 'lal_out_18m']);
@@ -592,7 +597,11 @@ describe('mutationPipeline trade persistence truth', () => {
     const worldId = 'world_trade_truth_sat';
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+      })
     );
 
     const satBasePlayer = makePlayer('sat_player', 'LAL', 0, {
@@ -671,7 +680,7 @@ describe('mutationPipeline trade persistence truth', () => {
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
 
     const sourceOverride = await getDoc(
       worldPlayerRef(worldId, 'LAL', 'sat_player')
@@ -691,9 +700,21 @@ describe('mutationPipeline trade persistence truth', () => {
 
   it('stores offer sheets from authoritative home-team ownership and ignores offering-team-path truth', async () => {
     const worldId = 'world_offer_sheet_store_truth';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId: 'store_rfa_truth',
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      salariesByYear: makeStoredOfferSheetContract().salariesByYear,
+    });
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
     );
 
     const homePlayerBase = makePlayer('store_rfa_truth', 'BOS', 8_000_000, {
@@ -702,6 +723,7 @@ describe('mutationPipeline trade persistence truth', () => {
         contractType: 'Standard',
         signingTeam: 'BOS',
       }),
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const lalKeeper = makePlayer('lal_keeper_store_truth', 'LAL', 7_000_000);
 
@@ -713,6 +735,7 @@ describe('mutationPipeline trade persistence truth', () => {
       {
         ...makeTeam('BOS', [homePlayerBase]),
         incomingOfferSheets: [],
+        rightsLedger: governed.rightsLedger,
       },
       { padRoster: false }
     );
@@ -758,11 +781,12 @@ describe('mutationPipeline trade persistence truth', () => {
         playerId: 'store_rfa_truth',
         worldId,
         contract: makeStoredOfferSheetContract(),
+        offerSheetProposal: governed.proposal,
         signedUsing: 'Cap Space',
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
 
     const offeringSnapshot = requireTeamSnapshot(worldId, 'LAL');
     const homeSnapshot = requireTeamSnapshot(worldId, 'BOS');
@@ -787,14 +811,27 @@ describe('mutationPipeline trade persistence truth', () => {
 
   it('resolves RFA home-team ownership from an active unsigned cap hold without rostering the player', async () => {
     const worldId = 'world_offer_sheet_store_cap_hold_rights';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId: 'cap_hold_rfa',
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      salariesByYear: makeStoredOfferSheetContract().salariesByYear,
+    });
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
     );
 
     const rightsPlayer = makePlayer('cap_hold_rfa', 'BOS', 8_000_000, {
       displayName: 'Cap Hold Rights Player',
       name: 'Cap Hold Rights Player',
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const lalKeeper = makePlayer('lal_keeper_cap_hold', 'LAL', 7_000_000);
     const bosKeeper = makePlayer('bos_keeper_cap_hold', 'BOS', 6_000_000);
@@ -808,17 +845,20 @@ describe('mutationPipeline trade persistence truth', () => {
     seedTeamSnapshot(
       worldId,
       'BOS',
-      makeTeam('BOS', [bosKeeper], [
-        {
-          playerId: 'cap_hold_rfa',
-          playerName: 'Cap Hold Rights Player',
-          amount: 2_000_000,
-          season: SEASON_ID,
-          type: 'RFA Rights',
-          active: true,
-          isSigned: false,
-        },
-      ]),
+      {
+        ...makeTeam('BOS', [bosKeeper], [
+          {
+            playerId: 'cap_hold_rfa',
+            playerName: 'Cap Hold Rights Player',
+            amount: 2_000_000,
+            season: SEASON_ID,
+            type: 'RFA Rights',
+            active: true,
+            isSigned: false,
+          },
+        ]),
+        rightsLedger: governed.rightsLedger,
+      },
       { padRoster: false }
     );
 
@@ -833,11 +873,12 @@ describe('mutationPipeline trade persistence truth', () => {
         playerId: 'cap_hold_rfa',
         worldId,
         contract: makeStoredOfferSheetContract(),
+        offerSheetProposal: governed.proposal,
         signedUsing: 'Cap Space',
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
 
     const offeringSnapshot = requireTeamSnapshot(worldId, 'LAL');
     const homeSnapshot = requireTeamSnapshot(worldId, 'BOS');
@@ -863,7 +904,11 @@ describe('mutationPipeline trade persistence truth', () => {
     const worldId = 'world_offer_sheet_store_no_owner';
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+      })
     );
 
     const baseOnlyPlayer = makePlayer('no_owner_rfa', 'BOS', 8_000_000, {
@@ -911,7 +956,11 @@ describe('mutationPipeline trade persistence truth', () => {
     const worldId = 'world_offer_sheet_store_multi_owner';
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+      })
     );
 
     const sharedPlayer = makePlayer('multi_owner_rfa', 'BOS', 8_000_000, {
@@ -1013,9 +1062,21 @@ describe('mutationPipeline trade persistence truth', () => {
 
   it('keeps E4 matched resolution compatible for offer sheets created under the strict store path', async () => {
     const worldId = 'world_offer_sheet_store_to_match_finalize';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId: 'store_match_rfa',
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      salariesByYear: makeStoredOfferSheetContract().salariesByYear,
+    });
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
     );
 
     const matchedPlayer = makePlayer('store_match_rfa', 'BOS', 9_000_000, {
@@ -1024,6 +1085,7 @@ describe('mutationPipeline trade persistence truth', () => {
         contractType: 'Standard',
         signingTeam: 'BOS',
       }),
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const lalKeeper = makePlayer('lal_keeper_store_match', 'LAL', 7_000_000);
 
@@ -1048,6 +1110,7 @@ describe('mutationPipeline trade persistence truth', () => {
           ]
         ),
         incomingOfferSheets: [],
+        rightsLedger: governed.rightsLedger,
       },
       { padRoster: false }
     );
@@ -1073,10 +1136,11 @@ describe('mutationPipeline trade persistence truth', () => {
         playerId: 'store_match_rfa',
         worldId,
         contract: makeStoredOfferSheetContract(),
+        offerSheetProposal: governed.proposal,
         signedUsing: 'Cap Space',
       },
     });
-    expect(storeResult.success).toBe(true);
+    expect(storeResult.success, String(storeResult.error)).toBe(true);
 
     const offerSheetId =
       getOfferSheets(requireTeamSnapshot(worldId, 'LAL'))[0]?.id || null;
@@ -1096,6 +1160,7 @@ describe('mutationPipeline trade persistence truth', () => {
         teamCode: 'BOS',
         offeringTeamCode: 'LAL',
         offerSheetId,
+        offerSheetResolutionAt: governed.resolutionAt,
       },
     });
     expect(matchResult.success).toBe(true);
@@ -1111,9 +1176,21 @@ describe('mutationPipeline trade persistence truth', () => {
 
   it('keeps E4 declined resolution compatible for offer sheets created under the strict store path', async () => {
     const worldId = 'world_offer_sheet_store_to_decline_finalize';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId: 'store_decline_rfa',
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      salariesByYear: makeStoredOfferSheetContract().salariesByYear,
+    });
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
     );
 
     const declinedPlayer = makePlayer('store_decline_rfa', 'BOS', 8_500_000, {
@@ -1122,6 +1199,7 @@ describe('mutationPipeline trade persistence truth', () => {
         contractType: 'Standard',
         signingTeam: 'BOS',
       }),
+      rfaContext: { governedEvidence: governed.evidence },
     });
     const lalKeeper = makePlayer('lal_keeper_store_decline', 'LAL', 6_500_000);
 
@@ -1146,6 +1224,7 @@ describe('mutationPipeline trade persistence truth', () => {
           ]
         ),
         incomingOfferSheets: [],
+        rightsLedger: governed.rightsLedger,
       },
       { padRoster: false }
     );
@@ -1184,10 +1263,11 @@ describe('mutationPipeline trade persistence truth', () => {
         playerId: 'store_decline_rfa',
         worldId,
         contract: makeStoredOfferSheetContract(),
+        offerSheetProposal: governed.proposal,
         signedUsing: 'Cap Space',
       },
     });
-    expect(storeResult.success).toBe(true);
+    expect(storeResult.success, String(storeResult.error)).toBe(true);
 
     const storedOfferSheet = requireValue(
       getOfferSheets(requireTeamSnapshot(worldId, 'LAL'))[0],
@@ -1208,6 +1288,7 @@ describe('mutationPipeline trade persistence truth', () => {
         teamCode: 'BOS',
         offeringTeamCode: 'LAL',
         offerSheetId: storedOfferSheet.id,
+        offerSheetResolutionAt: governed.resolutionAt,
       },
     });
     expect(declineResult.success).toBe(true);
@@ -1230,9 +1311,22 @@ describe('mutationPipeline trade persistence truth', () => {
 
   it('persists finalizeMatchedOfferSheet as a same-team canonical upsert with no delete path', async () => {
     const worldId = 'world_offer_sheet_matched_truth';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId: 'matched_rfa',
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      offerSheetId: 'os_match_truth',
+      salariesByYear: makeOfferSheet().salariesByYear,
+    });
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
     );
 
     const matchedPlayer = makePlayer('matched_rfa', 'BOS', 9_000_000, {
@@ -1252,6 +1346,7 @@ describe('mutationPipeline trade persistence truth', () => {
       homeTeamCode: 'BOS',
       status: 'MATCHED',
       totalValue: 77_582_250,
+      governedLifecycle: governed.lifecycle,
     });
 
     seedBasePlayer(matchedPlayer);
@@ -1299,10 +1394,11 @@ describe('mutationPipeline trade persistence truth', () => {
         teamCode: 'BOS',
         offeringTeamCode: 'LAL',
         offerSheetId: matchedOfferSheet.id,
+        offerSheetResolutionAt: governed.resolutionAt,
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
     expect(result.changedPlayers?.map((entry) => entry.playerId)).toEqual([
       'matched_rfa',
     ]);
@@ -1340,9 +1436,22 @@ describe('mutationPipeline trade persistence truth', () => {
 
   it('persists finalizeDeclinedOfferSheet as canonical movement with destination upsert and source delete', async () => {
     const worldId = 'world_offer_sheet_declined_truth';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId: 'declined_rfa',
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      offerSheetId: 'os_decline_truth',
+      salariesByYear: makeOfferSheet().salariesByYear,
+    });
     seedWorldMetadata(
       worldId,
-      createMockWorld({ worldId, userId: USER_ID, currentSeason: SEASON_ID })
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
     );
 
     const declinedPlayer = makePlayer('declined_rfa', 'BOS', 8_000_000, {
@@ -1362,6 +1471,7 @@ describe('mutationPipeline trade persistence truth', () => {
       homeTeamCode: 'BOS',
       status: 'DECLINED',
       totalValue: 77_582_250,
+      governedLifecycle: governed.lifecycle,
     });
 
     seedBasePlayer(declinedPlayer);
@@ -1424,10 +1534,11 @@ describe('mutationPipeline trade persistence truth', () => {
         offeringTeamCode: 'LAL',
         offerSheetId: declinedOfferSheet.id,
         dedupKey: declinedOfferSheet.dedupKey,
+        offerSheetResolutionAt: governed.resolutionAt,
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success, String(result.error)).toBe(true);
     expect(result.changedPlayers?.map((entry) => entry.playerId)).toEqual([
       'declined_rfa',
     ]);

--- a/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
+++ b/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
@@ -3,8 +3,10 @@ import { getDoc } from 'firebase/firestore';
 import {
   applyWorldMutation,
   computeWorldMutation,
+  persistWorldMutation,
   type ArchitectMutationContract,
 } from '@/features/architect/utils/mutationPipeline';
+import { loadStateForMutation } from '@/features/architect/utils/mutationPipeline.read.stateLoader';
 import { getMockTeamSnapshot } from '../helpers/architectTestHelpers.js';
 import {
   createMockPlayer,
@@ -20,7 +22,7 @@ import {
   type MockTeam,
   type MockTeamSnapshot,
 } from '../helpers/architectTestHelpers.js';
-import { resetMockDataStore } from '../__mocks__/firebase.js';
+import { getAllMockData, resetMockDataStore } from '../__mocks__/firebase.js';
 import { getPlayer } from '@/features/architect/utils/teamLoader';
 import { worldPlayerRef } from '@/features/architect/utils/architectFirestorePaths';
 import { makeGovernedOfferSheetFixture } from '../fixtures/architect/governedOfferSheet';
@@ -1172,6 +1174,148 @@ describe('mutationPipeline trade persistence truth', () => {
     expect(
       getIncomingOfferSheets(requireTeamSnapshot(worldId, 'BOS'))
     ).toHaveLength(0);
+  });
+
+  it('rejects a stale competing resolution without overwriting the committed lifecycle', async () => {
+    const worldId = 'world_offer_sheet_resolution_race';
+    const governed = makeGovernedOfferSheetFixture({
+      worldId,
+      playerId: 'resolution_race_rfa',
+      homeTeamId: 'BOS',
+      offeringTeamId: 'LAL',
+      salariesByYear: makeStoredOfferSheetContract().salariesByYear,
+    });
+    seedWorldMetadata(
+      worldId,
+      createMockWorld({
+        worldId,
+        userId: USER_ID,
+        currentSeason: SEASON_ID,
+        asOfDate: governed.asOfDate,
+      })
+    );
+
+    const player = makePlayer('resolution_race_rfa', 'BOS', 9_000_000, {
+      displayName: 'Resolution Race Player',
+      contract: makeContract(9_000_000, {
+        contractType: 'Standard',
+        signingTeam: 'BOS',
+      }),
+      rfaContext: { governedEvidence: governed.evidence },
+    });
+    const lalKeeper = makePlayer('lal_keeper_resolution_race', 'LAL', 7_000_000);
+    seedBasePlayer(player);
+    seedBasePlayer(lalKeeper);
+    seedTeamSnapshot(
+      worldId,
+      'BOS',
+      {
+        ...makeTeam('BOS', [player]),
+        incomingOfferSheets: [],
+        rightsLedger: governed.rightsLedger,
+      },
+      { padRoster: false }
+    );
+    seedTeamSnapshot(
+      worldId,
+      'LAL',
+      { ...makeTeam('LAL', [lalKeeper]), offerSheets: [] },
+      { padRoster: false }
+    );
+    seedPlayerOverride(worldId, 'BOS', player);
+
+    const stored = await applyWorldMutation({
+      userId: USER_ID,
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'storeOfferSheet',
+      timestamp: TIMESTAMP,
+      payload: {
+        teamCode: 'LAL',
+        playerId: 'resolution_race_rfa',
+        worldId,
+        contract: makeStoredOfferSheetContract(),
+        offerSheetProposal: governed.proposal,
+        signedUsing: 'Cap Space',
+      },
+    });
+    expect(stored.success, String(stored.error)).toBe(true);
+
+    const offerSheetId = requireValue(
+      getOfferSheets(requireTeamSnapshot(worldId, 'LAL'))[0]?.id,
+      'Expected a pending Offer Sheet for the concurrency fixture'
+    );
+    const resolutionPayload = {
+      teamCode: 'BOS',
+      homeTeamCode: 'BOS',
+      offeringTeamCode: 'LAL',
+      offerSheetId,
+      offerSheetResolutionAt: governed.resolutionAt,
+    };
+    const currentState = await loadStateForMutation(
+      worldId,
+      'matchOfferSheet',
+      resolutionPayload
+    );
+    const commonComputeInput = {
+      payload: resolutionPayload,
+      currentState,
+      seasonId: SEASON_ID,
+      timestamp: TIMESTAMP + 1,
+      asOfDate: governed.asOfDate,
+      worldId,
+    };
+    const winningMatch = computeWorldMutation({
+      mutationType: 'matchOfferSheet',
+      ...commonComputeInput,
+    });
+    const staleDecline = computeWorldMutation({
+      mutationType: 'declineOfferSheet',
+      ...commonComputeInput,
+    });
+    expect(winningMatch.success, String(winningMatch.error)).toBe(true);
+    expect(staleDecline.success, String(staleDecline.error)).toBe(true);
+
+    const winnerPersisted = await persistWorldMutation({
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'matchOfferSheet',
+      computeResult: winningMatch,
+      committedTeamUpdates: winningMatch.teamUpdates ?? [],
+      timestamp: TIMESTAMP + 1,
+    });
+    expect(winnerPersisted.success, String(winnerPersisted.error)).toBe(true);
+
+    const homeAfterWinner = JSON.stringify(requireTeamSnapshot(worldId, 'BOS'));
+    const offeringAfterWinner = JSON.stringify(
+      requireTeamSnapshot(worldId, 'LAL')
+    );
+    const eventCountAfterWinner = [...getAllMockData().keys()].filter((key) =>
+      key.includes('/events/')
+    ).length;
+
+    const stalePersisted = await persistWorldMutation({
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'declineOfferSheet',
+      computeResult: staleDecline,
+      committedTeamUpdates: staleDecline.teamUpdates ?? [],
+      timestamp: TIMESTAMP + 2,
+    });
+
+    expect(stalePersisted.success).toBe(false);
+    if (!stalePersisted.success) {
+      expect(stalePersisted.error).toContain('changed before commit');
+    }
+    expect(JSON.stringify(requireTeamSnapshot(worldId, 'BOS'))).toBe(
+      homeAfterWinner
+    );
+    expect(JSON.stringify(requireTeamSnapshot(worldId, 'LAL'))).toBe(
+      offeringAfterWinner
+    );
+    expect(
+      [...getAllMockData().keys()].filter((key) => key.includes('/events/'))
+    ).toHaveLength(eventCountAfterWinner);
   });
 
   it('keeps E4 declined resolution compatible for offer sheets created under the strict store path', async () => {

--- a/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
+++ b/tests/architect/mutationPipeline.tradePersistenceTruth.test.ts
@@ -1276,6 +1276,71 @@ describe('mutationPipeline trade persistence truth', () => {
     expect(winningMatch.success, String(winningMatch.error)).toBe(true);
     expect(staleDecline.success, String(staleDecline.error)).toBe(true);
 
+    const offeringBeforeConcurrentEdit = requireTeamSnapshot(worldId, 'LAL');
+    const eventCountBeforeConcurrentEdit = [...getAllMockData().keys()].filter(
+      (key) => key.includes('/events/')
+    ).length;
+    seedMockData(`architect_worlds/${worldId}/teams/LAL`, {
+      ...offeringBeforeConcurrentEdit,
+      teamName: 'Concurrent unrelated Team edit',
+    });
+
+    const staleAfterUnrelatedEdit = await persistWorldMutation({
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'matchOfferSheet',
+      computeResult: winningMatch,
+      committedTeamUpdates: winningMatch.teamUpdates ?? [],
+      timestamp: TIMESTAMP + 1,
+    });
+    expect(staleAfterUnrelatedEdit.success).toBe(false);
+    if (!staleAfterUnrelatedEdit.success) {
+      expect(staleAfterUnrelatedEdit.error).toContain('changed before commit');
+    }
+    expect(requireTeamSnapshot(worldId, 'LAL').teamName).toBe(
+      'Concurrent unrelated Team edit'
+    );
+    expect(
+      [...getAllMockData().keys()].filter((key) => key.includes('/events/'))
+    ).toHaveLength(eventCountBeforeConcurrentEdit);
+
+    seedMockData(
+      `architect_worlds/${worldId}/teams/LAL`,
+      offeringBeforeConcurrentEdit
+    );
+
+    const homePlayerPath =
+      `architect_worlds/${worldId}/teams/BOS/players/resolution_race_rfa`;
+    const homePlayerBeforeConcurrentEdit = requireValue(
+      getAllMockData().get(homePlayerPath),
+      'Expected a home player override for the concurrency fixture'
+    );
+    seedMockData(homePlayerPath, {
+      ...(homePlayerBeforeConcurrentEdit as Record<string, unknown>),
+      displayName: 'Concurrent player override edit',
+    });
+
+    const staleAfterPlayerEdit = await persistWorldMutation({
+      worldId,
+      seasonId: SEASON_ID,
+      mutationType: 'matchOfferSheet',
+      computeResult: winningMatch,
+      committedTeamUpdates: winningMatch.teamUpdates ?? [],
+      timestamp: TIMESTAMP + 1,
+    });
+    expect(staleAfterPlayerEdit.success).toBe(false);
+    if (!staleAfterPlayerEdit.success) {
+      expect(staleAfterPlayerEdit.error).toContain('changed before commit');
+    }
+    expect(getAllMockData().get(homePlayerPath)).toMatchObject({
+      displayName: 'Concurrent player override edit',
+    });
+    expect(
+      [...getAllMockData().keys()].filter((key) => key.includes('/events/'))
+    ).toHaveLength(eventCountBeforeConcurrentEdit);
+
+    seedMockData(homePlayerPath, homePlayerBeforeConcurrentEdit);
+
     const winnerPersisted = await persistWorldMutation({
       worldId,
       seasonId: SEASON_ID,

--- a/tests/architect/offerSheetPersistence.test.ts
+++ b/tests/architect/offerSheetPersistence.test.ts
@@ -18,6 +18,13 @@ import {
   type ArchitectMutationResult,
   type ArchitectMutationTeamRecord,
 } from '../../src/features/architect/utils/mutationPipeline';
+import {
+  makeGovernedOfferSheetEvidence,
+  makeGovernedOfferSheetContract,
+  makeGovernedOfferSheetProposal,
+  makeGovernedOfferSheetRightsLedger,
+} from '../fixtures/architect/governedOfferSheet';
+import type { GovernedOfferSheetProposal } from '@/schemas/governedOfferSheet';
 
 type ComputeWorldMutationArgs = Parameters<typeof computeWorldMutation>[0];
 type StoreOfferSheetArgs = Extract<
@@ -61,6 +68,7 @@ type StoreOfferSheetPayload = {
   playerId: string;
   worldId: string;
   offerSheetId?: string;
+  offerSheetProposal: GovernedOfferSheetProposal;
   contract: OfferSheetContractPayload;
 };
 
@@ -376,6 +384,9 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       displayName: 'Test Player',
       teamCode: 'BOS',
       contract: { signingTeam: 'BOS' },
+      rfaContext: {
+        governedEvidence: makeGovernedOfferSheetEvidence(),
+      },
     };
 
     const baseHomeTeam: StoreOfferSheetHomeTeam = {
@@ -391,6 +402,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       ],
       roster: ['player123'],
       incomingOfferSheets: [],
+      rightsLedger: makeGovernedOfferSheetRightsLedger(),
     };
 
     return {
@@ -417,6 +429,44 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
     overrides: StoreOfferSheetPayloadOverrides = {}
   ): StoreOfferSheetPayload => {
     const contractOverrides = overrides.contract ?? {};
+    const requestedRows = contractOverrides.salariesByYear ?? [
+      {
+        season: '2025-26',
+        salary: 25_000_000,
+        capHit: 25_000_000,
+        guaranteed: true,
+      },
+      {
+        season: '2026-27',
+        salary: 26_250_000,
+        capHit: 26_250_000,
+        guaranteed: true,
+      },
+    ];
+    const salaryRows =
+      requestedRows.length === 1
+        ? [
+            ...requestedRows,
+            {
+              ...requestedRows[0],
+              season: '2026-27',
+              salary: Math.round(requestedRows[0].salary * 1.05),
+              capHit: Math.round(requestedRows[0].capHit * 1.05),
+            },
+          ]
+        : requestedRows;
+    const offerSheetProposal = makeGovernedOfferSheetProposal({
+      salariesByYear: salaryRows.map((row) => ({
+        season: row.season,
+        salaryExcludingIncentive: row.salary,
+        regularSalary: row.salary,
+        bonuses: [],
+        guaranteedForLackOfSkill: true,
+        guaranteedForInjuryOrIllness: true,
+        individuallyNegotiatedProtectionConditions: false,
+        option: null,
+      })),
+    });
 
     return {
       teamCode: overrides.teamCode ?? 'LAL',
@@ -425,21 +475,15 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       ...(overrides.offerSheetId
         ? { offerSheetId: overrides.offerSheetId }
         : {}),
+      offerSheetProposal,
       contract: {
+        ...contractOverrides,
         rfaOfferSheet: true,
         rfaOfferSheetOnly: true,
         rfaOfferSheetStatus: 'PENDING_MATCH',
         contractYears: 4,
         totalValue: 100000000,
-        salariesByYear: contractOverrides.salariesByYear ?? [
-          {
-            season: '2025-26',
-            salary: 25000000,
-            capHit: 25000000,
-            guaranteed: true,
-          },
-        ],
-        ...contractOverrides,
+        salariesByYear: salaryRows,
       },
     };
   };
@@ -450,11 +494,11 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
 
       const result = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: createMockPayload({ offerSheetId: 'os_world_time' }),
         currentState: createMockState(),
         seasonId: '2025-26',
         timestamp: wallClockTimestamp,
-        asOfDate: '2026-07-01',
       });
 
       expect(result.success).toBe(true);
@@ -469,8 +513,8 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       );
 
       expect(offeringSheet.id).toBe(`os_world_time`);
-      expect(offeringSheet.createdAt).toBe('2026-07-01T00:00:00.000Z');
-      expect(homeSheet.createdAt).toBe('2026-07-01T00:00:00.000Z');
+      expect(offeringSheet.createdAt).toBe('2025-07-08T10:00:00-04:00');
+      expect(homeSheet.createdAt).toBe('2025-07-08T10:00:00-04:00');
       expect(offeringSheet.createdAt).not.toBe(
         new Date(wallClockTimestamp).toISOString()
       );
@@ -479,11 +523,11 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
     it('allows Match through D+2, blocks after the window, and leaves Decline unblocked', () => {
       const storeResult = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: createMockPayload({ offerSheetId: 'os_match_window' }),
         currentState: createMockState(),
         seasonId: '2025-26',
         timestamp: Date.parse('2026-03-25T12:00:00.000Z'),
-        asOfDate: '2026-07-01',
       });
 
       const offerSheet = requireValue(
@@ -491,7 +535,10 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
         'Expected incoming offer sheet for match-window validation'
       );
 
-      for (const asOfDate of ['2026-07-01', '2026-07-02', '2026-07-03']) {
+      for (const asOfDate of [
+        '2025-07-08T10:00:00-04:00',
+        '2025-07-09T23:59:59-04:00',
+      ]) {
         const result = validateOfferSheetResolution({
           offerSheet,
           actingTeamCode: 'BOS',
@@ -508,7 +555,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
         offerSheet,
         actingTeamCode: 'BOS',
         action: 'match',
-        asOfDate: '2026-07-04',
+        asOfDate: '2025-07-10T00:00:00-04:00',
       });
 
       expect(expiredMatch.valid).toBe(false);
@@ -522,7 +569,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
         offerSheet,
         actingTeamCode: 'BOS',
         action: 'decline',
-        asOfDate: '2026-07-04',
+        asOfDate: '2025-07-10T00:00:00-04:00',
       });
 
       expect(lateDecline.valid).toBe(true);
@@ -538,6 +585,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       const payload1 = createMockPayload({ offerSheetId: 'os_test_1' });
       const result1 = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: payload1,
         currentState,
         seasonId: '2025-26',
@@ -567,6 +615,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       const payload2 = createMockPayload({ offerSheetId: 'os_test_2' });
       const result2 = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: payload2,
         currentState: stateAfterFirst,
         seasonId: '2025-26',
@@ -598,7 +647,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       ).toBe('os:world_test_123:LAL:player123:2025-26');
     });
 
-    it('should update contract terms in place on second store', () => {
+    it('should reject a retry that changes signed contract terms', () => {
       const currentState = createMockState();
 
       // First store with original salary
@@ -621,6 +670,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       });
       const result1 = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: payload1,
         currentState,
         seasonId: '2025-26',
@@ -654,32 +704,16 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
       });
       const result2 = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: payload2,
         currentState: stateAfterFirst,
         seasonId: '2025-26',
         timestamp: Date.now() + 1000,
       });
 
-      const offeringTeamAfter2 = getUpdatedTeam(result2, 'LAL');
-      const offeringTeamAfter2OfferSheets = getOfferSheets(
-        offeringTeamAfter2,
-        'LAL'
-      );
-      const updatedOfferSheet = requireValue(
-        offeringTeamAfter2OfferSheets[0],
-        'Expected updated offer sheet after second store'
-      );
-
-      // Should still be 1 entry
-      expect(offeringTeamAfter2OfferSheets).toHaveLength(1);
-      // Should have UPDATED totalValue
-      expect(updatedOfferSheet.totalValue).toBe(120000000);
-      expect(
-        requireValue(
-          updatedOfferSheet.salariesByYear?.[0],
-          'Expected updated salary row'
-        ).salary
-      ).toBe(30000000);
+      expect(result2.success).toBe(false);
+      expect(String(result2.error)).toContain('signed Principal Terms');
+      expect(result2.teamUpdates ?? []).toHaveLength(0);
     });
   });
 
@@ -694,6 +728,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
 
       const result1 = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: payload1,
         currentState,
         seasonId: '2025-26',
@@ -726,6 +761,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
 
       const result2 = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: payload2,
         currentState: stateAfterFirst,
         seasonId: '2025-26',
@@ -756,6 +792,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
     it('fails closed when authoritative home team is missing', () => {
       const result = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: createMockPayload(),
         currentState: {
           team: createMockState().team,
@@ -776,6 +813,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
     it('fails closed when home team resolves to the offering team', () => {
       const result = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: createMockPayload(),
         currentState: createMockState({
           homeTeam: {
@@ -807,6 +845,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
     it('fails closed when canonical player truth is not backed by the home-team snapshot player', () => {
       const result = computeWorldMutation({
         mutationType: 'storeOfferSheet',
+        asOfDate: '2025-07-08',
         payload: createMockPayload(),
         currentState: createMockState({
           homeTeam: {
@@ -847,14 +886,22 @@ describe('Phase 18.2: worldId Required for Offer Sheet Identity', () => {
       displayName: 'Test Player',
       teamCode: 'BOS',
       contract: { signingTeam: 'BOS' },
+      rfaContext: { governedEvidence: makeGovernedOfferSheetEvidence() },
     },
     teamCode: 'LAL',
     homeTeam: {
       teamCode: 'BOS',
       teamName: 'Boston Celtics',
-      players: [{ player_id: 'player123', name: 'Test Player' }],
+      players: [
+        {
+          player_id: 'player123',
+          name: 'Test Player',
+          rfaContext: { governedEvidence: makeGovernedOfferSheetEvidence() },
+        },
+      ],
       roster: ['player123'],
       incomingOfferSheets: [],
+      rightsLedger: makeGovernedOfferSheetRightsLedger(),
     },
   });
 
@@ -930,29 +977,18 @@ describe('Phase 18.2: worldId Required for Offer Sheet Identity', () => {
 
   it('should SUCCEED when worldId is provided', () => {
     const currentState = createMockState();
-
+    const proposal = makeGovernedOfferSheetProposal();
     const payload = {
       teamCode: 'LAL',
       playerId: 'player123',
-      worldId: 'world_test_123', // Valid worldId
-      contract: {
-        rfaOfferSheet: true,
-        rfaOfferSheetOnly: true,
-        contractYears: 4,
-        totalValue: 100000000,
-        salariesByYear: [
-          {
-            season: '2025-26',
-            salary: 25000000,
-            capHit: 25000000,
-            guaranteed: true,
-          },
-        ],
-      },
+      worldId: 'world_test_123',
+      contract: makeGovernedOfferSheetContract(proposal),
+      offerSheetProposal: proposal,
     };
 
     const result = computeWorldMutation({
       mutationType: 'storeOfferSheet',
+      asOfDate: '2025-07-08',
       payload,
       currentState,
       seasonId: '2025-26',
@@ -967,8 +1003,8 @@ describe('Phase 18.2: worldId Required for Offer Sheet Identity', () => {
 // Phase 18.2: Cleanup by dedupKey Tests
 // ==============================================================================
 
-describe('Phase 18.2: finalizeDeclinedOfferSheet Cleanup by dedupKey', () => {
-  it('should remove offer sheet from BOTH teams when arrays have different IDs but same dedupKey', () => {
+describe('Phase 18.2: legacy finalization boundary', () => {
+  it('fails closed when legacy mirrors have no governed lifecycle', () => {
     const dedupKey = 'os:world1:LAL:player123:2025-26';
 
     // Create state where offering team and home team have DIFFERENT IDs for same offer
@@ -1048,22 +1084,14 @@ describe('Phase 18.2: finalizeDeclinedOfferSheet Cleanup by dedupKey', () => {
       timestamp: Date.now(),
     });
 
-    expect(result.success).toBe(true);
-
-    const offeringTeamResult = getUpdatedTeam(result, 'LAL');
-    const homeTeamResult = getUpdatedTeam(result, 'BOS');
-
-    // Both arrays should be empty
-    expect(getOfferSheets(offeringTeamResult, 'LAL')).toHaveLength(0);
-    expect(getIncomingOfferSheets(homeTeamResult, 'BOS')).toHaveLength(0);
-
-    // Player should be added to offering team roster
-    expect(offeringTeamResult.roster).toContain('player123');
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain('governed Offer Sheet lifecycle');
+    expect(result.teamUpdates ?? []).toHaveLength(0);
   });
 });
 
-describe('E4: Offer sheet finalization canonical persistence manifests', () => {
-  it('finalizeMatchedOfferSheet emits a same-team player upsert with no delete path', () => {
+describe('E4: legacy finalization authority guard', () => {
+  it('finalizeMatchedOfferSheet rejects an ungoverned historical fragment', () => {
     const offerSheet = {
       id: 'os_match_e4',
       dedupKey: 'os:world1:LAL:player123:2025-26',
@@ -1143,21 +1171,12 @@ describe('E4: Offer sheet finalization canonical persistence manifests', () => {
       timestamp: Date.now(),
     });
 
-    expect(result.success).toBe(true);
-    expect(result.playerUpdates ?? []).toHaveLength(1);
-    expect(result.playerDeletes).toEqual([]);
-    const matchedPlayer = getUpdatedPlayer(result, 'player123');
-    expect(matchedPlayer.playerId).toBe('player123');
-    expect(matchedPlayer.teamCode).toBe('BOS');
-    expect(matchedPlayer.displayName).toBe('Canonical Matched Name');
-    expect(matchedPlayer.contract?.signedUsing).toBe('Match');
-
-    const homeTeamResult = getUpdatedTeam(result, 'BOS');
-    expect(getIncomingOfferSheets(homeTeamResult, 'BOS')).toHaveLength(0);
-    expect(homeTeamResult.capHolds).toHaveLength(0);
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain('governed Offer Sheet lifecycle');
+    expect(result.playerUpdates ?? []).toHaveLength(0);
   });
 
-  it('finalizeDeclinedOfferSheet emits move manifest and preserves canonical source player identity', () => {
+  it('finalizeDeclinedOfferSheet rejects an ungoverned historical fragment', () => {
     const offerSheet = {
       id: 'os_decline_e4',
       dedupKey: 'os:world1:LAL:player123:2025-26',
@@ -1247,23 +1266,9 @@ describe('E4: Offer sheet finalization canonical persistence manifests', () => {
       timestamp: Date.now(),
     });
 
-    expect(result.success).toBe(true);
-    expect(result.playerUpdates ?? []).toHaveLength(1);
-    expect(result.playerDeletes).toEqual([
-      { playerId: 'player123', teamCode: 'BOS' },
-    ]);
-    const declinedPlayer = getUpdatedPlayer(result, 'player123');
-    expect(declinedPlayer.teamCode).toBe('LAL');
-    expect(declinedPlayer.displayName).toBe('Canonical Source Name');
-    expect(declinedPlayer.displayName).not.toBe('Fragment-Only Name');
-    expect(declinedPlayer.contract?.signedUsing).toBe('Offer Sheet');
-
-    const offeringTeamResult = getUpdatedTeam(result, 'LAL');
-    const homeTeamResult = getUpdatedTeam(result, 'BOS');
-    expect(offeringTeamResult.roster).toContain('player123');
-    expect(offeringTeamResult.capHolds).toHaveLength(0);
-    expect(homeTeamResult.roster).not.toContain('player123');
-    expect(homeTeamResult.capHolds).toHaveLength(0);
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain('governed Offer Sheet lifecycle');
+    expect(result.playerUpdates ?? []).toHaveLength(0);
   });
 
   it('finalizeDeclinedOfferSheet fails closed when canonical source player cannot be resolved', () => {
@@ -1318,6 +1323,6 @@ describe('E4: Offer sheet finalization canonical persistence manifests', () => {
     });
 
     expect(result.success).toBe(false);
-    expect(String(result.error)).toContain('not found on home team roster');
+    expect(String(result.error)).toContain('governed Offer Sheet lifecycle');
   });
 });

--- a/tests/architect/offerSheetPersistence.test.ts
+++ b/tests/architect/offerSheetPersistence.test.ts
@@ -535,7 +535,7 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
         'Expected incoming offer sheet for match-window validation'
       );
 
-      for (const asOfDate of [
+      for (const resolutionAt of [
         '2025-07-08T10:00:00-04:00',
         '2025-07-09T23:59:59-04:00',
       ]) {
@@ -543,19 +543,22 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
           offerSheet,
           actingTeamCode: 'BOS',
           action: 'match',
-          asOfDate,
+          asOfDate: '2025-07-10',
+          resolutionAt,
         });
 
-        expect(result.valid, `Expected Match to be allowed on ${asOfDate}`).toBe(
-          true
-        );
+        expect(
+          result.valid,
+          `Expected Match to be allowed at ${resolutionAt}`
+        ).toBe(true);
       }
 
       const expiredMatch = validateOfferSheetResolution({
         offerSheet,
         actingTeamCode: 'BOS',
         action: 'match',
-        asOfDate: '2025-07-10T00:00:00-04:00',
+        asOfDate: '2025-07-10',
+        resolutionAt: '2025-07-10T00:00:00-04:00',
       });
 
       expect(expiredMatch.valid).toBe(false);
@@ -565,11 +568,31 @@ describe('Phase 18.2: Idempotency Proof - storeOfferSheet', () => {
         ])
       );
 
+      for (const resolutionAt of [undefined, '2025-07-09T23:59:59-05:00']) {
+        const invalidInstant = validateOfferSheetResolution({
+          offerSheet,
+          actingTeamCode: 'BOS',
+          action: 'match',
+          asOfDate: '2025-07-09T23:59:59-04:00',
+          resolutionAt,
+        });
+
+        expect(invalidInstant.valid).toBe(false);
+        expect(invalidInstant.violations).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              rule: 'offer_sheet_resolution_instant_required',
+            }),
+          ])
+        );
+      }
+
       const lateDecline = validateOfferSheetResolution({
         offerSheet,
         actingTeamCode: 'BOS',
         action: 'decline',
-        asOfDate: '2025-07-10T00:00:00-04:00',
+        asOfDate: '2025-07-10',
+        resolutionAt: '2025-07-10T00:00:00-04:00',
       });
 
       expect(lateDecline.valid).toBe(true);

--- a/tests/e2e/architect-governed-offer-sheet.spec.ts
+++ b/tests/e2e/architect-governed-offer-sheet.spec.ts
@@ -1,7 +1,6 @@
 /** BZE-283 exact-head browser and persistence proof for governed RFA Offer Sheets. */
 
 import { expect, test, type Page, type TestInfo } from '@playwright/test';
-import admin from 'firebase-admin';
 
 import {
   makeGovernedOfferSheetFixture,
@@ -24,8 +23,6 @@ const HOME_TEAM = 'BOS';
 const OFFERING_TEAM = 'LAL';
 const PLAYER_ID = 'review_offer_sheet_guard';
 const PLAYER_NAME = 'Review Offer Sheet Guard';
-const AUTHOR_PLAYER_ID = 'bze283_offer_sheet_author';
-const AUTHOR_PLAYER_NAME = 'BZE 283 Offer Sheet Author';
 const LEGACY_PLAYER_NAME = 'Unreadable Legacy Offer';
 const WORLD_SEASON = '2025-26';
 const WORLD_AS_OF_DATE = '2025-07-10';
@@ -34,7 +31,6 @@ const OFFERING_URL = '/gm/LAL?season=2026';
 const RESOLUTION_AT = '2025-07-09T23:59:59-04:00';
 
 const seededWorldIds = new Set<string>();
-let basePlayerBefore: RecordLike | undefined;
 
 const teamPlayers = (team: RecordLike | undefined): RecordLike[] =>
   Array.isArray(team?.players)
@@ -72,25 +68,12 @@ const seedGovernedOfferSheetWorld = async (userId: string) => {
       { season: '2026-27', salary: 10_500_000 },
     ],
   });
-  const authorFixture = makeGovernedOfferSheetFixture({
-    worldId,
-    playerId: AUTHOR_PLAYER_ID,
-    homeTeamId: HOME_TEAM,
-    offeringTeamId: OFFERING_TEAM,
-    offerSheetId: 'bze-283-authoring-fixture',
-    salariesByYear: [
-      { season: '2025-26', salary: 9_000_000 },
-      { season: '2026-27', salary: 9_450_000 },
-    ],
-  });
-  const [world, homeTeam, offeringTeam, basePlayerSnapshot] = await Promise.all(
-    [
-      db.doc(`architect_worlds/${worldId}`).get(),
-      getWorldTeamDocument(worldId, HOME_TEAM),
-      getWorldTeamDocument(worldId, OFFERING_TEAM),
-      db.doc(`architect_basePlayers/${PLAYER_ID}`).get(),
-    ]
-  );
+  const [world, homeTeam, offeringTeam, basePlayerSnapshot] = await Promise.all([
+    db.doc(`architect_worlds/${worldId}`).get(),
+    getWorldTeamDocument(worldId, HOME_TEAM),
+    getWorldTeamDocument(worldId, OFFERING_TEAM),
+    db.doc(`architect_basePlayers/${PLAYER_ID}`).get(),
+  ]);
   if (
     !world.exists ||
     !homeTeam ||
@@ -99,10 +82,10 @@ const seedGovernedOfferSheetWorld = async (userId: string) => {
   ) {
     throw new Error('BZE-283 review seed is incomplete.');
   }
-  basePlayerBefore = basePlayerSnapshot.data() as RecordLike;
+  const basePlayerData = basePlayerSnapshot.data() as RecordLike;
 
   const player: RecordLike = {
-    ...basePlayerBefore,
+    ...basePlayerData,
     id: PLAYER_ID,
     playerId: PLAYER_ID,
     player_id: PLAYER_ID,
@@ -157,118 +140,71 @@ const seedGovernedOfferSheetWorld = async (userId: string) => {
     totalValue: 16_400_000,
   };
 
-  await Promise.all([
-    world.ref.set(
-      {
-        currentSeason: WORLD_SEASON,
-        baselineSeason: WORLD_SEASON,
-        asOfDate: WORLD_AS_OF_DATE,
-        rightsLedgerVersion: 1,
-        contractBaselineVersion: 2,
-        contractSourceRelease: {
-          releaseId: 'bze-283-browser-offer-sheet',
-          releaseVersion: 1,
-          releaseDigest: `sha256:${'9'.repeat(64)}`,
-        },
-        contractBaselineEffectiveAt: '2025-07-01T00:00:00-04:00',
-        contractBaselineSalaryCapYear: 2026,
-        contractBaselineCoverage: {
-          total: 0,
-          complete: 0,
-          needsInput: 0,
-        },
-        description:
-          'BZE-283 deterministic governed Offer Sheet browser proof.',
+  await world.ref.set(
+    {
+      currentSeason: WORLD_SEASON,
+      baselineSeason: WORLD_SEASON,
+      asOfDate: WORLD_AS_OF_DATE,
+      rightsLedgerVersion: 1,
+      contractBaselineVersion: 2,
+      contractSourceRelease: {
+        releaseId: 'bze-283-browser-offer-sheet',
+        releaseVersion: 1,
+        releaseDigest: `sha256:${'9'.repeat(64)}`,
       },
-      { merge: true }
-    ),
-    db.doc(`architect_basePlayers/${PLAYER_ID}`).set(
-      {
-        ...basePlayerBefore,
-        rfaContext: { governedEvidence: fixture.evidence },
+      contractBaselineEffectiveAt: '2025-07-01T00:00:00-04:00',
+      contractBaselineSalaryCapYear: 2026,
+      contractBaselineCoverage: {
+        total: 0,
+        complete: 0,
+        needsInput: 0,
       },
-      { merge: false }
-    ),
-    db.doc(`architect_basePlayers/${AUTHOR_PLAYER_ID}`).set(
-      {
-        id: AUTHOR_PLAYER_ID,
-        playerId: AUTHOR_PLAYER_ID,
-        player_id: AUTHOR_PLAYER_ID,
-        name: AUTHOR_PLAYER_NAME,
-        displayName: AUTHOR_PLAYER_NAME,
-        teamId: HOME_TEAM,
-        teamCode: null,
-        teamName: 'Free Agent',
-        position: 'G',
-        bio: { position: 'G', age: 25, experience: 3 },
-        contract: {
-          contractType: 'VETERAN CONTRACT',
-          signingTeam: HOME_TEAM,
-          startSeason: '2024-25',
-          endSeason: '2025-26',
-          contractLength: 2,
-          yearsRemaining: 0,
-          salariesByYear: [
-            {
-              season: '2024-25',
-              salary: 4_000_000,
-              capHit: 4_000_000,
-              guaranteed: true,
-            },
-            {
-              season: '2025-26',
-              salary: 4_400_000,
-              capHit: 4_400_000,
-              guaranteed: true,
-            },
-          ],
-          birdRights: { status: 'Restricted' },
-          freeAgency: { type: 'RFA', year: 2026, capHold: 6_600_000 },
-        },
-        rfaContext: { governedEvidence: authorFixture.evidence },
-        source: { provider: 'BZE-283 Playwright fixture' },
-      },
-      { merge: false }
-    ),
-    db.doc(`architect_worlds/${worldId}/teams/${HOME_TEAM}`).set(
-      {
-        ...homeTeam,
-        season: WORLD_SEASON,
-        players: [
-          ...teamPlayers(homeTeam).filter(
-            (candidate) =>
-              String(candidate.playerId || candidate.id || '') !== PLAYER_ID
-          ),
-          player,
-        ],
-        roster: [
-          ...new Set([
-            ...(Array.isArray(homeTeam.roster)
-              ? homeTeam.roster.map((entry) =>
-                  typeof entry === 'string'
-                    ? entry
-                    : String((entry as RecordLike)?.playerId || '')
-                )
-              : []),
-            PLAYER_ID,
-          ]),
-        ].filter(Boolean),
-        incomingOfferSheets: [governedOfferSheet, unreadableOfferSheet],
-        rightsLedger: fixture.rightsLedger,
-      },
-      { merge: false }
-    ),
-    db.doc(`architect_worlds/${worldId}/teams/${OFFERING_TEAM}`).set(
-      {
-        ...offeringTeam,
-        season: WORLD_SEASON,
-        offerSheets: [governedOfferSheet],
-      },
-      { merge: false }
-    ),
-  ]);
+      description: 'BZE-283 deterministic governed Offer Sheet browser proof.',
+    },
+    { merge: true }
+  );
 
-  return { worldId, fixture };
+  const stagePendingOfferSheet = () =>
+    Promise.all([
+      db.doc(`architect_worlds/${worldId}/teams/${HOME_TEAM}`).set(
+        {
+          ...homeTeam,
+          season: WORLD_SEASON,
+          players: [
+            ...teamPlayers(homeTeam).filter(
+              (candidate) =>
+                String(candidate.playerId || candidate.id || '') !== PLAYER_ID
+            ),
+            player,
+          ],
+          roster: [
+            ...new Set([
+              ...(Array.isArray(homeTeam.roster)
+                ? homeTeam.roster.map((entry) =>
+                    typeof entry === 'string'
+                      ? entry
+                      : String((entry as RecordLike)?.playerId || '')
+                  )
+                : []),
+              PLAYER_ID,
+            ]),
+          ].filter(Boolean),
+          incomingOfferSheets: [governedOfferSheet, unreadableOfferSheet],
+          rightsLedger: fixture.rightsLedger,
+        },
+        { merge: false }
+      ),
+      db.doc(`architect_worlds/${worldId}/teams/${OFFERING_TEAM}`).set(
+        {
+          ...offeringTeam,
+          season: WORLD_SEASON,
+          offerSheets: [governedOfferSheet],
+        },
+        { merge: false }
+      ),
+    ]);
+
+  return { worldId, fixture, stagePendingOfferSheet };
 };
 
 const waitForUser = async (page: Page) => {
@@ -288,7 +224,7 @@ const capture = async (page: Page, testInfo: TestInfo, name: string) => {
 };
 
 test.describe('BZE-283 governed Offer Sheet browser proof', () => {
-  test.describe.configure({ mode: 'serial', timeout: 300_000 });
+  test.describe.configure({ mode: 'serial', timeout: 240_000 });
 
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
@@ -305,25 +241,19 @@ test.describe('BZE-283 governed Offer Sheet browser proof', () => {
       )
     );
     seededWorldIds.clear();
-    if (basePlayerBefore) {
-      await db
-        .doc(`architect_basePlayers/${PLAYER_ID}`)
-        .set(basePlayerBefore, { merge: false });
-      basePlayerBefore = undefined;
-    }
-    await db.doc(`architect_basePlayers/${AUTHOR_PLAYER_ID}`).delete();
   });
 
   test('authors exact notice evidence, rejects an unreadable row, and persists an exact matched result through reload', async ({
     page,
   }, testInfo) => {
     const userId = await waitForUser(page);
-    const { worldId } = await seedGovernedOfferSheetWorld(userId);
+    const { worldId, stagePendingOfferSheet } =
+      await seedGovernedOfferSheetWorld(userId);
     await activateSeededWorld(page, userId, worldId);
 
     await openDashboardTab(page, 'Free Agency');
     const freeAgentRow = page.locator('li').filter({
-      has: page.getByText(new RegExp(`^${AUTHOR_PLAYER_NAME}$`, 'i')),
+      has: page.getByText(PLAYER_NAME, { exact: true }),
     });
     await expect(freeAgentRow).toBeVisible({ timeout: 20_000 });
     await freeAgentRow
@@ -350,6 +280,7 @@ test.describe('BZE-283 governed Offer Sheet browser proof', () => {
       .fill(makeGovernedOfferSheetProposal().receivedAt);
     await capture(page, testInfo, 'BZE-283-exact-notice-authoring');
     await modal.getByRole('button', { name: /^Cancel$/i }).click();
+    await stagePendingOfferSheet();
 
     await page.goto(HOME_URL, { waitUntil: 'domcontentloaded' });
     await waitForReviewDashboard(page);

--- a/tests/e2e/architect-governed-offer-sheet.spec.ts
+++ b/tests/e2e/architect-governed-offer-sheet.spec.ts
@@ -1,0 +1,470 @@
+/** BZE-283 exact-head browser and persistence proof for governed RFA Offer Sheets. */
+
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import admin from 'firebase-admin';
+
+import {
+  makeGovernedOfferSheetFixture,
+  makeGovernedOfferSheetProposal,
+} from '../fixtures/architect/governedOfferSheet';
+import {
+  activateSeededWorld,
+  enableArchitectReviewFlags,
+  getReviewAdminDb,
+  getWorldEventDocuments,
+  getWorldTeamDocument,
+  openDashboardTab,
+  readReviewUserId,
+  seedSeasonAdvanceReviewWorld,
+  waitForReviewDashboard,
+  type RecordLike,
+} from './helpers/architectReviewWorld';
+
+const HOME_TEAM = 'BOS';
+const OFFERING_TEAM = 'LAL';
+const PLAYER_ID = 'review_offer_sheet_guard';
+const PLAYER_NAME = 'Review Offer Sheet Guard';
+const AUTHOR_PLAYER_ID = 'bze283_offer_sheet_author';
+const AUTHOR_PLAYER_NAME = 'BZE 283 Offer Sheet Author';
+const LEGACY_PLAYER_NAME = 'Unreadable Legacy Offer';
+const WORLD_SEASON = '2025-26';
+const WORLD_AS_OF_DATE = '2025-07-10';
+const HOME_URL = '/gm/BOS?season=2026';
+const OFFERING_URL = '/gm/LAL?season=2026';
+const RESOLUTION_AT = '2025-07-09T23:59:59-04:00';
+
+const seededWorldIds = new Set<string>();
+let basePlayerBefore: RecordLike | undefined;
+
+const teamPlayers = (team: RecordLike | undefined): RecordLike[] =>
+  Array.isArray(team?.players)
+    ? team.players.filter(
+        (player): player is RecordLike =>
+          Boolean(player) &&
+          typeof player === 'object' &&
+          !Array.isArray(player)
+      )
+    : [];
+
+const teamPlayer = (team: RecordLike | undefined, playerId: string) =>
+  teamPlayers(team).find((player) =>
+    [player.id, player.playerId, player.player_id].some(
+      (candidate) => String(candidate || '') === playerId
+    )
+  );
+
+const seedGovernedOfferSheetWorld = async (userId: string) => {
+  const db = getReviewAdminDb();
+  const worldId = await seedSeasonAdvanceReviewWorld(
+    userId,
+    `BZE 283 Offer Sheet Proof ${Date.now()}`
+  );
+  seededWorldIds.add(worldId);
+
+  const fixture = makeGovernedOfferSheetFixture({
+    worldId,
+    playerId: PLAYER_ID,
+    homeTeamId: HOME_TEAM,
+    offeringTeamId: OFFERING_TEAM,
+    offerSheetId: 'bze-283-governed-offer-sheet',
+    salariesByYear: [
+      { season: '2025-26', salary: 10_000_000 },
+      { season: '2026-27', salary: 10_500_000 },
+    ],
+  });
+  const authorFixture = makeGovernedOfferSheetFixture({
+    worldId,
+    playerId: AUTHOR_PLAYER_ID,
+    homeTeamId: HOME_TEAM,
+    offeringTeamId: OFFERING_TEAM,
+    offerSheetId: 'bze-283-authoring-fixture',
+    salariesByYear: [
+      { season: '2025-26', salary: 9_000_000 },
+      { season: '2026-27', salary: 9_450_000 },
+    ],
+  });
+  const [world, homeTeam, offeringTeam, basePlayerSnapshot] = await Promise.all(
+    [
+      db.doc(`architect_worlds/${worldId}`).get(),
+      getWorldTeamDocument(worldId, HOME_TEAM),
+      getWorldTeamDocument(worldId, OFFERING_TEAM),
+      db.doc(`architect_basePlayers/${PLAYER_ID}`).get(),
+    ]
+  );
+  if (
+    !world.exists ||
+    !homeTeam ||
+    !offeringTeam ||
+    !basePlayerSnapshot.exists
+  ) {
+    throw new Error('BZE-283 review seed is incomplete.');
+  }
+  basePlayerBefore = basePlayerSnapshot.data() as RecordLike;
+
+  const player: RecordLike = {
+    ...basePlayerBefore,
+    id: PLAYER_ID,
+    playerId: PLAYER_ID,
+    player_id: PLAYER_ID,
+    name: PLAYER_NAME,
+    displayName: PLAYER_NAME,
+    teamCode: HOME_TEAM,
+    teamId: HOME_TEAM,
+    teamName: 'Boston Celtics',
+    contract: {
+      signingTeam: HOME_TEAM,
+      salariesByYear: [],
+      freeAgency: { type: 'RFA', year: 2026, capHold: 7_200_000 },
+    },
+    rfaContext: { governedEvidence: fixture.evidence },
+  };
+  const totalValue = fixture.contract.salariesByYear.reduce(
+    (sum, row) => sum + Number(row.salary || 0),
+    0
+  );
+  const governedOfferSheet = {
+    id: 'bze-283-governed-offer-sheet',
+    dedupKey: `os:${worldId}:${OFFERING_TEAM}:${PLAYER_ID}:${WORLD_SEASON}`,
+    playerId: PLAYER_ID,
+    playerName: PLAYER_NAME,
+    offeringTeamCode: OFFERING_TEAM,
+    homeTeamCode: HOME_TEAM,
+    seasonKey: WORLD_SEASON,
+    year: 2026,
+    contractYears: fixture.contract.salariesByYear.length,
+    salariesByYear: fixture.contract.salariesByYear,
+    status: 'PENDING_MATCH',
+    createdAt: fixture.proposal.receivedAt,
+    totalValue,
+    governedLifecycle: fixture.lifecycle,
+  };
+  const unreadableOfferSheet = {
+    id: 'bze-283-unreadable-offer-sheet',
+    dedupKey: `os:${worldId}:NYK:legacy-player:${WORLD_SEASON}`,
+    playerId: 'legacy-player',
+    playerName: LEGACY_PLAYER_NAME,
+    offeringTeamCode: 'NYK',
+    homeTeamCode: HOME_TEAM,
+    seasonKey: WORLD_SEASON,
+    year: 2026,
+    contractYears: 2,
+    salariesByYear: [
+      { season: '2025-26', salary: 8_000_000, capHit: 8_000_000 },
+      { season: '2026-27', salary: 8_400_000, capHit: 8_400_000 },
+    ],
+    status: 'PENDING_MATCH',
+    createdAt: fixture.proposal.receivedAt,
+    totalValue: 16_400_000,
+  };
+
+  await Promise.all([
+    world.ref.set(
+      {
+        currentSeason: WORLD_SEASON,
+        baselineSeason: WORLD_SEASON,
+        asOfDate: WORLD_AS_OF_DATE,
+        rightsLedgerVersion: 1,
+        contractBaselineVersion: 2,
+        contractSourceRelease: {
+          releaseId: 'bze-283-browser-offer-sheet',
+          releaseVersion: 1,
+          releaseDigest: `sha256:${'9'.repeat(64)}`,
+        },
+        contractBaselineEffectiveAt: '2025-07-01T00:00:00-04:00',
+        contractBaselineSalaryCapYear: 2026,
+        contractBaselineCoverage: {
+          total: 0,
+          complete: 0,
+          needsInput: 0,
+        },
+        description:
+          'BZE-283 deterministic governed Offer Sheet browser proof.',
+      },
+      { merge: true }
+    ),
+    db.doc(`architect_basePlayers/${PLAYER_ID}`).set(
+      {
+        ...basePlayerBefore,
+        rfaContext: { governedEvidence: fixture.evidence },
+      },
+      { merge: false }
+    ),
+    db.doc(`architect_basePlayers/${AUTHOR_PLAYER_ID}`).set(
+      {
+        id: AUTHOR_PLAYER_ID,
+        playerId: AUTHOR_PLAYER_ID,
+        player_id: AUTHOR_PLAYER_ID,
+        name: AUTHOR_PLAYER_NAME,
+        displayName: AUTHOR_PLAYER_NAME,
+        teamId: HOME_TEAM,
+        teamCode: null,
+        teamName: 'Free Agent',
+        position: 'G',
+        bio: { position: 'G', age: 25, experience: 3 },
+        contract: {
+          contractType: 'VETERAN CONTRACT',
+          signingTeam: HOME_TEAM,
+          startSeason: '2024-25',
+          endSeason: '2025-26',
+          contractLength: 2,
+          yearsRemaining: 0,
+          salariesByYear: [
+            {
+              season: '2024-25',
+              salary: 4_000_000,
+              capHit: 4_000_000,
+              guaranteed: true,
+            },
+            {
+              season: '2025-26',
+              salary: 4_400_000,
+              capHit: 4_400_000,
+              guaranteed: true,
+            },
+          ],
+          birdRights: { status: 'Restricted' },
+          freeAgency: { type: 'RFA', year: 2026, capHold: 6_600_000 },
+        },
+        rfaContext: { governedEvidence: authorFixture.evidence },
+        source: { provider: 'BZE-283 Playwright fixture' },
+      },
+      { merge: false }
+    ),
+    db.doc(`architect_worlds/${worldId}/teams/${HOME_TEAM}`).set(
+      {
+        ...homeTeam,
+        season: WORLD_SEASON,
+        players: [
+          ...teamPlayers(homeTeam).filter(
+            (candidate) =>
+              String(candidate.playerId || candidate.id || '') !== PLAYER_ID
+          ),
+          player,
+        ],
+        roster: [
+          ...new Set([
+            ...(Array.isArray(homeTeam.roster)
+              ? homeTeam.roster.map((entry) =>
+                  typeof entry === 'string'
+                    ? entry
+                    : String((entry as RecordLike)?.playerId || '')
+                )
+              : []),
+            PLAYER_ID,
+          ]),
+        ].filter(Boolean),
+        incomingOfferSheets: [governedOfferSheet, unreadableOfferSheet],
+        rightsLedger: fixture.rightsLedger,
+      },
+      { merge: false }
+    ),
+    db.doc(`architect_worlds/${worldId}/teams/${OFFERING_TEAM}`).set(
+      {
+        ...offeringTeam,
+        season: WORLD_SEASON,
+        offerSheets: [governedOfferSheet],
+      },
+      { merge: false }
+    ),
+  ]);
+
+  return { worldId, fixture };
+};
+
+const waitForUser = async (page: Page) => {
+  await expect
+    .poll(() => readReviewUserId(page), {
+      timeout: 25_000,
+      message: 'anonymous review user should initialize',
+    })
+    .not.toBe('');
+  return readReviewUserId(page);
+};
+
+const capture = async (page: Page, testInfo: TestInfo, name: string) => {
+  const path = testInfo.outputPath(`${name}-1280x720.png`);
+  await page.screenshot({ path, fullPage: false });
+  await testInfo.attach(name, { path, contentType: 'image/png' });
+};
+
+test.describe('BZE-283 governed Offer Sheet browser proof', () => {
+  test.describe.configure({ mode: 'serial', timeout: 300_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await enableArchitectReviewFlags(page);
+    await page.goto(OFFERING_URL, { waitUntil: 'domcontentloaded' });
+    await waitForReviewDashboard(page);
+  });
+
+  test.afterEach(async () => {
+    const db = getReviewAdminDb();
+    await Promise.allSettled(
+      [...seededWorldIds].map((worldId) =>
+        db.recursiveDelete(db.doc(`architect_worlds/${worldId}`))
+      )
+    );
+    seededWorldIds.clear();
+    if (basePlayerBefore) {
+      await db
+        .doc(`architect_basePlayers/${PLAYER_ID}`)
+        .set(basePlayerBefore, { merge: false });
+      basePlayerBefore = undefined;
+    }
+    await db.doc(`architect_basePlayers/${AUTHOR_PLAYER_ID}`).delete();
+  });
+
+  test('authors exact notice evidence, rejects an unreadable row, and persists an exact matched result through reload', async ({
+    page,
+  }, testInfo) => {
+    const userId = await waitForUser(page);
+    const { worldId } = await seedGovernedOfferSheetWorld(userId);
+    await activateSeededWorld(page, userId, worldId);
+
+    await openDashboardTab(page, 'Free Agency');
+    const freeAgentRow = page.locator('li').filter({
+      has: page.getByText(new RegExp(`^${AUTHOR_PLAYER_NAME}$`, 'i')),
+    });
+    await expect(freeAgentRow).toBeVisible({ timeout: 20_000 });
+    await freeAgentRow
+      .locator('button')
+      .filter({ hasText: '•••' })
+      .first()
+      .click();
+    await page.getByRole('button', { name: /^Sign Free Agent$/i }).click();
+    const modal = page.getByTestId('edit-contract-modal');
+    await expect(modal).toBeVisible({ timeout: 20_000 });
+    await modal.getByRole('radio', { name: /Sign Free Agent/i }).check();
+    await modal.getByLabel(/^Offer Sheet$/i).check();
+    await expect(
+      modal.getByTestId('governed-offer-sheet-signed-at')
+    ).toBeVisible();
+    await expect(
+      modal.getByTestId('governed-offer-sheet-received-at')
+    ).toBeVisible();
+    await modal
+      .getByTestId('governed-offer-sheet-signed-at')
+      .fill(makeGovernedOfferSheetProposal().signedAt);
+    await modal
+      .getByTestId('governed-offer-sheet-received-at')
+      .fill(makeGovernedOfferSheetProposal().receivedAt);
+    await capture(page, testInfo, 'BZE-283-exact-notice-authoring');
+    await modal.getByRole('button', { name: /^Cancel$/i }).click();
+
+    await page.goto(HOME_URL, { waitUntil: 'domcontentloaded' });
+    await waitForReviewDashboard(page);
+    await activateSeededWorld(page, userId, worldId);
+    await openDashboardTab(page, 'Free Agency');
+    const incoming = page
+      .locator('div')
+      .filter({
+        has: page.getByRole('heading', { name: /Incoming Offer Sheets/i }),
+      })
+      .first();
+    const governedRow = incoming.locator('tr').filter({ hasText: PLAYER_NAME });
+    const unreadableRow = incoming
+      .locator('tr')
+      .filter({ hasText: LEGACY_PLAYER_NAME });
+    await expect(governedRow).toBeVisible({ timeout: 20_000 });
+    await expect(unreadableRow).toContainText(
+      /missing the saved notice record/i
+    );
+    await expect(
+      unreadableRow.getByRole('button', { name: /^Match$/i })
+    ).toBeDisabled();
+    const resolutionInput = governedRow.getByTestId(
+      'offer-sheet-resolution-at-bze-283-governed-offer-sheet'
+    );
+    await resolutionInput.fill('2025-07-09T23:59:59-05:00');
+    await expect(
+      governedRow.getByRole('button', { name: /^Match$/i })
+    ).toBeDisabled();
+    await resolutionInput.fill(RESOLUTION_AT);
+    await expect(
+      governedRow.getByRole('button', { name: /^Match$/i })
+    ).toBeEnabled();
+    await capture(page, testInfo, 'BZE-283-pending-and-fail-closed');
+    await governedRow.getByRole('button', { name: /^Match$/i }).click();
+
+    await expect(page.getByTestId('cockpit-last-receipt')).toContainText(
+      /Offer sheet matched/i,
+      { timeout: 25_000 }
+    );
+    await expect
+      .poll(
+        async () => {
+          const [home, offering] = await Promise.all([
+            getWorldTeamDocument(worldId, HOME_TEAM),
+            getWorldTeamDocument(worldId, OFFERING_TEAM),
+          ]);
+          const persistedPlayer = teamPlayer(home, PLAYER_ID);
+          const contract =
+            persistedPlayer?.contract &&
+            typeof persistedPlayer.contract === 'object' &&
+            !Array.isArray(persistedPlayer.contract)
+              ? (persistedPlayer.contract as RecordLike)
+              : {};
+          return {
+            homeIncoming: Array.isArray(home?.incomingOfferSheets)
+              ? home.incomingOfferSheets.filter(
+                  (sheet) =>
+                    String((sheet as RecordLike)?.playerId || '') === PLAYER_ID
+                ).length
+              : -1,
+            offeringOutgoing: Array.isArray(offering?.offerSheets)
+              ? offering.offerSheets.filter(
+                  (sheet) =>
+                    String((sheet as RecordLike)?.playerId || '') === PLAYER_ID
+                ).length
+              : -1,
+            signingRoute: String(contract.signedUsing || ''),
+            restriction: contract.offerSheetMatchRestriction || null,
+          };
+        },
+        {
+          timeout: 25_000,
+          message:
+            'matched Offer Sheet should persist atomically on both Teams',
+        }
+      )
+      .toMatchObject({
+        homeIncoming: 0,
+        offeringOutgoing: 0,
+        signingRoute: 'Match',
+        restriction: {
+          restrictionVersion: 1,
+          offeringTeamId: OFFERING_TEAM,
+          matchedAt: RESOLUTION_AT,
+          restrictedUntil: '2026-07-09T23:59:59-04:00',
+        },
+      });
+    await expect
+      .poll(async () => {
+        const events = await getWorldEventDocuments(worldId);
+        return events.some(
+          (event) =>
+            event.mutationType === 'matchOfferSheet' &&
+            JSON.stringify(event).includes(PLAYER_ID)
+        );
+      })
+      .toBe(true);
+    await capture(page, testInfo, 'BZE-283-matched-receipt');
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForReviewDashboard(page);
+    await openDashboardTab(page, 'Full Cap Table');
+    await expect(page.getByText(PLAYER_NAME).first()).toBeVisible({
+      timeout: 20_000,
+    });
+    const reloadedHome = await getWorldTeamDocument(worldId, HOME_TEAM);
+    expect(
+      (teamPlayer(reloadedHome, PLAYER_ID)?.contract as RecordLike)
+        ?.offerSheetMatchRestriction
+    ).toMatchObject({ matchedAt: RESOLUTION_AT });
+    testInfo.annotations.push({
+      type: 'audit-note',
+      description:
+        'At 1280×720 the saved-world UI exposes exact Eastern notice inputs, visibly disables an unreadable pending lifecycle and a wrong seasonal offset, resolves the certified mirror at the exact deadline, persists one matched contract with the one-year restriction, removes both active mirrors, records the event, and reloads the player in Full Cap Table.',
+    });
+  });
+});

--- a/tests/fixtures/architect/governedOfferSheet.ts
+++ b/tests/fixtures/architect/governedOfferSheet.ts
@@ -1,0 +1,182 @@
+import type {
+  GovernedOfferSheetEvidence,
+  GovernedOfferSheetProposal,
+} from '@/schemas/governedOfferSheet';
+import {
+  makeRightsEstablishedEvent,
+  makeRightsLedger,
+} from './rightsHistory';
+
+const SOURCE = {
+  provider: 'NBA retained fixture',
+  retainedArtifactPath: 'tests/fixtures/architect/offer-sheet-authority.json',
+  artifactSha256: `sha256:${'a'.repeat(64)}`,
+  artifactBytes: 1_024,
+  retrievedAt: '2025-06-30T12:00:00-04:00',
+  recordVersion: 1,
+  recordStatus: 'current' as const,
+};
+
+export function makeGovernedOfferSheetEvidence(
+  overrides: Partial<GovernedOfferSheetEvidence> = {}
+): GovernedOfferSheetEvidence {
+  return {
+    evidenceVersion: 1,
+    evidenceId: 'rfa-qo-evidence-player123-2026',
+    evidenceRecordVersion: 1,
+    status: 'known',
+    worldId: 'world_test_123',
+    homeTeamId: 'BOS',
+    playerId: 'player123',
+    salaryCapYear: 2026,
+    observedAt: '2025-07-01T09:00:00-04:00',
+    eligibility: {
+      category: 'three-or-fewer-yos',
+      yearsOfService: 3,
+      firstRoundRookieScaleYearFourCompleted: false,
+      qualifyingTwoWayService: false,
+      otherPlayerEligible: true,
+    },
+    qualifyingOffer: {
+      offerId: 'qo-player123-2026',
+      offerVersion: 1,
+      branch: 'standard',
+      amount: 5_000_000,
+      deliveredAt: '2025-06-29T17:00:00-04:00',
+      openThrough: '2025-10-01T23:59:59-04:00',
+      withdrawnAt: null,
+      withdrawalConsentAt: null,
+      contractYears: 1,
+      annualRaiseBasisPoints: 0,
+      fullyProtected: true,
+      requiredTermsPresent: true,
+      hasOptionOrEto: false,
+      calculation: {
+        basis: 'prior-salary',
+        certifiedAmount: 5_000_000,
+        inputSourceIds: ['qo-calculation-player123-v1'],
+        draftSlotAmount: null,
+        priorSalary: 4_500_000,
+        starterCriteriaAmount: null,
+        twoWayQualifyingAmount: null,
+      },
+      recordStatus: 'current',
+      source: SOURCE,
+    },
+    league: {
+      salaryCap: 500_000_000,
+      nonTaxpayerMle: 15_000_000,
+      maximumSalary: 40_000_000,
+      source: { ...SOURCE, retrievedAt: '2025-06-28T12:00:00-04:00' },
+    },
+    ...overrides,
+  };
+}
+
+export function makeGovernedOfferSheetProposal(
+  overrides: Partial<GovernedOfferSheetProposal> = {}
+): GovernedOfferSheetProposal {
+  return {
+    proposalVersion: 1,
+    signedAt: '2025-07-08T09:55:00-04:00',
+    receivedAt: '2025-07-08T10:00:00-04:00',
+    principalTermsDocumentId: 'principal-terms-player123-v1',
+    noticeDocumentId: 'notice-player123-v1',
+    salariesByYear: [
+      {
+        season: '2025-26',
+        salaryExcludingIncentive: 10_000_000,
+        regularSalary: 10_000_000,
+        bonuses: [],
+        guaranteedForLackOfSkill: true,
+        guaranteedForInjuryOrIllness: true,
+        individuallyNegotiatedProtectionConditions: false,
+        option: null,
+      },
+      {
+        season: '2026-27',
+        salaryExcludingIncentive: 10_500_000,
+        regularSalary: 10_500_000,
+        bonuses: [],
+        guaranteedForLackOfSkill: true,
+        guaranteedForInjuryOrIllness: true,
+        individuallyNegotiatedProtectionConditions: false,
+        option: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function makeGovernedOfferSheetRightsLedger() {
+  const event = makeRightsEstablishedEvent({
+    salaryCapYear: 2026,
+    freeAgentStatus: 'RFA',
+    rightOfFirstRefusal: 'active',
+  });
+  return makeRightsLedger({
+    ...event,
+    worldId: 'world_test_123',
+    teamId: 'BOS',
+    playerId: 'player123',
+    serviceSeasons: event.serviceSeasons.map((season) => ({
+      ...season,
+      creditedTeamId: season.creditedTeamId === null ? null : 'BOS',
+      rightsTeamId: 'BOS',
+    })),
+  });
+}
+
+export function makeGovernedOfferSheetContract(
+  proposal = makeGovernedOfferSheetProposal()
+) {
+  return {
+    rfaOfferSheet: true,
+    rfaOfferSheetOnly: true,
+    rfaOfferSheetStatus: 'PENDING_MATCH',
+    contractYears: proposal.salariesByYear.length,
+    totalValue: proposal.salariesByYear.reduce(
+      (sum, row) => sum + row.regularSalary,
+      0
+    ),
+    salariesByYear: proposal.salariesByYear.map((row) => ({
+      season: row.season,
+      salary: row.regularSalary,
+      capHit: row.regularSalary,
+      guaranteed: true,
+    })),
+  };
+}
+
+export function makeGovernedOfferSheetState(
+  evidence = makeGovernedOfferSheetEvidence()
+) {
+  const player = {
+    player_id: 'player123',
+    id: 'player123',
+    name: 'Test Player',
+    displayName: 'Test Player',
+    teamCode: 'BOS',
+    contract: { signingTeam: 'BOS' },
+    rfaContext: { governedEvidence: evidence },
+  };
+  return {
+    team: {
+      teamCode: 'LAL',
+      teamName: 'Los Angeles Lakers',
+      players: [],
+      roster: [],
+      offerSheets: [],
+    },
+    player,
+    teamCode: 'LAL',
+    homeTeam: {
+      teamCode: 'BOS',
+      teamName: 'Boston Celtics',
+      players: [player],
+      roster: ['player123'],
+      incomingOfferSheets: [],
+      rightsLedger: makeGovernedOfferSheetRightsLedger(),
+    },
+  };
+}

--- a/tests/fixtures/architect/governedOfferSheet.ts
+++ b/tests/fixtures/architect/governedOfferSheet.ts
@@ -1,11 +1,9 @@
 import type {
   GovernedOfferSheetEvidence,
+  GovernedOfferSheetLifecycle,
   GovernedOfferSheetProposal,
 } from '@/schemas/governedOfferSheet';
-import {
-  makeRightsEstablishedEvent,
-  makeRightsLedger,
-} from './rightsHistory';
+import { makeRightsEstablishedEvent, makeRightsLedger } from './rightsHistory';
 
 const SOURCE = {
   provider: 'NBA retained fixture',
@@ -44,22 +42,42 @@ export function makeGovernedOfferSheetEvidence(
       amount: 5_000_000,
       deliveredAt: '2025-06-29T17:00:00-04:00',
       openThrough: '2025-10-01T23:59:59-04:00',
+      extensionDocumentId: null,
       withdrawnAt: null,
       withdrawalConsentAt: null,
+      withdrawalConsentDocumentId: null,
       contractYears: 1,
       annualRaiseBasisPoints: 0,
+      annualBaseSchedule: [5_000_000],
       fullyProtected: true,
       requiredTermsPresent: true,
       hasOptionOrEto: false,
+      requiredOfferSheetGuaranteedSeasons: 2,
       calculation: {
         basis: 'prior-salary',
         certifiedAmount: 5_000_000,
         inputSourceIds: ['qo-calculation-player123-v1'],
+        calculationYear: 2026,
+        draftSlot: null,
         draftSlotAmount: null,
         priorSalary: 4_500_000,
+        officialStarts: null,
+        officialMinutes: null,
+        starterStartsThreshold: null,
+        starterMinutesThreshold: null,
         starterCriteriaAmount: null,
         twoWayQualifyingAmount: null,
       },
+      recordStatus: 'current',
+      source: SOURCE,
+    },
+    homeTeamMatchingAuthority: {
+      authorityId: 'matching-authority-player123-2026',
+      authorityVersion: 1,
+      kind: 'exception',
+      amount: 50_000_000,
+      effectiveFrom: '2025-07-01T00:00:00-04:00',
+      effectiveThrough: '2026-03-01T23:59:59-05:00',
       recordStatus: 'current',
       source: SOURCE,
     },
@@ -67,6 +85,14 @@ export function makeGovernedOfferSheetEvidence(
       salaryCap: 500_000_000,
       nonTaxpayerMle: 15_000_000,
       maximumSalary: 40_000_000,
+      maximumSalaryBySeason: [
+        { season: '2025-26', amount: 40_000_000 },
+        { season: '2026-27', amount: 40_000_000 },
+        { season: '2027-28', amount: 40_000_000 },
+        { season: '2028-29', amount: 41_800_000 },
+      ],
+      arenasYearOneMaximum: 15_000_000,
+      arenasYearTwoMaximum: 15_750_000,
       source: { ...SOURCE, retrievedAt: '2025-06-28T12:00:00-04:00' },
     },
     ...overrides,
@@ -108,21 +134,32 @@ export function makeGovernedOfferSheetProposal(
   };
 }
 
-export function makeGovernedOfferSheetRightsLedger() {
+export function makeGovernedOfferSheetRightsLedger(
+  overrides: {
+    worldId?: string;
+    homeTeamId?: string;
+    playerId?: string;
+    salaryCapYear?: number;
+  } = {}
+) {
+  const worldId = overrides.worldId ?? 'world_test_123';
+  const homeTeamId = overrides.homeTeamId ?? 'BOS';
+  const playerId = overrides.playerId ?? 'player123';
+  const salaryCapYear = overrides.salaryCapYear ?? 2026;
   const event = makeRightsEstablishedEvent({
-    salaryCapYear: 2026,
+    salaryCapYear,
     freeAgentStatus: 'RFA',
     rightOfFirstRefusal: 'active',
   });
   return makeRightsLedger({
     ...event,
-    worldId: 'world_test_123',
-    teamId: 'BOS',
-    playerId: 'player123',
+    worldId,
+    teamId: homeTeamId,
+    playerId,
     serviceSeasons: event.serviceSeasons.map((season) => ({
       ...season,
-      creditedTeamId: season.creditedTeamId === null ? null : 'BOS',
-      rightsTeamId: 'BOS',
+      creditedTeamId: season.creditedTeamId === null ? null : homeTeamId,
+      rightsTeamId: homeTeamId,
     })),
   });
 }
@@ -143,8 +180,214 @@ export function makeGovernedOfferSheetContract(
       season: row.season,
       salary: row.regularSalary,
       capHit: row.regularSalary,
-      guaranteed: true,
+      guaranteed:
+        row.guaranteedForLackOfSkill &&
+        row.guaranteedForInjuryOrIllness &&
+        !row.individuallyNegotiatedProtectionConditions,
+      option: row.option,
+      ...(row.bonuses.length > 0
+        ? {
+            incentives: {
+              likely: row.bonuses
+                .filter((bonus) => bonus.classification === 'likely')
+                .reduce((sum, bonus) => sum + bonus.amount, 0),
+              unlikely: row.bonuses
+                .filter((bonus) => bonus.classification === 'unlikely')
+                .reduce((sum, bonus) => sum + bonus.amount, 0),
+            },
+          }
+        : {}),
     })),
+  };
+}
+
+export function makePendingGovernedOfferSheetLifecycle(): GovernedOfferSheetLifecycle {
+  const evidence = makeGovernedOfferSheetEvidence();
+  const proposal = makeGovernedOfferSheetProposal();
+  return {
+    payloadVersion: 1,
+    ledgerId: 'offer-sheet-ledger:world_test_123:os-governed-1',
+    ledgerVersion: 1,
+    worldId: evidence.worldId,
+    playerId: evidence.playerId,
+    homeTeamId: evidence.homeTeamId,
+    offeringTeamId: 'LAL',
+    salaryCapYear: evidence.salaryCapYear,
+    status: 'pending-match',
+    evidenceReference: {
+      evidenceId: evidence.evidenceId,
+      evidenceRecordVersion: evidence.evidenceRecordVersion,
+    },
+    evidenceSnapshot: evidence,
+    rightsReference: {
+      ledgerId: 'rights-ledger:world_test_123:BOS:player123',
+      ledgerVersion: 1,
+      stateId: 'rights-state:world_test_123:BOS:player123:2026',
+      stateVersion: 1,
+    },
+    reservations: {
+      offeringTeam: proposal.salariesByYear.map((row) => ({
+        season: row.season,
+        amount: row.regularSalary,
+      })),
+      offeringTeamSalaryReference: {
+        ledgerKind: 'team-salary',
+        asOfDate: proposal.signedAt,
+        salaryCap: evidence.league.salaryCap,
+        totalBeforeOfferSheet: 0,
+        teamStateReference: 'world_test_123:LAL:fixture-digest',
+        canonLeafIds: ['CBA2-L04.3'],
+      },
+      homeTeamAuthority: evidence.homeTeamMatchingAuthority.kind,
+      arenasApplies: false,
+      offeringTeamAccounting: 'stated-schedule',
+      homeTeamAccounting: 'stated-schedule',
+    },
+    events: [
+      {
+        eventKind: 'offer-sheet-signed',
+        eventId: 'os-governed-1:signed:v1',
+        eventVersion: 1,
+        executedAt: proposal.signedAt,
+        recordedAt: '2025-07-08T14:00:01.000Z',
+        qualifyingOfferId: evidence.qualifyingOffer.offerId,
+        qualifyingOfferVersion: evidence.qualifyingOffer.offerVersion,
+        exerciseNoticeDeadline: '2025-07-09T23:59:59-04:00',
+        proposal,
+      },
+    ],
+  };
+}
+
+type GovernedOfferSheetFixtureSalaryRow = {
+  season: string;
+  salary: number;
+  capHit?: number;
+};
+
+/**
+ * Adapts older persistence-boundary fixtures to the governed Offer Sheet
+ * contract without weakening production fail-closed behavior.
+ */
+export function makeGovernedOfferSheetFixture({
+  worldId,
+  playerId,
+  homeTeamId,
+  offeringTeamId,
+  offerSheetId = 'os-governed-fixture',
+  salariesByYear,
+}: {
+  worldId: string;
+  playerId: string;
+  homeTeamId: string;
+  offeringTeamId: string;
+  offerSheetId?: string;
+  salariesByYear: readonly GovernedOfferSheetFixtureSalaryRow[];
+}) {
+  const proposal = makeGovernedOfferSheetProposal({
+    salariesByYear: salariesByYear.map((row) => ({
+      season: row.season,
+      salaryExcludingIncentive: row.salary,
+      regularSalary: row.salary,
+      bonuses: [],
+      guaranteedForLackOfSkill: true,
+      guaranteedForInjuryOrIllness: true,
+      individuallyNegotiatedProtectionConditions: false,
+      option: null,
+    })),
+  });
+  const baseEvidence = makeGovernedOfferSheetEvidence();
+  const evidence = makeGovernedOfferSheetEvidence({
+    evidenceId: `rfa-qo-evidence-${playerId}-2026`,
+    worldId,
+    homeTeamId,
+    playerId,
+    qualifyingOffer: {
+      ...baseEvidence.qualifyingOffer,
+      offerId: `qo-${playerId}-2026`,
+    },
+    homeTeamMatchingAuthority: {
+      ...baseEvidence.homeTeamMatchingAuthority,
+      authorityId: `matching-authority-${playerId}-2026`,
+    },
+    league: {
+      ...baseEvidence.league,
+      // These compatibility fixtures exercise persistence boundaries rather
+      // than Arenas accounting. Keep their historical schedules on the
+      // ordinary stated-schedule branch.
+      nonTaxpayerMle: 100_000_000,
+      arenasYearOneMaximum: 100_000_000,
+      arenasYearTwoMaximum: 105_000_000,
+    },
+  });
+  const contract = makeGovernedOfferSheetContract(proposal);
+  const rightsLedger = makeGovernedOfferSheetRightsLedger({
+    worldId,
+    homeTeamId,
+    playerId,
+  });
+  const lifecycle: GovernedOfferSheetLifecycle = {
+    payloadVersion: 1,
+    ledgerId: `offer-sheet-ledger:${worldId}:${offerSheetId}`,
+    ledgerVersion: 1,
+    worldId,
+    playerId,
+    homeTeamId,
+    offeringTeamId,
+    salaryCapYear: 2026,
+    status: 'pending-match',
+    evidenceReference: {
+      evidenceId: evidence.evidenceId,
+      evidenceRecordVersion: evidence.evidenceRecordVersion,
+    },
+    evidenceSnapshot: evidence,
+    rightsReference: {
+      ledgerId: `rights-ledger:${worldId}:${homeTeamId}:${playerId}`,
+      ledgerVersion: 1,
+      stateId: `rights-state:${worldId}:${homeTeamId}:${playerId}:2026`,
+      stateVersion: 1,
+    },
+    reservations: {
+      offeringTeam: salariesByYear.map((row) => ({
+        season: row.season,
+        amount: row.capHit ?? row.salary,
+      })),
+      offeringTeamSalaryReference: {
+        ledgerKind: 'team-salary',
+        asOfDate: proposal.signedAt,
+        salaryCap: evidence.league.salaryCap,
+        totalBeforeOfferSheet: 0,
+        teamStateReference: `${worldId}:${offeringTeamId}:fixture-digest`,
+        canonLeafIds: ['CBA2-L04.3'],
+      },
+      homeTeamAuthority: evidence.homeTeamMatchingAuthority.kind,
+      arenasApplies: false,
+      offeringTeamAccounting: 'stated-schedule',
+      homeTeamAccounting: 'stated-schedule',
+    },
+    events: [
+      {
+        eventKind: 'offer-sheet-signed',
+        eventId: `${offerSheetId}:signed:v1`,
+        eventVersion: 1,
+        executedAt: proposal.signedAt,
+        recordedAt: '2025-07-08T14:00:01.000Z',
+        qualifyingOfferId: evidence.qualifyingOffer.offerId,
+        qualifyingOfferVersion: evidence.qualifyingOffer.offerVersion,
+        exerciseNoticeDeadline: '2025-07-09T23:59:59-04:00',
+        proposal,
+      },
+    ],
+  };
+
+  return {
+    asOfDate: '2025-07-08',
+    resolutionAt: proposal.receivedAt,
+    evidence,
+    proposal,
+    contract,
+    rightsLedger,
+    lifecycle,
   };
 }
 

--- a/tests/tradeHelpers.test.ts
+++ b/tests/tradeHelpers.test.ts
@@ -27,11 +27,16 @@ const settings = {
 describe('getSalaryForYear', () => {
   const year = 2025;
 
-  it('extracts capHit from contract.salariesByYear', () => {
+  it('uses an explicit capHit without adding its retained likely incentive twice', () => {
     const p = {
       contract: {
         salariesByYear: [
-          { season: '2024-25', capHit: 12_000_000, salary: 10_000_000 },
+          {
+            season: '2024-25',
+            capHit: 12_000_000,
+            salary: 10_000_000,
+            incentives: { likely: 500_000 },
+          },
         ],
       },
     };
@@ -63,9 +68,7 @@ describe('Two-Way trade classification', () => {
   it.each(['TwoWay', 'two-way', 'two_way', 'two way'])(
     'recognizes the explicit %s contract spelling',
     (contractType) => {
-      expect(
-        isTwoWayTradePlayer({ contract: { contractType } })
-      ).toBe(true);
+      expect(isTwoWayTradePlayer({ contract: { contractType } })).toBe(true);
     }
   );
 


### PR DESCRIPTION
## Product workflow

Governs restricted-free-agency Offer Sheets as one atomic Free Agency workflow: authenticated RFA/QO authority, exact signed and received notices, dated Team Salary room preservation, mirrored two-Team persistence, match/decline deadlines, Arenas terms and optional matching-Team averaging election, downstream restrictions, Team History, and reload.

## Why this tranche

This is the largest remaining independently reviewable workflow under the Phase 3A parent: its rules, source evidence, world clock, offer terms, cap reservation, two-Team lifecycle, persistence, and rendered proof share one user surface and transaction boundary. Waivers remain separate because their claim, medical, and authority questions do not share this lifecycle; season advance is downstream. BZE-282 remains closed, and none of its retained non-blocking observations were reopened or converted into scope.

## Candidate scope

- Base and merge base: `2d6d97e39a3be137611f0907f86d8f4c0ccba1a5`
- Frozen exact head: `36ca94a5313a37a5e051f0c6f9b25d1afc0593d4`
- Final changes: the real-Firestore-emulator proof plus its narrow PR/main CI gate; production logic is unchanged from the repaired implementation at `4f19242b...`
- Risk class: critical rules, money, mirrored persistence, exact-time, and downstream-restriction workflow
- Freeze declaration: https://github.com/Bet-Zero/scoutzero/pull/506#issuecomment-5353738561
- Landed unchanged as merge commit `abb95c63f3a6af7fc8e5d6766da5ad0cf0405687`

## Canon authority

- Accepted candidate: `6cf8aaf358c158a88e630e8a7336f7e9c3febc17`
- SHA-256: `23fe883f6f1aec7799fc3396bef404c250fd26beefa705582a5307766ad7ff76`
- Established for this saved-world workflow: `CBA2-L04.18` through `CBA2-L04.24`, `CBA2-C15.1` through `CBA2-C15.13`, `CBA2-L03.5`, `CBA2-L03.9`, `CBA2-L01.3`, and `CBA2-L04.3`

## Open Canon accounting

- `CBA2-C23.6` remains open. Architect currently has no representable signing-bonus field, so this tranche does not implement, establish, or close that leaf. No signing-bonus implementation or child issue is part of this landing; the leaf remains in BZE-267's open Canon accounting.

## Risk contract and author failure matrix

- Authority: missing, stale, conflicting, post-transaction, wrong-world, wrong-Team, wrong-player, malformed, internally inconsistent, and calculation-divergent RFA/QO records fail closed.
- Timing: exact Eastern QO delivery/open/withdrawal evidence, exact Eastern Offer Sheet signing/receipt/resolution, actual seasonal UTC offset, Moratorium special case, before/at-noon deadline boundaries, world-date mismatch, and one-second-late match fail closed.
- Terms/accounting: minimum protected term, principal-term/contract parity including incentives, Arenas NTMLE/three 5% bases/maximum/4.5%/protection rules, insufficient dated Team Salary Room, multiple outstanding reservations, stated salary versus averaged cap hit, and election eligibility/notice relay are independently checked.
- Mutation/persistence: duplicate outstanding sheets, changed idempotent retries, divergent or ambiguous Team mirrors, missing evidence, atomic creation and match/decline, immutable creation authority, bonus/accounting survival, exact resolution evidence, concurrent/stale mutation protection, and metadata allowlisting have no-write failure assertions.
- Downstream restrictions: a matched player's one-year consent requirement, offering-Team trade bar, sign-and-trade bar, and amendment bar persist and fail closed when unreadable.
- Product path: exact notice fields are authored in the contract modal; incoming resolution requires an exact Eastern instant, disables unreadable records, explains incomplete averaging elections, and preserves the committed result through reload.
- Source safety: the browser and emulator proofs write only run-scoped `architect_worlds` data; immutable source data is read-only to browser clients.

## Creation/concurrency emulator proof

`src/tests/architect/mutationPipeline.offerSheetCreation.emulator.test.ts` runs against the real Firestore and Auth emulators with the Firebase Web SDK and production `loadStateForMutation` → `computeWorldMutation` → `persistWorldMutation` code. Admin access is limited to fixture setup that a browser cannot perform: the immutable base player and governed world root. The authenticated owner client establishes the starting Team documents and performs the governed mutations.

Two candidates load the same persisted starting state and race the production persistence transaction. Exactly one wins. The stale loser fails at the real Firestore boundary with `Team snapshot for LAL changed before commit`; it leaves no partial Team mirror, authorization, event, or metadata writes, does not duplicate the winner's event, and does not erase or alter either winning Team. The emulator ends with exactly the winner's two identical mirrors, one immutable authorization anchor, one event, and `lastModifiedTeams` containing only BOS and LAL.

The proof is durable validation rather than a manual-only test. `ci:offer-sheet-creation-emulator-gate` uses pinned `firebase-tools@13.35.1`, starts only Firestore/Auth for demo project `demo-bze-283`, runs only this test through `vitest.emulator.config.js`, and shuts the emulators down. Both PR validation and main/scheduled validation invoke the gate.

## Completed validation

- `npm run ci:offer-sheet-creation-emulator-gate` — real Firestore/Auth emulator, 1 file / 1 test passed locally
- Exact-head hosted PR Validation: https://github.com/Bet-Zero/scoutzero/actions/runs/32350802769 — passed, including the named governed Offer Sheet emulator gate, typecheck, Architect gate, accepted Canon fetch, Phase 3A workflow tooling, diff-selected tests, project validation, and build
- `npm run test:diff -- --files tests/architect/mutationPipeline.tradePersistenceTruth.test.ts --reporter=dot` — 1 file / 17 tests passed
- `npm run test:phase3a-workflow` — 11 tests passed after the CI wiring repair
- `npm run typecheck` — passed
- `npm run validate:project` — passed
- Prettier check for the new test, package script, and workflow — passed
- `git diff --check` — passed
- `graphify update .` — passed after the source test was added; 17,108 nodes / 35,381 edges / 804 communities
- Retained deterministic governed Offer Sheet browser proof at 1280×720 — 1 test passed in 1.9 minutes, covering real authoring, legacy fail-closed rendering, seasonal Eastern offset, atomic exact-deadline Match, mirrored cleanup, contract/restriction/event persistence, Team History, and reload
- Retained broader author evidence: production build passed; schema check passed; Trade suite 73 files / 669 tests passed; risk matrix 4 files / 158 tests passed; focused lifecycle/source-authority 2 files / 53 tests passed; focused Free Agency UI 2 files / 27 tests passed

The retained browser evidence and earlier focused behavior evidence remain valid because the final two commits add only the emulator test and its validation wiring; no product or browser-test code changed after those proofs.

## Automated review

- The two prior P1 findings were independently reverified at `36ca94a5313a37a5e051f0c6f9b25d1afc0593d4`, answered with exact-head evidence, and resolved. Creation participates in the exact-state transaction, and resolution re-authenticates mutable mirrors against a write-once anchor and immutable base evidence both while loading and inside the commit transaction.
- The review of `22a9a7fd...` found one P2: the emulator test was not wired into routine validation. Commit `36ca94a5` added the narrow pinned emulator command and PR/main CI steps. The repair passed locally and in exact-head hosted CI; the thread was answered and resolved.
- The final exact-head Codex delta review reported no major issues on reviewed commit `36ca94a531`: https://github.com/Bet-Zero/scoutzero/pull/506#issuecomment-5353717154
- CodeRabbit's final-head check was skipped because PR #506 remained draft. Its earlier-head threads are resolved, but no substantive CodeRabbit review is claimed for `36ca94a5313a37a5e051f0c6f9b25d1afc0593d4`.
- The older Codex reviews of `09dad4fa...` and `22a9a7fd...` are not the freeze verdict.
- All 38 review threads are resolved.

## Hosted checks and rendered proof

- Exact-head CI run: https://github.com/Bet-Zero/scoutzero/actions/runs/32350802769 — passed.
- Post-merge main CI: https://github.com/Bet-Zero/scoutzero/actions/runs/32356284370 — passed, including the real-emulator gate and hosted full validation.
- Exact-head Vercel preview: https://scoutzero-git-feature-bze-283-g-9bd09a-brents-projects-686e97fc.vercel.app — ready.
- Frozen candidate declaration: https://github.com/Bet-Zero/scoutzero/pull/506#issuecomment-5353738561
- Immutable independent-Claude prompt: https://github.com/Bet-Zero/scoutzero/pull/506#issuecomment-5353780887
- Claude's complete raw exact-head `ACCEPT`: https://github.com/Bet-Zero/scoutzero/pull/506#issuecomment-5354271291

## Skipped checks and limitations

- The existing browser proof was not repeated because the final changes are test/validation-only; it remains the evidence for resolution, persistence, Team History, and reload, while the real emulator test supplies the previously missing creation/concurrency boundary proof.
- Business-day calculations exclude Saturdays and Sundays only. Governed league/public-holiday handling is not implemented or claimed.
- `npm run test:architect -- --reporter=dot` was previously stopped at the mandated four-minute cap; every compatibility failure it surfaced was repaired and each affected suite then passed in focused runs.
- The full suite was not run because the request did not contain the required `RUN FULL SUITE` authorization.
- Graphify was not repeated for the validation-wiring-only repair.
- ESLint was not run as a standalone whole-repository check; the push hook's scoped Architect ratchet passed and decreased by two pre-existing violations.
- Claude returned exact-head `ACCEPT`; the owner accepted that verdict, and the candidate landed unchanged after the metadata-only corrections.

## Landing receipt

Merged unchanged as `abb95c63f3a6af7fc8e5d6766da5ad0cf0405687`. Its verified parents are base `2d6d97e39a3be137611f0907f86d8f4c0ccba1a5` and accepted candidate `36ca94a5313a37a5e051f0c6f9b25d1afc0593d4`; post-merge main CI is green.

Fixes BZE-283
